### PR TITLE
upgrade scalatest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.version.prefix}</artifactId>
-      <version>1.9.2</version>
+      <version>2.2.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
supports wildcard single-{test,suite} running, e.g.:

`mvn -Dsuites='*PileupSuite' test`
`mvn -Dsuites='*PileupSuite qualities' test`

see also: [`mvn-test` helper script in `internal-tools`](https://github.com/hammerlab/internal-tools/pull/11)
