### PR TITLE
Add filter for pileups and genotypes

### DIFF
--- a/src/main/scala/org/bdgenomics/guacamole/filters/GenotypeFilter.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/filters/GenotypeFilter.scala
@@ -1,0 +1,176 @@
+package org.bdgenomics.guacamole.filters
+
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.avro.ADAMGenotype
+import org.bdgenomics.guacamole.Common.Arguments.Base
+import org.kohsuke.args4j.Option
+import org.bdgenomics.guacamole.Common
+
+/**
+ * Filter to remove genotypes where the number of reads at the locus is low
+ */
+object MinimumReadDepthFilter {
+
+  def hasMinimumReadDepth(genotype: ADAMGenotype,
+                          minReadDepth: Int,
+                          includeNull: Boolean = true): Boolean = {
+    if (genotype.readDepth != null) {
+      genotype.readDepth > minReadDepth
+    } else {
+      includeNull
+    }
+  }
+
+  /**
+   *
+   *  Apply the filter to an RDD of genotypes
+   *
+   * @param genotypes RDD of genotypes to filter
+   * @param minReadDepth minimum number of reads at locus for this genotype
+   * @param includeNull include the genotype if the required fields are nu
+   * @param debug if true, compute the count of genotypes after filtering
+   * @return Genotypes with read depth > minReadDepth
+   */
+  def apply(genotypes: RDD[ADAMGenotype],
+            minReadDepth: Int,
+            includeNull: Boolean = true,
+            debug: Boolean = false): RDD[ADAMGenotype] = {
+    val filteredGenotypes = genotypes.filter(hasMinimumReadDepth(_, minReadDepth, includeNull))
+    if (debug) GenotypeFilter.printFilterProgress(filteredGenotypes)
+    filteredGenotypes
+  }
+}
+
+/**
+ * Filter to remove genotypes where the number of reads to support the alternate allele is low
+ */
+object MinimumAlternateReadDepthFilter {
+
+  /**
+   *
+   * Apply the filter to an RDD of genotypes
+   *
+   * @param genotypes RDD of genotypes to filter
+   * @param minAlternateReadDepth minimum number of reads with alternate allele at locus for this genotype
+   * @param includeNull include the genotype if the required fields are null
+   * @param debug if true, compute the count of genotypes after filtering
+   * @return Genotypes with read depth > minAlternateReadDepth
+   */
+  def apply(genotypes: RDD[ADAMGenotype],
+            minAlternateReadDepth: Int,
+            includeNull: Boolean = true,
+            debug: Boolean = false): RDD[ADAMGenotype] = {
+    val filteredGenotypes = genotypes.filter(hasMinimumAlternateReadDepth(_, minAlternateReadDepth, includeNull))
+    if (debug) GenotypeFilter.printFilterProgress(filteredGenotypes)
+    filteredGenotypes
+  }
+
+  def hasMinimumAlternateReadDepth(genotype: ADAMGenotype,
+                                   minAlternateReadDepth: Int,
+                                   includeNull: Boolean = true): Boolean = {
+    if (genotype.alternateReadDepth != null) {
+      genotype.alternateReadDepth > minAlternateReadDepth
+    } else {
+      includeNull
+    }
+  }
+}
+
+/**
+ * Filter to remove genotypes where most of the reads that support come from a single strand
+ */
+object StrandBiasFilter {
+
+  /**
+   *
+   * This filter will remove genotypes where most of the supporting reads come from a single strand.
+   * Genotypes pass this filter by having there strand ratio between an upper and lower limit.
+   * If the number of reads is high we may want to ignore this filter so this filter is only applicable up to a number
+   * of reads (maxStrandBiasReadDepth)
+   *
+   * @param genotype Genotype to evaluate
+   * @param lowStrandBiasLimit Minimum alloweed percent of reads on the forward strand
+   * @param highStrandBiasLimit Maximum allowed percent of reads on the forward strand
+   * @param maxStrandBiasReadDepth maximum depth at which to apply filter
+   * @return
+   */
+  def isBiasedToSingleStrand(genotype: ADAMGenotype,
+                             lowStrandBiasLimit: Int,
+                             highStrandBiasLimit: Int,
+                             maxStrandBiasReadDepth: Int,
+                             includeNull: Boolean = true): Boolean = {
+    if (genotype.readsMappedForwardStrand != null && genotype.readDepth != null && genotype.alternateReadDepth != null) {
+      val strandRatio = genotype.readsMappedForwardStrand / genotype.readDepth
+      strandRatio < highStrandBiasLimit && strandRatio > lowStrandBiasLimit && genotype.alternateReadDepth < maxStrandBiasReadDepth
+    } else {
+      includeNull
+    }
+  }
+
+  /**
+   *  Apply the filter to an RDD of genotypes
+   *
+   * @param genotypes RDD of genotypes to filter
+   * @param lowStrandBiasLimit Minimum allowed percent of reads on the forward strand
+   * @param highStrandBiasLimit Maximum allowed percent of reads on the forward strand
+   * @param maxStrandBiasReadDepth maximum depth at which to apply filter
+   * @param includeNull include the genotype if the required fields are null
+   * @param debug if true, compute the count of genotypes after filtering
+   * @return Genotypes with read depth > minAlternateReadDepth
+   */
+  def apply(genotypes: RDD[ADAMGenotype], lowStrandBiasLimit: Int,
+            highStrandBiasLimit: Int,
+            maxStrandBiasReadDepth: Int,
+            includeNull: Boolean = true,
+            debug: Boolean = false): RDD[ADAMGenotype] = {
+    val filteredGenotypes = genotypes.filter(isBiasedToSingleStrand(_, lowStrandBiasLimit, highStrandBiasLimit, maxStrandBiasReadDepth, includeNull))
+    if (debug) GenotypeFilter.printFilterProgress(filteredGenotypes)
+    filteredGenotypes
+  }
+}
+
+object GenotypeFilter {
+
+  def printFilterProgress(filteredGenotypes: RDD[ADAMGenotype]) = {
+    filteredGenotypes.persist()
+    Common.progress("Filtered genotypes down to %d genotypes".format(filteredGenotypes.count()))
+  }
+
+  trait GenotypeFilterArguments extends Base {
+
+    @Option(name = "-minReadDepth", usage = "Minimum number of reads for a genotype call")
+    var minReadDepth: Int = 0
+
+    @Option(name = "-minAlternateReadDepth", usage = "Minimum number of reads with alternate allele for a genotype call")
+    var minAlternateReadDepth: Int = 0
+
+    @Option(name = "-maxStrandBiasAltReadDepth", usage = "Max number of reads to apply strand bias filter to")
+    var maxStrandBiasAltReadDepth: Int = 10
+
+    @Option(name = "-lowStrandBiasLimit", usage = "Minimum allowed % of reads on the forward strand. (To prevent strand bias)")
+    var lowStrandBiasLimit: Int = 0
+
+    @Option(name = "-highStrandBiasLimit", usage = "Maximum allowed % of reads on the forward strand. (To prevent strand bias)")
+    var highStrandBiasLimit: Int = 100
+
+  }
+
+  def apply(genotypes: RDD[ADAMGenotype], args: GenotypeFilterArguments): RDD[ADAMGenotype] = {
+    var filteredGenotypes = genotypes
+
+    if (args.minReadDepth > 0) {
+      filteredGenotypes = MinimumReadDepthFilter(genotypes, args.minReadDepth)
+    }
+
+    if (args.minAlternateReadDepth > 0) {
+      filteredGenotypes = MinimumReadDepthFilter(genotypes, args.minAlternateReadDepth)
+    }
+
+    if (args.lowStrandBiasLimit >= 0 || args.highStrandBiasLimit <= 100) {
+      filteredGenotypes = StrandBiasFilter(genotypes, args.lowStrandBiasLimit, args.highStrandBiasLimit, args.maxStrandBiasAltReadDepth)
+    }
+
+    filteredGenotypes
+  }
+
+}

