### PR TITLE
Add pair alignment information to read

### DIFF
--- a/src/main/scala/org/bdgenomics/guacamole/filters/PileupFilter.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/filters/PileupFilter.scala
@@ -4,7 +4,6 @@ import org.bdgenomics.guacamole.pileup.{ PileupElement, Pileup }
 import org.bdgenomics.guacamole.Common.Arguments.Base
 import org.kohsuke.args4j.Option
 import org.bdgenomics.guacamole.Bases
-import org.bdgenomics.guacamole.filters.QualityAlignedReadsFilter
 
 /**
  * This is a cheap computation for a region's complexity


### PR DESCRIPTION
This somewhat bulks the read representation - I don't think it will be too much an issue, but something to watch for.  We could create a separte PairedRead implementation, but then either a Mapped or Unmapped read could have pair, so I didn't want to add that complexity yet unless we see issues with this.
