### PR TITLE
make scalariform tolerate dangling close-parends

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,7 @@
               <alignParameters>true</alignParameters>
               <alignSingleLineCaseStatements>true</alignSingleLineCaseStatements>
               <doubleIndentClassDeclaration>true</doubleIndentClassDeclaration>
+              <preserveDanglingCloseParenthesis>true</preserveDanglingCloseParenthesis>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
scala style guide doesn't seem to have strong guidance here,
and occasionally it feels clearer to allow parends to surround
code blocks visually in a similar fashion to the way curly-braces
commonly do (often in scala one can do as much between parends as
between curly-braces)