--- a/src/main/scala/org/bdgenomics/guacamole/filters/PileupFilter.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/filters/PileupFilter.scala
@@ -1,0 +1,127 @@
+package org.bdgenomics.guacamole.filters
+
+import org.bdgenomics.guacamole.pileup.{ PileupElement, Pileup }
+import org.bdgenomics.guacamole.Common.Arguments.Base
+import org.kohsuke.args4j.Option
+import org.bdgenomics.guacamole.Bases
+
+/**
+ * Filter to remove pileup elements with low alignment quality
+ */
+object QualityAlignedReadsFilter {
+  /**
+   *
+   * @param elements sequence of pileup elements to filter
+   * @param minimumAlignmentQuality Threshold to define whether a read was poorly aligned
+   * @return filtered sequence of elements - those who had higher than minimumAlignmentQuality alignmentQuality
+   */
+  def apply(elements: Seq[PileupElement], minimumAlignmentQuality: Int): Seq[PileupElement] = {
+    elements.filter(_.read.alignmentQuality > minimumAlignmentQuality)
+  }
+}
+
+/**
+ * This is a cheap computation for a region's complexity
+ * We define a region's complexity as the number of reads whose alignment quality was below a certain threshold
+ * (minimumAlignmentQuality).
+ *
+ * This filter eliminates pileups where the number of low quality aligned reads is above the maximumAlignmentComplexity
+ */
+object RegionComplexityFilter {
+
+  /**
+   *
+   * @param elements sequence of pileup elements to filter
+   * @param maximumAlignmentComplexity The maximum allowed percent of reads to be poorly aligned (as defined by minimumAlignmentQuality)
+   * @param minimumAlignmentQuality Threshold to define whether a read was poorly aligned
+   * @return Empty sequence if the number of poorly mapped reads surpass the maximumAlignmentComplexity
+   */
+  def apply(elements: Seq[PileupElement], maximumAlignmentComplexity: Int, minimumAlignmentQuality: Int): Seq[PileupElement] = {
+    val depth = elements.length
+    val qualityMappedReads = elements.filter(_.read.alignmentQuality > minimumAlignmentQuality).length
+    if ((depth - qualityMappedReads).toFloat / depth > maximumAlignmentComplexity) {
+      Seq.empty
+    } else {
+      elements
+    }
+  }
+}
+
+/**
+ *
+ */
+object AmbiguousMappingPileupFilter {
+  /**
+   *
+   * @param elements sequence of pileup elements to filter
+   * @return Empty sequence if any of the reads had alignment quality = 0, otherwise original set of elements
+   */
+  def apply(elements: Seq[PileupElement]): Seq[PileupElement] = {
+    if (!elements.forall(_.read.alignmentQuality > 0)) {
+      Seq.empty
+    } else {
+      elements
+    }
+  }
+}
+
+/**
+ * Filter to remove pileups which may produce multi-allelic variant calls.
+ * These are generally more complex and more difficult to call
+ */
+object MultiAllelicPileupFilter {
+  /**
+   *
+   * @param elements sequence of pileup elements to filter
+   * @param maxPloidy pumber of alleles to expect (> maxPloidy would mean multiple possible alternates) default: 2
+   * @return Empty sequence if there are > maxPloidy possible allelee, otherwise original set of elements
+   */
+  def apply(elements: Seq[PileupElement], maxPloidy: Int = 2): Seq[PileupElement] = {
+    if (elements.map(el => Bases.basesToString(el.sequencedBases)).distinct.length > maxPloidy) {
+      Seq.empty
+    } else {
+      elements
+    }
+  }
+}
+
+object PileupFilter {
+
+  trait PileupFilterArguments extends Base {
+
+    @Option(name = "-minMapQ", usage = "Minimum read mapping quality for a read (Phred-scaled). Default: 30")
+    var minAlignmentQuality: Int = 30
+
+    @Option(name = "-maxMappingComplexity", usage = "Maximum percent of reads that can be mapped with low quality (indicative of a complex region")
+    var maxMappingComplexity: Int = 25
+
+    @Option(name = "-filterAmbiguousMapped", usage = "Filter any reads with duplicate mapping or alignment quality = 0")
+    var filterAmbiguousMapped: Boolean = false
+
+    @Option(name = "-filterMultiAllelic", usage = "Filter any pileups > 2 bases considered")
+    var filterMultiAllelic: Boolean = false
+
+  }
+
+  def apply(p: Pileup, args: PileupFilterArguments): Pileup = {
+
+    var elements: Seq[PileupElement] = p.elements
+    if (args.filterAmbiguousMapped) {
+      elements = AmbiguousMappingPileupFilter(elements)
+    }
+
+    if (args.filterMultiAllelic) {
+      elements = MultiAllelicPileupFilter(elements)
+    }
+
+    if (args.maxMappingComplexity < 100) {
+      elements = RegionComplexityFilter(elements, args.maxMappingComplexity, args.minAlignmentQuality)
+    }
+
+    if (args.minAlignmentQuality > 0) {
+      elements = QualityAlignedReadsFilter(elements, args.minAlignmentQuality)
+    }
+
+    Pileup(p.locus, elements)
+  }
+}

