### PR TITLE
Delay MDTag parsing

### DIFF
--- a/src/main/scala/org/bdgenomics/guacamole/filters/GenotypeFilter.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/filters/GenotypeFilter.scala
@@ -47,9 +47,9 @@ object MinimumLikelihoodFilter {
 object ReadDepthFilter {
 
   def withinReadDepthRange(genotype: ADAMGenotype,
-                          minReadDepth: Int,
-                          maxReadDepth: Int,
-                          includeNull: Boolean = true): Boolean = {
+                           minReadDepth: Int,
+                           maxReadDepth: Int,
+                           includeNull: Boolean = true): Boolean = {
     if (genotype.readDepth != null) {
       genotype.readDepth >= minReadDepth && genotype.readDepth < maxReadDepth
     } else {

--- a/src/test/scala/org/bdgenomics/guacamole/ReadSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/ReadSuite.scala
@@ -187,7 +187,7 @@ class ReadSuite extends TestUtil.SparkFunSuite with ShouldMatchers {
       50,
       325352323,
       TextCigarCodec.getSingleton.decode(""),
-      Some(MdTag("6", 325352323)), // mdtag
+      Some("6"), // mdtag
       false,
       isPositiveStrand = true,
       isPaired = true,
@@ -315,7 +315,7 @@ class ReadSuite extends TestUtil.SparkFunSuite with ShouldMatchers {
     allReads.reads.count() should be(8)
 
     val mdTagReads = TestUtil.loadReads(sc, "mdtagissue.sam", Read.InputFilters(mapped = true, hasMdTag = true))
-    mdTagReads.reads.count() should be(5)
+    mdTagReads.reads.count() should be(6)
 
     val nonDuplicateReads = TestUtil.loadReads(sc, "mdtagissue.sam", Read.InputFilters(mapped = true, nonDuplicate = true))
     nonDuplicateReads.reads.count() should be(6)
@@ -331,7 +331,7 @@ class ReadSuite extends TestUtil.SparkFunSuite with ShouldMatchers {
       deserialized.alignmentQuality should equal(read.alignmentQuality)
       deserialized.start should equal(read.start)
       deserialized.cigar should equal(read.cigar)
-      deserialized.mdTag should equal(read.mdTag)
+      deserialized.mdTagString should equal(read.mdTagString)
       deserialized.failedVendorQualityChecks should equal(read.failedVendorQualityChecks)
       deserialized.isPositiveStrand should equal(read.isPositiveStrand)
       deserialized.isMateMapped should equal(read.isMateMapped)


### PR DESCRIPTION
From some basic profiling I saw that we spend a fair amount of time parsing out the MDTag and then calling .toString on it when we serialize the reads.  When we are repartitioning the reads, we parse and then reserialize the mdtag and then reparse when we process.  This change would only parse the tags when we access them (for example in pileup processing) but at the cost of hanging out to the original mdtag string
