### PR TITLE
Avoid java serialization through spark broadcast

### DIFF
--- a/guacamole-core/src/main/scala/org/bdgenomics/guacamole/LociMap.scala
+++ b/guacamole-core/src/main/scala/org/bdgenomics/guacamole/LociMap.scala
@@ -25,7 +25,6 @@ import com.esotericsoftware.kryo.{ Serializer, Kryo }
 import com.esotericsoftware.kryo.io.{ Input, Output }
 import scala.Some
 import scala.collection.immutable.NumericRange.Exclusive
-import sun.reflect.generics.reflectiveObjects.NotImplementedException
 import scala.collection.mutable.ArrayBuffer
 
 /**
@@ -86,9 +85,10 @@ case class LociMap[T](private val map: Map[String, LociMap.SingleContig[T]]) {
   }
   override def hashCode = sortedMap.hashCode
 }
+
 object LociMap {
   // Make NumericRange instances comparable.
-  private implicit object RangeOrdering extends Ordering[NumericRange.Exclusive[Long]] {
+  private implicit object RangeOrdering extends Ordering[NumericRange.Exclusive[Long]] with Serializable {
     def compare(o1: NumericRange.Exclusive[Long], o2: NumericRange.Exclusive[Long]) = (o1.start - o2.start).toInt
   }
 

--- a/guacamole-core/src/main/scala/org/bdgenomics/guacamole/LociSet.scala
+++ b/guacamole-core/src/main/scala/org/bdgenomics/guacamole/LociSet.scala
@@ -165,6 +165,7 @@ class LociSetSerializer extends Serializer[LociSet] {
     LociSet.parse(input.readString())
   }
 }
+
 class LociSetSingleContigSerializer extends Serializer[LociSet.SingleContig] {
   def write(kyro: Kryo, output: Output, obj: LociSet.SingleContig) = {
     assert(kyro != null)
@@ -172,6 +173,7 @@ class LociSetSingleContigSerializer extends Serializer[LociSet.SingleContig] {
     assert(obj != null)
     output.writeString(obj.toString)
   }
+
   def read(kryo: Kryo, input: Input, klass: Class[LociSet.SingleContig]): LociSet.SingleContig = {
     assert(kryo != null)
     assert(input != null)

--- a/guacamole-core/src/test/scala/org/bdgenomics/guacamole/LociMapSuite.scala
+++ b/guacamole-core/src/test/scala/org/bdgenomics/guacamole/LociMapSuite.scala
@@ -80,7 +80,7 @@ class LociMapSuite extends TestUtil.SparkFunSuite with ShouldMatchers {
 
   test("SingleContig, empty") {
     type JLong = java.lang.Long
-    val contigMap = LociMap.SingleContig("chr1", ImmutableRangeMap.builder[JLong, String]().build())
+    val contigMap = new LociMap.SingleContig("chr1", ImmutableRangeMap.builder[JLong, String]().build())
 
     contigMap.get(100) should be(None)
     contigMap.getAll(0, 10000) should equal(Set())
@@ -97,7 +97,7 @@ class LociMapSuite extends TestUtil.SparkFunSuite with ShouldMatchers {
     val range100to200 = ImmutableRangeMap.of[JLong, String](Range.closedOpen[JLong](100, 200), "A")
     val range200to300 = ImmutableRangeMap.of[JLong, String](Range.closedOpen[JLong](200, 300), "B")
 
-    val contigMap = LociMap.SingleContig("chr1",
+    val contigMap = new LociMap.SingleContig("chr1",
       ImmutableRangeMap.builder[JLong, String]().putAll(range100to200).putAll(range200to300).build())
 
     contigMap.get(99) should be(None)
@@ -125,11 +125,11 @@ class LociMapSuite extends TestUtil.SparkFunSuite with ShouldMatchers {
     contigMap.isEmpty should be(false)
     contigMap.toString should be("chr1:100-200=A,chr1:200-300=B")
 
-    val emptyMap = LociMap.SingleContig("chr1", ImmutableRangeMap.builder[JLong, String]().build())
+    val emptyMap = new LociMap.SingleContig("chr1", ImmutableRangeMap.builder[JLong, String]().build())
     contigMap.union(contigMap) should equal(contigMap)
     contigMap.union(emptyMap) should equal(contigMap)
 
-    val emptyMapWrongContig = LociMap.SingleContig("chr2", ImmutableRangeMap.builder[JLong, String]().build())
+    val emptyMapWrongContig = new LociMap.SingleContig("chr2", ImmutableRangeMap.builder[JLong, String]().build())
     val caught = evaluating { contigMap.union(emptyMapWrongContig) } should produce[AssertionError]
     caught.getMessage should include("different contigs: chr1 and chr2")
   }

--- a/guacamole-core/src/test/scala/org/bdgenomics/guacamole/LociSetSuite.scala
+++ b/guacamole-core/src/test/scala/org/bdgenomics/guacamole/LociSetSuite.scala
@@ -101,4 +101,5 @@ class LociSetSuite extends TestUtil.SparkFunSuite with ShouldMatchers {
     sets.foreach(check_invariants)
     check_invariants(LociSet.union(sets: _*))
   }
+
 }


### PR DESCRIPTION
Instead of serializing using Java serialization when serializing closure, let's just broadcast the necessary serialization.  This will use the Kryo serializers and will shared data explicit
