### PR TITLE
Cigar offsets incorrectly jumps full length of elements

### DIFF
--- a/guacamole-core/src/test/scala/org/bdgenomics/guacamole/PileupSuite.scala
+++ b/guacamole-core/src/test/scala/org/bdgenomics/guacamole/PileupSuite.scala
@@ -53,6 +53,71 @@ class PileupSuite extends TestUtil.SparkFunSuite with ShouldMatchers {
     }
   }
 
+  test("test pileup element creation") {
+    val read = TestUtil.makeDecadentRead("AATTG", "5M", "5", 0, "chr1")
+    val firstElement = Pileup.Element(read, 0)
+
+    firstElement.isMatch should be(true)
+    firstElement.indexInCigarElements should be(0L)
+    firstElement.indexWithinCigarElement should be(0L)
+
+    val secondElement = firstElement.elementAtGreaterLocus(1L)
+    secondElement.isMatch should be(true)
+    secondElement.indexInCigarElements should be(0L)
+    secondElement.indexWithinCigarElement should be(1L)
+
+    val thirdElement = secondElement.elementAtGreaterLocus(2L)
+    thirdElement.isMatch should be(true)
+    thirdElement.indexInCigarElements should be(0L)
+    thirdElement.indexWithinCigarElement should be(2L)
+
+  }
+
+  test("test pileup element creation with multiple cigar elements") {
+    val read = TestUtil.makeDecadentRead("AAATTT", "3M3M", "6", 0, "chr1")
+
+    val secondMatch = Pileup.Element(read, 3)
+    secondMatch.isMatch should be(true)
+    secondMatch.indexInCigarElements should be(1L)
+    secondMatch.indexWithinCigarElement should be(0L)
+
+    val secondMatchSecondElement = Pileup.Element(read, 4)
+    secondMatchSecondElement.isMatch should be(true)
+    secondMatchSecondElement.indexInCigarElements should be(1L)
+    secondMatchSecondElement.indexWithinCigarElement should be(1L)
+
+  }
+
+  test("test pileup element creation with deletion cigar elements") {
+    val read = TestUtil.makeDecadentRead("AATTGAATTG", "5M1D5M", "5^C5", 0, "chr1")
+    val firstElement = Pileup.Element(read, 0)
+
+    firstElement.isMatch should be(true)
+    firstElement.indexInCigarElements should be(0L)
+    firstElement.indexWithinCigarElement should be(0L)
+
+    val matchElement = firstElement.elementAtGreaterLocus(4L)
+    matchElement.isMatch should be(true)
+    matchElement.indexInCigarElements should be(0L)
+    matchElement.indexWithinCigarElement should be(4L)
+
+    val deletionElement = matchElement.elementAtGreaterLocus(5L)
+    deletionElement.isDeletion should be(true)
+    deletionElement.indexInCigarElements should be(1L)
+    deletionElement.indexWithinCigarElement should be(0L)
+
+    val pastDeletionElement = matchElement.elementAtGreaterLocus(6L)
+    pastDeletionElement.isMatch should be(true)
+    pastDeletionElement.indexInCigarElements should be(2L)
+    pastDeletionElement.indexWithinCigarElement should be(0L)
+
+    val continuePastDeletionElement = pastDeletionElement.elementAtGreaterLocus(9L)
+    continuePastDeletionElement.isMatch should be(true)
+    continuePastDeletionElement.indexInCigarElements should be(2L)
+    continuePastDeletionElement.indexWithinCigarElement should be(3L)
+
+  }
+
   sparkTest("Loci 10-19 deleted from half of the reads") {
     val pileup = loadPileup("same_start_reads.sam", 0)
     for (i <- 10 to 19) {


### PR DESCRIPTION
The current cigar element offsets are incorrect - while we are searching for the next cigar element the indices jump by the complete length of the cigar element, when we may already be offset by some amount into the cigar element.

This PR only contains failing tests for now - not sure how we should handle this.  Currently at any given locus we don't have information on whether the current element consumes read and/or reference bases so we don't know whether to subtract off the offset from either.  We could save this information around, but then the next issue is currently we define a read position for deletion element and I'm not sure what the interpretation of a read position for a deletion element is.
