### PR TITLE
The SomaticThresholdVariantCaller now filters non-variants out of the list of variants Closes #103

### DIFF
--- a/src/main/scala/org/bdgenomics/guacamole/callers/SomaticThresholdVariantCaller.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/callers/SomaticThresholdVariantCaller.scala
@@ -136,7 +136,7 @@ object SomaticThresholdVariantCaller extends Command with Serializable with Logg
     // A variant allele is, by definition, not equal to the reference base. Filter non-variants out.
     val possibleVariantAlles = possibleAlleles.filter(_ != refBase)
 
-    val thresholdSatisfyingAlleles = possibleAlleles.filter(
+    val thresholdSatisfyingAlleles = possibleVariantAlles.filter(
       base => possibleAllelesNormal(base) < thresholdNormal && possibleAllelesTumor(base) > thresholdTumor)
 
     // For now, we call a het when we have one somatic variant, and a compound alt when we have two. This is not really


### PR DESCRIPTION
Fixing #103 by filtering out non-variants from the list of variants
