### PR TITLE
update filters; add pileup element fields and filters

### DIFF
--- a/src/main/scala/org/bdgenomics/guacamole/filters/PileupElementsFilter.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/filters/PileupElementsFilter.scala
@@ -12,7 +12,23 @@ object QualityAlignedReadsFilter {
    * @return filtered sequence of elements - those who had higher than minimumAlignmentQuality alignmentQuality
    */
   def apply(elements: Seq[PileupElement], minimumAlignmentQuality: Int): Seq[PileupElement] = {
-    elements.filter(_.read.alignmentQuality > minimumAlignmentQuality)
+    elements.filter(_.read.alignmentQuality >= minimumAlignmentQuality)
+  }
+
+}
+
+/**
+ * Filter to remove pileup elements close to edge of reads
+ */
+object EdgeBaseFilter {
+  /**
+   *
+   * @param elements sequence of pileup elements to filter
+   * @param minimumDistanceFromEndFromRead Threshold of distance from base to edge of read
+   * @return filtered sequence of elements - those who were further from directional end minimumDistanceFromEndFromRead
+   */
+  def apply(elements: Seq[PileupElement], minimumDistanceFromEndFromRead: Int): Seq[PileupElement] = {
+    elements.filter(_.distanceFromSequencingEnd >= minimumDistanceFromEndFromRead)
   }
 }
 

--- a/src/main/scala/org/bdgenomics/guacamole/pileup/Pileup.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/pileup/Pileup.scala
@@ -71,6 +71,26 @@ case class Pileup(locus: Long, elements: Seq[PileupElement]) {
   }
 
   /**
+   * Depth of pileup - number of reads at locus
+   */
+  lazy val depth: Int = elements.length
+
+  /**
+   * Number of positively stranded reads
+   */
+  lazy val positiveDepth: Int = elements.view.filter(_.read.isPositiveStrand).size
+
+  /**
+   * PileupElements that match the reference base
+   */
+  lazy val referenceElements = elements.filter(_.isMatch)
+
+  /**
+   * PileupElements that match the reference base
+   */
+  lazy val referenceDepth = referenceElements.size
+
+  /**
    * Returns a new [[Pileup]] at a different locus on the same contig.
    *
    * To enable an efficient implementation, the new locus must be greater than the current locus.


### PR DESCRIPTION
- Updated filters to be >= rather than >
- Added EdgeDistance filter to drop bases closes to the edge of the read
- Added MinLikelihood filter to filter Genotypes with low likelihood
- Added nearbyMismatches function to pileupelement to skip elements within many SNVs nearby
- Removed strand bias filter from GenotypeFilters for now as those fields were removed from ADAMGenotype
