### PR TITLE
Remove println which dumps map to cmdline

### DIFF
--- a/src/main/scala/org/bdgenomics/guacamole/DistributedUtil.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/DistributedUtil.scala
@@ -452,7 +452,6 @@ object DistributedUtil extends Logging {
     val readsByTask = sc.accumulator(MutableHashMap.empty[String, Long])(new HashMapAccumulatorParam)
     DelayedMessages.default.say { () =>
       {
-        println(readsByTask.toString)
         assert(readsByTask.value.size == numTasks)
         val stats = new math3.stat.descriptive.DescriptiveStatistics()
         readsByTask.value.valuesIterator.foreach(stats.addValue(_))


### PR DESCRIPTION
I believe this was left in accidentally, dumps the full task to read count map to stdout.
