### PR TITLE
Upgrade ADAM to 0.10 and move off snapshot release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <name>guacamole: Simple ADAM-based variant calling</name>
 
   <properties>
-    <adam.version>0.9.1-SNAPSHOT</adam.version>
+    <adam.version>0.10.0</adam.version>
     <java.version>1.6</java.version>
     <scala.version>2.10.3</scala.version>
     <scala.version.prefix>2.10</scala.version.prefix>
@@ -153,14 +153,24 @@
   </build>
 
   <repositories>
-    <repository>
-      <id>Sonatype</id>
-      <url>http://oss.sonatype.org/content/repositories/snapshots/</url>
-    </repository>
-    <repository>
-      <id>Apache</id>
-      <url>http://people.apache.org/repo/m2-snapshot-repository</url>
-    </repository>
+      <repository>
+          <id>sonatype-nexus-snapshots</id>
+          <name>Sonatype Nexus Snapshots</name>
+          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+          <releases>
+              <enabled>false</enabled>
+          </releases>
+          <snapshots>
+              <enabled>true</enabled>
+          </snapshots>
+      </repository>
+      <repository>
+          <snapshots>
+              <enabled>false</enabled>
+          </snapshots>
+          <id>central</id>
+          <url>http://repo1.maven.org/maven2</url>
+      </repository>
   </repositories>
 
   <dependencies>


### PR DESCRIPTION
This upgrades ADAM to 0.10, the latest release and only switches to use the 0.10 build instead of the latest snapshot.

This is mostly positive in that we won't have builds break due to ADAM changes, but we may fall behind on ADAM changes, but hopefully there are fast releases and we can manage that
