### PR TITLE
Update tests from deprecated syntax

### DIFF
--- a/src/test/scala/org/bdgenomics/guacamole/DistributedUtilSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/DistributedUtilSuite.scala
@@ -18,14 +18,15 @@
 
 package org.bdgenomics.guacamole
 
-import org.scalatest.matchers.ShouldMatchers
-import org.bdgenomics.formats.avro.{ ADAMGenotypeAllele, ADAMGenotype }
-import org.bdgenomics.guacamole.callers.ThresholdVariantCaller
-import scala.collection.JavaConversions._
-import org.bdgenomics.guacamole.pileup.{ PileupElement, Pileup }
 import org.apache.spark.rdd.RDD
+import org.bdgenomics.formats.avro.{ ADAMGenotype, ADAMGenotypeAllele }
+import org.bdgenomics.guacamole.callers.ThresholdVariantCaller
+import org.bdgenomics.guacamole.pileup.{ Pileup, PileupElement }
+import org.scalatest.Matchers
 
-class DistributedUtilSuite extends TestUtil.SparkFunSuite with ShouldMatchers {
+import scala.collection.JavaConversions._
+
+class DistributedUtilSuite extends TestUtil.SparkFunSuite with Matchers {
 
   // You can use a line like the following to turn on only a particular unit test for debugging.
   // TestUtil.runOnly = "partitionLociByApproximateReadDepth chr20 synth1 subset"

--- a/src/test/scala/org/bdgenomics/guacamole/LociMapSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/LociMapSuite.scala
@@ -18,10 +18,10 @@
 
 package org.bdgenomics.guacamole
 
-import org.scalatest.matchers.ShouldMatchers
 import com.google.common.collect._
+import org.scalatest.Matchers
 
-class LociMapSuite extends TestUtil.SparkFunSuite with ShouldMatchers {
+class LociMapSuite extends TestUtil.SparkFunSuite with Matchers {
 
   test("properties of empty LociMap") {
     val emptyMap = LociMap[String]()

--- a/src/test/scala/org/bdgenomics/guacamole/LociSetSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/LociSetSuite.scala
@@ -18,9 +18,9 @@
 
 package org.bdgenomics.guacamole
 
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 
-class LociSetSuite extends TestUtil.SparkFunSuite with ShouldMatchers {
+class LociSetSuite extends TestUtil.SparkFunSuite with Matchers {
 
   test("properties of empty LociSet") {
     LociSet.empty.contigs should have length (0)

--- a/src/test/scala/org/bdgenomics/guacamole/ReadSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/ReadSuite.scala
@@ -18,11 +18,10 @@
 
 package org.bdgenomics.guacamole
 
-import org.scalatest.matchers.ShouldMatchers
 import net.sf.samtools.TextCigarCodec
-import org.bdgenomics.adam.util.MdTag
+import org.scalatest.Matchers
 
-class ReadSuite extends TestUtil.SparkFunSuite with ShouldMatchers {
+class ReadSuite extends TestUtil.SparkFunSuite with Matchers {
 
   test("mappedread is mapped") {
     val read = MappedRead(

--- a/src/test/scala/org/bdgenomics/guacamole/SlidingWindowSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/SlidingWindowSuite.scala
@@ -18,10 +18,9 @@
 
 package org.bdgenomics.guacamole
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers._
+import org.scalatest.{ Matchers, FunSuite }
 
-class SlidingWindowSuite extends FunSuite {
+class SlidingWindowSuite extends FunSuite with Matchers {
 
   test("test sliding read window, duplicate reads") {
 
@@ -42,7 +41,7 @@ class SlidingWindowSuite extends FunSuite {
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1, "chr2"),
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1, "chr3"))
     val window = SlidingWindow(2, reads.iterator)
-    val caught = evaluating { window.setCurrentLocus(0) } should produce[IllegalArgumentException]
+    val caught = the[IllegalArgumentException] thrownBy { window.setCurrentLocus(0) }
     caught.getMessage should include("must have the same reference name")
 
   }
@@ -70,7 +69,7 @@ class SlidingWindowSuite extends FunSuite {
       TestUtil.makeRead("TCGATCGA", "8M", "8", 8),
       TestUtil.makeRead("TCGATCGA", "8M", "8", 4))
     val window = SlidingWindow(8, reads.iterator)
-    val caught = evaluating { window.setCurrentLocus(0) } should produce[IllegalArgumentException]
+    val caught = the[IllegalArgumentException] thrownBy { window.setCurrentLocus(0) }
     caught.getMessage should include("Regions must be sorted by start locus")
 
   }

--- a/src/test/scala/org/bdgenomics/guacamole/TestUtil.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/TestUtil.scala
@@ -4,21 +4,21 @@ package org.bdgenomics.guacamole
  * This is copied from SparkFunSuite in ADAM, which is for some reason not exposed.
  *
  */
-import org.scalatest._
+import java.io.{ File, FileNotFoundException }
 import java.net.ServerSocket
-import org.apache.spark.SparkContext
-import org.apache.log4j.{ Logger, Level }
-import org.bdgenomics.adam.cli.SparkArgs
-import scala.math._
-import scala.Some
-import com.twitter.chill.{ KryoPool, IKryoRegistrar, KryoInstantiator }
-import com.esotericsoftware.kryo.Kryo
-import org.scalatest.matchers.ShouldMatchers
-import org.apache.commons.io.FileUtils
-import java.io.{ FileNotFoundException, File }
-import org.bdgenomics.guacamole.pileup.Pileup
 
-object TestUtil extends ShouldMatchers {
+import com.esotericsoftware.kryo.Kryo
+import com.twitter.chill.{ IKryoRegistrar, KryoInstantiator, KryoPool }
+import org.apache.commons.io.FileUtils
+import org.apache.log4j.{ Level, Logger }
+import org.apache.spark.SparkContext
+import org.bdgenomics.adam.cli.SparkArgs
+import org.bdgenomics.guacamole.pileup.Pileup
+import org.scalatest._
+
+import scala.math._
+
+object TestUtil extends Matchers {
 
   // As a hack to run a single unit test, you can set this to the name of a test to run only it. See the top of
   // DistributedUtilSuite for an example.

--- a/src/test/scala/org/bdgenomics/guacamole/callers/SomaticLogOddsVariantCallerSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/callers/SomaticLogOddsVariantCallerSuite.scala
@@ -3,11 +3,11 @@ package org.bdgenomics.guacamole.callers
 import org.bdgenomics.guacamole.{ MappedRead, TestUtil }
 import org.bdgenomics.guacamole.TestUtil.SparkFunSuite
 import org.bdgenomics.guacamole.pileup.Pileup
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.bdgenomics.guacamole.filters.GenotypeFilter
 
-class SomaticLogOddsVariantCallerSuite extends SparkFunSuite with ShouldMatchers with TableDrivenPropertyChecks {
+class SomaticLogOddsVariantCallerSuite extends SparkFunSuite with Matchers with TableDrivenPropertyChecks {
 
   def loadPileup(filename: String, locus: Long = 0): Pileup = {
     val records = TestUtil.loadReads(sc, filename).mappedReads

--- a/src/test/scala/org/bdgenomics/guacamole/callers/ThresholdVariantCallerSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/callers/ThresholdVariantCallerSuite.scala
@@ -1,13 +1,12 @@
 package org.bdgenomics.guacamole.callers
 
-import org.scalatest.FunSuite
+import org.scalatest.{ Matchers, FunSuite }
 import org.bdgenomics.guacamole.{ TestUtil }
 import org.bdgenomics.formats.avro.ADAMGenotypeAllele
 import scala.collection.JavaConversions._
 import org.bdgenomics.guacamole.pileup.Pileup
-import org.scalatest.matchers.ShouldMatchers
 
-class ThresholdVariantCallerSuite extends FunSuite with ShouldMatchers {
+class ThresholdVariantCallerSuite extends FunSuite with Matchers {
 
   test("no variants, threshold 0") {
     val reads = Seq(

--- a/src/test/scala/org/bdgenomics/guacamole/pileup/PileupSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/pileup/PileupSuite.scala
@@ -18,10 +18,10 @@
 
 package org.bdgenomics.guacamole.pileup
 
-import org.scalatest.matchers.ShouldMatchers
 import org.bdgenomics.guacamole.{ Bases, TestUtil }
+import org.scalatest.Matchers
 
-class PileupSuite extends TestUtil.SparkFunSuite with ShouldMatchers {
+class PileupSuite extends TestUtil.SparkFunSuite with Matchers {
 
   //lazy so that this is only accessed from inside a spark test where SparkContext has been initialized
   lazy val testAdamRecords = TestUtil.loadReads(sc, "different_start_reads.sam").mappedReads.collect()


### PR DESCRIPTION
This changes the package ShouldMatchers to Matchers since the former is deprecated in the latest scalatest.  Some other deprecated test syntax is removed as well.