--- a/src/test/scala/org/bdgenomics/guacamole/TestUtil.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/TestUtil.scala
@@ -43,7 +43,8 @@ object TestUtil extends ShouldMatchers {
                mdtag: String,
                start: Long = 1,
                chr: String = "chr1",
-               qualityScores: Option[Array[Int]] = None): MappedRead = {
+               qualityScores: Option[Array[Int]] = None,
+               alignmentQuality: Int = 30): MappedRead = {
 
     val qualityScoreString = if (qualityScores.isDefined) {
       qualityScores.get.map(q => q + 33).map(_.toChar).mkString
@@ -56,7 +57,8 @@ object TestUtil extends ShouldMatchers {
       mdTagString = mdtag,
       start = start,
       referenceContig = chr,
-      baseQualities = qualityScoreString).getMappedRead
+      baseQualities = qualityScoreString,
+      alignmentQuality = alignmentQuality).getMappedRead
   }
 
   def assertAlmostEqual(a: Double, b: Double, epsilon: Double = 1e-6) {


### PR DESCRIPTION
This PR contains many of the filters that I have been playing with to improve precision and recall on the test sets.  I organized them in two sets, filters for pileup elements and filters for called genotypes.  

Pileup Filters:
- remove low alignment quality elements
- mapping complexity - as a heuristic for region complexity we can check if a significant number of reads are poorly aligned
- any ambiguous mappings (mapping quality = 0)
- multiple alternate alleles

Genotype filters
- read depth
- alternate allele depth
- strand bias

Some of the genotype filters could be "executed" earlier in the process (i.e. min read depth could skip pileups with < elements completely) but I think more often we will call a larger set of genotypes and apply filters after.

In the Args I set parameters that gave reasonable performance for this, but they need more exploration.
