### PR TITLE
Project all CIGAR operations onto our Pileup.Element.Alignment

### DIFF
--- a/guacamole-core/src/main/scala/org/bdgenomics/guacamole/Pileup.scala
+++ b/guacamole-core/src/main/scala/org/bdgenomics/guacamole/Pileup.scala
@@ -153,18 +153,17 @@ object Pileup {
       val cigarElement: CigarElement = cigar.getCigarElement(indexInCigarElements.toInt)
       val cigarOperator = cigarElement.getOperator
       cigarOperator match {
-        case CigarOperator.INSERTION =>
+        case CigarOperator.I =>
           val startPos: Int = readPosition.toInt
           val endPos: Int = startPos + cigarElement.getLength - indexWithinCigarElement.toInt
           val bases = read.record.getSequence.toString.subSequence(startPos, endPos).toString
           Insertion(bases)
-        case CigarOperator.MATCH_OR_MISMATCH =>
+        case CigarOperator.M | CigarOperator.EQ | CigarOperator.X =>
           val base: Char = read.record.getSequence.charAt(readPosition.toInt)
           if (read.record.mdTag.get.isMatch(locus)) { Match(base) }
           else { Mismatch(base) }
-        case CigarOperator.DELETION => Deletion()
-        case other =>
-          throw new AssertionError("Not a match, mismatch, deletion, or insertion: " + other.toString)
+        case CigarOperator.D | CigarOperator.S | CigarOperator.N |
+          CigarOperator.H | CigarOperator.P => Deletion()
       }
     }
 

--- a/guacamole-core/src/test/scala/org/bdgenomics/guacamole/PileupSuite.scala
+++ b/guacamole-core/src/test/scala/org/bdgenomics/guacamole/PileupSuite.scala
@@ -69,7 +69,6 @@ class PileupSuite extends TestUtil.SparkFunSuite with ShouldMatchers {
     }
   }
 
-
   sparkTest("Pileup.Element basic test") {
     intercept[NullPointerException] {
       val e = Pileup.Element(null, 42)
@@ -157,19 +156,17 @@ class PileupSuite extends TestUtil.SparkFunSuite with ShouldMatchers {
 
     // Read5: ACGTACGTACGTACG, 5M4=1X5=, [10; 25[
     //        MMMMM====G=====
-    if (false) { // This test fails because of issue #30
-      val decadentRead5 = new DecadentRead(adamRecords(4))
-      val read5At10 = Pileup.Element(decadentRead5, 10)
-      assert(read5At10 != null)
-      assert(read5At10.elementAtGreaterLocus(10).sequenceRead === "A")
-      assert(read5At10.elementAtGreaterLocus(14).sequenceRead === "A")
-      assert(read5At10.elementAtGreaterLocus(18).sequenceRead === "A")
-      assert(read5At10.elementAtGreaterLocus(19).sequenceRead === "C")
-      assert(read5At10.elementAtGreaterLocus(20).sequenceRead === "G")
-      assert(read5At10.elementAtGreaterLocus(21).sequenceRead === "T")
-      assert(read5At10.elementAtGreaterLocus(22).sequenceRead === "A")
-      assert(read5At10.elementAtGreaterLocus(24).sequenceRead === "G")
-    }
+    val decadentRead5 = new DecadentRead(adamRecords(4))
+    val read5At10 = Pileup.Element(decadentRead5, 10)
+    assert(read5At10 != null)
+    assert(read5At10.elementAtGreaterLocus(10).sequenceRead === "A")
+    assert(read5At10.elementAtGreaterLocus(14).sequenceRead === "A")
+    assert(read5At10.elementAtGreaterLocus(18).sequenceRead === "A")
+    assert(read5At10.elementAtGreaterLocus(19).sequenceRead === "C")
+    assert(read5At10.elementAtGreaterLocus(20).sequenceRead === "G")
+    assert(read5At10.elementAtGreaterLocus(21).sequenceRead === "T")
+    assert(read5At10.elementAtGreaterLocus(22).sequenceRead === "A")
+    assert(read5At10.elementAtGreaterLocus(24).sequenceRead === "G")
   }
 }
 


### PR DESCRIPTION
This is a first fix for #30. It also re-enables the “read 5” test of PileupSuite (#2).

The “long names” of `CigarOperator` are not enough
(c.f. [net/sf/samtools/CigarOperator.java](https://github.com/nh13/picard/blob/master/src/java/net/sf/samtools/CigarOperator.java) and [documentation](http://picard.sourceforge.net/javadoc/net/sf/samtools/CigarOperator.html)) so I went back to the “one-letter” ones.

The assumptions are taken from this [wikipage about SAM](http://davetang.org/wiki/tiki-index.php?page=SAM) and Matt's [blog post](http://zenfractal.com/2013/06/19/playing-with-matches/).
