### PR TITLE
Update ADAM to 0.12.2 snapshot for mdtag and formats changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <name>guacamole: variant caller</name>
   
   <properties>
-    <adam.version>0.11.1-SNAPSHOT</adam.version>
+    <adam.version>0.12.2-SNAPSHOT</adam.version>
     <java.version>1.7.4</java.version>
     <scala.version>2.10.3</scala.version>
     <scala.version.prefix>2.10</scala.version.prefix>
@@ -212,11 +212,6 @@
   </repositories>
 
   <dependencies>
-    <dependency>
-      <groupId>org.bdgenomics.adam</groupId>
-      <artifactId>adam-format</artifactId>
-      <version>${adam.version}</version>
-    </dependency>
     <dependency>
       <groupId>org.bdgenomics.adam</groupId>
       <artifactId>adam-core</artifactId>

--- a/src/main/scala/org/bdgenomics/guacamole/Common.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/Common.scala
@@ -20,7 +20,7 @@ package org.bdgenomics.guacamole
 
 import org.bdgenomics.adam.cli.{ SparkArgs, ParquetArgs, Args4jBase }
 import org.kohsuke.args4j.{ Option => Opt }
-import org.bdgenomics.adam.avro.ADAMGenotype
+import org.bdgenomics.formats.avro.ADAMGenotype
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{ SparkConf, Logging, SparkContext }
 import org.bdgenomics.adam.rdd.ADAMContext._

--- a/src/main/scala/org/bdgenomics/guacamole/callers/BayesianQualityVariantCaller.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/callers/BayesianQualityVariantCaller.scala
@@ -4,7 +4,7 @@ import org.bdgenomics.guacamole._
 import org.apache.spark.Logging
 import org.bdgenomics.adam.cli.Args4j
 import org.bdgenomics.guacamole.pileup.{ PileupElement, Pileup }
-import org.bdgenomics.adam.avro.{ ADAMVariant, ADAMContig, ADAMGenotypeAllele, ADAMGenotype }
+import org.bdgenomics.formats.avro.{ ADAMVariant, ADAMContig, ADAMGenotypeAllele, ADAMGenotype }
 import scala.collection.JavaConversions
 import org.apache.spark.rdd.RDD
 import org.kohsuke.args4j.Option
@@ -15,7 +15,7 @@ import org.bdgenomics.guacamole.concordance.GenotypesEvaluator
 import org.bdgenomics.guacamole.concordance.GenotypesEvaluator.GenotypeConcordance
 import org.bdgenomics.guacamole.filters.GenotypeFilter.GenotypeFilterArguments
 import org.bdgenomics.guacamole.filters.PileupFilter.PileupFilterArguments
