### PR TITLE
Dropped filterLociWhoseContigsHaveNoRegions

### DIFF
--- a/src/test/scala/org/bdgenomics/guacamole/DistributedUtilSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/DistributedUtilSuite.scala
@@ -91,37 +91,6 @@ class DistributedUtilSuite extends TestUtil.SparkFunSuite with Matchers {
     }
   }
 
-  sparkTest("partitionLociByApproximateReadDepth empty chromosomes") {
-    def makeRead(start: Long, length: Long) = {
-      TestUtil.makeRead("A" * length.toInt, "%sM".format(length), "%s".format(length), start, "chr5")
-    }
-    def pairsToReads(pairs: Seq[(Long, Long)]): RDD[MappedRead] = {
-      sc.parallelize(pairs.map(pair => makeRead(pair._1, pair._2)))
-    }
-    {
-      val reads = pairsToReads(Seq(
-        (5, 1),
-        (6, 1),
-        (7, 1),
-        (8, 1)))
-      val loci = LociSet.parse("chr1:0-1000000,chr5:0-100")
-      val result = DistributedUtil.partitionLociByApproximateDepth(2, loci, 100, reads)
-      result.toString should equal("chr1:0-1000000=0,chr5:0-7=0,chr5:7-100=1")
-    }
-  }
-
-  sparkTest("partitionLociByApproximateReadDepth chr20 synth1 subset") {
-    val tumorReads = TestUtil.loadReads(sc, "dream_training.chr20.mdTagged.loci0-150k.tumor.sam")
-    val normalReads = TestUtil.loadReads(sc, "dream_training.chr20.mdTagged.loci0-150k.normal.sam")
-
-    val loci = LociSet.parse("1:0-249250621,20:0-100000")
-    val partitioned = DistributedUtil.partitionLociByApproximateDepth(2, loci, 250, tumorReads.mappedReads, normalReads.mappedReads)
-    println(partitioned)
-
-    // The entire chromosome 1, which has no reads, should be assigned to task 0.
-    partitioned.filterContigs(_ == "1").toString should equal("1:0-249250621=0")
-  }
-
   sparkTest("test pileup flatmap parallelism 0; create pileups") {
 
     val reads = sc.parallelize(Seq(

--- a/src/test/scala/org/bdgenomics/guacamole/callers/SomaticThresholdVariantCallerSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/callers/SomaticThresholdVariantCallerSuite.scala
@@ -12,5 +12,6 @@ class SomaticThresholdVariantCallerSuite extends SparkFunSuite {
       "-tumor-reads", TestUtil.testDataPath("synth1.tumor.100k-200k.withmd.bam"),
       "-normal-reads", TestUtil.testDataPath("synth1.normal.100k-200k.withmd.bam"),
       "-parallelism", "20",
+      "-loci", "20:100000-200000",
       "-out", output))
 }


### PR DESCRIPTION
Dropped filterLociWhoseContigsHaveNoRegions - this is useful if 1) the user misspecifies loci by including loci not in the file or 2) loci are not specified and the sequence dictionary has more sequences than actually in the file. These are easily solved by the user either specifying loci or using the flag to get loci from reads instead of the sequence dictionary. Otherwise has ~4-5min overhead on every run. Closes #140