-import org.bdgenomics.guacamole.filters.{ QualityAlignedReadsFilter, MinimumReadDepthFilter, GenotypeFilter }
+import org.bdgenomics.guacamole.filters.{ QualityAlignedReadsFilter, GenotypeFilter }
 
 /**
  * A Genotype is a sequence of alleles of length equal to the ploidy of the organism.

--- a/src/main/scala/org/bdgenomics/guacamole/callers/SomaticThresholdVariantCaller.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/callers/SomaticThresholdVariantCaller.scala
@@ -18,8 +18,8 @@
 
 package org.bdgenomics.guacamole.callers
 
-import org.bdgenomics.adam.avro.{ ADAMContig, ADAMVariant, ADAMGenotypeAllele, ADAMGenotype }
-import org.bdgenomics.adam.avro.ADAMGenotypeAllele.{ NoCall, Ref, Alt, OtherAlt }
+import org.bdgenomics.formats.avro.{ ADAMContig, ADAMVariant, ADAMGenotypeAllele, ADAMGenotype }
+import org.bdgenomics.formats.avro.ADAMGenotypeAllele.{ Ref, Alt, OtherAlt }
 import org.bdgenomics.guacamole._
 import org.apache.spark.SparkContext._
 import scala.collection.JavaConversions

--- a/src/main/scala/org/bdgenomics/guacamole/callers/ThresholdVariantCaller.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/callers/ThresholdVariantCaller.scala
@@ -18,8 +18,8 @@
 
 package org.bdgenomics.guacamole.callers
 
-import org.bdgenomics.adam.avro.{ ADAMContig, ADAMVariant, ADAMGenotypeAllele, ADAMGenotype }
-import org.bdgenomics.adam.avro.ADAMGenotypeAllele.{ NoCall, Ref, Alt, OtherAlt }
+import org.bdgenomics.formats.avro.{ ADAMContig, ADAMVariant, ADAMGenotypeAllele, ADAMGenotype }
+import org.bdgenomics.formats.avro.ADAMGenotypeAllele.{ NoCall, Ref, Alt, OtherAlt }
 import org.bdgenomics.guacamole._
 import org.apache.spark.SparkContext._
 import scala.collection.JavaConversions

--- a/src/main/scala/org/bdgenomics/guacamole/concordance/GenotypesEvaluator.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/concordance/GenotypesEvaluator.scala
@@ -3,12 +3,12 @@ package org.bdgenomics.guacamole.concordance
 import org.bdgenomics.guacamole.{ Common, Command }
 import org.apache.spark.{ SparkContext, Logging }
 import org.kohsuke.args4j.Option
-import org.bdgenomics.adam.cli.{ GenotypeConcordance, Args4j }
+import org.bdgenomics.adam.cli.Args4j
 import org.bdgenomics.adam.rdd.variation.ADAMVariationContext._
 import org.apache.spark.SparkContext._
 import org.bdgenomics.adam.rdd.variation.ConcordanceTable
 import java.util.EnumSet
-import org.bdgenomics.adam.avro.{ ADAMGenotype, ADAMGenotypeType }
+import org.bdgenomics.formats.avro.{ ADAMGenotype, ADAMGenotypeType }
 import org.bdgenomics.adam.rich.RichADAMVariant
 import org.apache.spark.rdd.RDD
 

--- a/src/main/scala/org/bdgenomics/guacamole/filters/GenotypeFilter.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/filters/GenotypeFilter.scala
@@ -1,7 +1,7 @@
 package org.bdgenomics.guacamole.filters
 
 import org.apache.spark.rdd.RDD
-import org.bdgenomics.adam.avro.ADAMGenotype
+import org.bdgenomics.formats.avro.ADAMGenotype
 import org.bdgenomics.guacamole.Common.Arguments.Base
 import org.kohsuke.args4j.Option
 import org.bdgenomics.guacamole.Common

--- a/src/main/scala/org/bdgenomics/guacamole/pileup/Pileup.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/pileup/Pileup.scala
@@ -18,7 +18,7 @@
 
 package org.bdgenomics.guacamole.pileup
 
-import org.bdgenomics.guacamole.{ Bases, MappedRead, Read, Common }
+import org.bdgenomics.guacamole.{ Bases, MappedRead }
 
 /**
  * A [[Pileup]] at a locus contains a sequence of [[PileupElement]] instances, one for every read that overlaps that

--- a/src/main/scala/org/bdgenomics/guacamole/pileup/PileupElement.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/pileup/PileupElement.scala
@@ -1,9 +1,8 @@
 package org.bdgenomics.guacamole.pileup
 
-import net.sf.samtools.{ TextCigarCodec, CigarOperator, CigarElement }
-import org.bdgenomics.guacamole.{ MappedRead, Read, CigarUtils }
+import net.sf.samtools.{ CigarOperator, CigarElement }
+import org.bdgenomics.guacamole.{ MappedRead, CigarUtils }
 import scala.annotation.tailrec
-import scala.collection.JavaConversions._
 
 /**
  * A [[PileupElement]] represents the bases  sequenced by a particular read at a particular reference locus.

--- a/src/main/scala/org/bdgenomics/guacamole/somatic/SimpleSomaticVariantCaller.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/somatic/SimpleSomaticVariantCaller.scala
@@ -18,19 +18,17 @@
 
 package org.bdgenomics.guacamole.somatic
 
-import org.bdgenomics.adam.avro._
+import org.bdgenomics.formats.avro._
 import org.bdgenomics.guacamole.{ Common, Command }
-import org.bdgenomics.guacamole.Common.Arguments.{ Base }
+import org.bdgenomics.guacamole.Common.Arguments.Base
 import org.bdgenomics.adam.cli.Args4j
 import org.apache.spark.rdd.RDD
 import org.apache.spark.SparkContext._
 import org.apache.spark.SparkContext.rddToPairRDDFunctions
 import scala.collection.{ mutable, JavaConversions }
 import org.bdgenomics.adam.rdd.ADAMContext._
-import net.sf.samtools.{ CigarOperator }
+import net.sf.samtools.CigarOperator
 import org.apache.spark.SparkContext
-import org.apache.hadoop.io.{ Text, LongWritable }
-import org.apache.hadoop.mapred.TextInputFormat
 
 /**
  * Simple somatic variant caller implementation.

--- a/src/test/scala/org/bdgenomics/guacamole/DistributedUtilSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/DistributedUtilSuite.scala
@@ -19,7 +19,7 @@
 package org.bdgenomics.guacamole
 
 import org.scalatest.matchers.ShouldMatchers
-import org.bdgenomics.adam.avro.{ ADAMGenotypeAllele, ADAMGenotype }
+import org.bdgenomics.formats.avro.{ ADAMGenotypeAllele, ADAMGenotype }
 import org.bdgenomics.guacamole.callers.ThresholdVariantCaller
 import scala.collection.JavaConversions._
 import org.bdgenomics.guacamole.pileup.{ PileupElement, Pileup }

--- a/src/test/scala/org/bdgenomics/guacamole/LociMapSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/LociMapSuite.scala
@@ -20,7 +20,6 @@ package org.bdgenomics.guacamole
 
 import org.scalatest.matchers.ShouldMatchers
 import com.google.common.collect._
-import org.scalatest.matchers.ShouldMatchers._
 
 class LociMapSuite extends TestUtil.SparkFunSuite with ShouldMatchers {
 

--- a/src/test/scala/org/bdgenomics/guacamole/ReadSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/ReadSuite.scala
@@ -19,11 +19,7 @@
 package org.bdgenomics.guacamole
 
 import org.scalatest.matchers.ShouldMatchers
-import com.google.common.collect._
-import com.esotericsoftware.kryo.Kryo
-import com.twitter.chill.{ IKryoRegistrar, KryoInstantiator, KryoPool }
-import net.sf.samtools.{ Cigar, TextCigarCodec }
-import org.bdgenomics.adam.util.MdTag
+import net.sf.samtools.TextCigarCodec
 
 class ReadSuite extends TestUtil.SparkFunSuite with ShouldMatchers {
   test("serialize / deserialize mapped read") {

--- a/src/test/scala/org/bdgenomics/guacamole/SimpleSomaticVariantCallerSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/SimpleSomaticVariantCallerSuite.scala
@@ -19,7 +19,7 @@
 
 package org.bdgenomics.guacamole
 
-import org.bdgenomics.adam.avro.{ ADAMGenotype }
+import org.bdgenomics.formats.avro.{ ADAMGenotype }
 import org.scalatest.matchers.ShouldMatchers
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.apache.spark.SparkContext._

--- a/src/test/scala/org/bdgenomics/guacamole/SlidingReadWindowSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/SlidingReadWindowSuite.scala
@@ -19,9 +19,7 @@
 package org.bdgenomics.guacamole
 
 import org.scalatest.FunSuite
-import org.bdgenomics.adam.avro.{ ADAMContig }
 import org.scalatest.matchers.ShouldMatchers._
-import org.scalatest.matchers._
 
 class SlidingReadWindowSuite extends FunSuite {
 

--- a/src/test/scala/org/bdgenomics/guacamole/TestUtil.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/TestUtil.scala
@@ -9,16 +9,13 @@ import java.net.ServerSocket
 import org.apache.spark.SparkContext
 import org.apache.log4j.{ Logger, Level }
 import org.bdgenomics.adam.cli.SparkArgs
-import org.bdgenomics.adam.avro.{ ADAMContig, ADAMRecord }
-import org.bdgenomics.adam.rich.DecadentRead
 import scala.math._
 import scala.Some
 import com.twitter.chill.{ KryoPool, IKryoRegistrar, KryoInstantiator }
 import com.esotericsoftware.kryo.Kryo
 import org.scalatest.matchers.ShouldMatchers
-import org.apache.spark.rdd.RDD
 import org.apache.commons.io.FileUtils
-import java.io.{ FileNotFoundException, IOError, File }
+import java.io.{ FileNotFoundException, File }
 
 object TestUtil extends ShouldMatchers {
 

--- a/src/test/scala/org/bdgenomics/guacamole/callers/BayesianQualityVariantCallerSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/callers/BayesianQualityVariantCallerSuite.scala
@@ -3,7 +3,7 @@ package org.bdgenomics.guacamole.callers
 import org.bdgenomics.guacamole.TestUtil.SparkFunSuite
 import org.bdgenomics.guacamole.TestUtil
 import org.bdgenomics.guacamole.pileup.Pileup
-import org.bdgenomics.adam.avro.ADAMGenotypeAllele
+import org.bdgenomics.formats.avro.ADAMGenotypeAllele
 import scala.collection.JavaConversions._
 import org.bdgenomics.adam.util.PhredUtils
 

--- a/src/test/scala/org/bdgenomics/guacamole/callers/SomaticThresholdVariantCallerSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/callers/SomaticThresholdVariantCallerSuite.scala
@@ -2,8 +2,6 @@ package org.bdgenomics.guacamole.callers
 
 import org.bdgenomics.guacamole.TestUtil.SparkFunSuite
 import org.bdgenomics.guacamole.TestUtil
-import org.apache.commons.io.FileUtils
-import java.io.{ IOError, File }
 
 class SomaticThresholdVariantCallerSuite extends SparkFunSuite {
   val output = "/tmp/somatic.threshold.chr20.vcf"

--- a/src/test/scala/org/bdgenomics/guacamole/callers/ThresholdVariantCallerSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/callers/ThresholdVariantCallerSuite.scala
@@ -2,7 +2,7 @@ package org.bdgenomics.guacamole.callers
 
 import org.scalatest.FunSuite
 import org.bdgenomics.guacamole.{ TestUtil }
-import org.bdgenomics.adam.avro.ADAMGenotypeAllele
+import org.bdgenomics.formats.avro.ADAMGenotypeAllele
 import scala.collection.JavaConversions._
 import org.bdgenomics.guacamole.pileup.Pileup
 import org.scalatest.matchers.ShouldMatchers

--- a/src/test/scala/org/bdgenomics/guacamole/pileup/PileupSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/pileup/PileupSuite.scala
@@ -18,11 +18,8 @@
 
 package org.bdgenomics.guacamole.pileup
 
-import org.bdgenomics.adam.avro.ADAMRecord
 import org.scalatest.matchers.ShouldMatchers
-import org.bdgenomics.adam.rdd.ADAMContext._
-import org.apache.spark.rdd.RDD
-import org.bdgenomics.guacamole.{ Bases, MappedRead, Read, TestUtil }
+import org.bdgenomics.guacamole.{ Bases, TestUtil }
 
 class PileupSuite extends TestUtil.SparkFunSuite with ShouldMatchers {
 


### PR DESCRIPTION
Update ADAM to 0.12.2 from 0.11.1.  This is needed for some recent additions to MdTag and required some import changes due to moving over from adam-formats to bdg-formats.

This does introduce some deprecation warnings which will need to be cleaned up.
