### PR TITLE
better Array[Byte] <-> String conversions

### DIFF
--- a/src/main/scala/org/bdgenomics/guacamole/Bases.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/Bases.scala
@@ -20,6 +20,7 @@ package org.bdgenomics.guacamole
  *
  */
 object Bases {
+
   /** Standard bases. Note that other bases are sometimes used as well (e.g. "N"). */
   val A = "A".getBytes()(0)
   val C = "C".getBytes()(0)
@@ -61,13 +62,4 @@ object Bases {
     bases.map(_.toChar).mkString
   }
 
-  /** Are the two given base sequences equal? */
-  def equal(bases1: Array[Byte], bases2: Array[Byte]): Boolean = {
-    bases1.sameElements(bases2)
-  }
-
-  /* Is the first base sequence equal to the second string? */
-  def equalString(bases1: Array[Byte], bases2: String): Boolean = {
-    bases1.sameElements(stringToBases(bases2))
-  }
 }

--- a/src/test/scala/org/bdgenomics/guacamole/DistributedUtilSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/DistributedUtilSuite.scala
@@ -23,6 +23,8 @@ import org.bdgenomics.formats.avro.{ GenotypeAllele, Genotype }
 import org.bdgenomics.guacamole.callers.ThresholdVariantCaller
 import org.bdgenomics.guacamole.pileup.{ Pileup, PileupElement }
 import org.bdgenomics.guacamole.reads.MappedRead
+import org.bdgenomics.guacamole.TestUtil.assertBases
+import org.bdgenomics.guacamole.TestUtil.Implicits._
 import org.scalatest.Matchers
 
 import scala.collection.JavaConversions._
@@ -248,8 +250,10 @@ class DistributedUtilSuite extends TestUtil.SparkFunSuite with Matchers {
       (pileup1, pileup2) => (pileup1.elements ++ pileup2.elements).toIterator).collect()
 
     elements.forall(_.isMatch) should be(true)
-    val concatenated = Bases.basesToString(elements.flatMap(_.sequencedSingleBaseOpt))
-    concatenated should equal("TTTACTCCCACTGGGACTAAAACTTTTACTCCCACTGGGACTAAAACTXGGGXGGGXGGGGGGGGGGGGGGGGGG")
+    assertBases(
+      elements.flatMap(_.sequencedSingleBaseOpt),
+      "TTTACTCCCACTGGGACTAAAACTTTTACTCCCACTGGGACTAAAACTXGGGXGGGXGGGGGGGGGGGGGGGGGG"
+    )
   }
 
   sparkTest("test pileup flatmap parallelism 5; create pileup elements; with indel") {

--- a/src/test/scala/org/bdgenomics/guacamole/TestUtil.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/TestUtil.scala
@@ -22,6 +22,11 @@ import scala.math._
 
 object TestUtil extends Matchers {
 
+  object Implicits {
+    implicit def basesToString = Bases.basesToString _
+    implicit def stringToBases = Bases.stringToBases _
+  }
+
   // As a hack to run a single unit test, you can set this to the name of a test to run only it. See the top of
   // DistributedUtilSuite for an example.
   var runOnly: String = ""
@@ -104,6 +109,8 @@ object TestUtil extends Matchers {
       )
     ).getMappedReadOpt.get
   }
+
+  def assertBases(bases1: String, bases2: String) = bases1 should equal(bases2)
 
   def testDataPath(filename: String): String = {
     val resource = ClassLoader.getSystemClassLoader.getResource(filename)

--- a/src/test/scala/org/bdgenomics/guacamole/reads/MappedReadSerializerSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/reads/MappedReadSerializerSuite.scala
@@ -1,7 +1,8 @@
 package org.bdgenomics.guacamole.reads
 
 import net.sf.samtools.TextCigarCodec
-import org.bdgenomics.guacamole.{ Bases, TestUtil }
+import org.bdgenomics.guacamole.TestUtil
+import org.bdgenomics.guacamole.TestUtil.Implicits._
 import org.scalatest.Matchers
 
 class MappedReadSerializerSuite extends TestUtil.SparkFunSuite with Matchers {
@@ -9,7 +10,7 @@ class MappedReadSerializerSuite extends TestUtil.SparkFunSuite with Matchers {
   test("serialize / deserialize mapped read") {
     val read = MappedRead(
       5, // token
-      Bases.stringToBases("TCGACCCTCGA"),
+      "TCGACCCTCGA",
       Array[Byte]((10 to 20).map(_.toByte): _*),
       true,
       "some sample name",
@@ -59,7 +60,7 @@ class MappedReadSerializerSuite extends TestUtil.SparkFunSuite with Matchers {
   test("serialize / deserialize mapped read with mdtag") {
     val read = MappedRead(
       5, // token
-      Bases.stringToBases("TCGACCCTCGA"),
+      "TCGACCCTCGA",
       Array[Byte]((10 to 20).map(_.toByte): _*),
       true,
       "some sample name",
@@ -109,7 +110,7 @@ class MappedReadSerializerSuite extends TestUtil.SparkFunSuite with Matchers {
   test("serialize / deserialize mapped read with unmapped pair") {
     val read = MappedRead(
       5, // token
-      Bases.stringToBases("TCGACCCTCGA"),
+      "TCGACCCTCGA",
       Array[Byte]((10 to 20).map(_.toByte): _*),
       true,
       "some sample name",

--- a/src/test/scala/org/bdgenomics/guacamole/reads/MappedReadSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/reads/MappedReadSuite.scala
@@ -1,7 +1,8 @@
 package org.bdgenomics.guacamole.reads
 
 import net.sf.samtools.TextCigarCodec
-import org.bdgenomics.guacamole.{ Bases, TestUtil }
+import org.bdgenomics.guacamole.TestUtil
+import org.bdgenomics.guacamole.TestUtil.Implicits._
 import org.scalatest.Matchers
 
 class MappedReadSuite extends TestUtil.SparkFunSuite with Matchers {
@@ -9,7 +10,7 @@ class MappedReadSuite extends TestUtil.SparkFunSuite with Matchers {
   test("mappedread is mapped") {
     val read = MappedRead(
       5, // token
-      Bases.stringToBases("TCGACCCTCGA"),
+      "TCGACCCTCGA",
       Array[Byte]((10 to 20).map(_.toByte): _*),
       true,
       "some sample name",
@@ -42,7 +43,7 @@ class MappedReadSuite extends TestUtil.SparkFunSuite with Matchers {
   test("mixed collections mapped and unmapped reads") {
     val uread = UnmappedRead(
       5, // token
-      Bases.stringToBases("TCGACCCTCGA"),
+      "TCGACCCTCGA",
       Array[Byte]((10 to 20).map(_.toByte): _*),
       true,
       "some sample name",
@@ -62,7 +63,7 @@ class MappedReadSuite extends TestUtil.SparkFunSuite with Matchers {
 
     val mread = MappedRead(
       5, // token
-      Bases.stringToBases("TCGACCCTCGA"),
+      "TCGACCCTCGA",
       Array[Byte]((10 to 20).map(_.toByte): _*),
       true,
       "some sample name",

--- a/src/test/scala/org/bdgenomics/guacamole/reads/UnmappedReadSerializerSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/reads/UnmappedReadSerializerSuite.scala
@@ -1,6 +1,7 @@
 package org.bdgenomics.guacamole.reads
 
-import org.bdgenomics.guacamole.{ Bases, TestUtil }
+import org.bdgenomics.guacamole.TestUtil
+import org.bdgenomics.guacamole.TestUtil.Implicits._
 import org.scalatest.Matchers
 
 class UnmappedReadSerializerSuite extends TestUtil.SparkFunSuite with Matchers {
@@ -8,7 +9,7 @@ class UnmappedReadSerializerSuite extends TestUtil.SparkFunSuite with Matchers {
   test("serialize / deserialize unmapped read") {
     val read = UnmappedRead(
       22, // token
-      Bases.stringToBases("TCGACCCTCGA"),
+      "TCGACCCTCGA",
       Array[Byte]((10 to 20).map(_.toByte): _*),
       true,
       "some sample name",

--- a/src/test/scala/org/bdgenomics/guacamole/reads/UnmappedReadSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/reads/UnmappedReadSuite.scala
@@ -1,6 +1,7 @@
 package org.bdgenomics.guacamole.reads
 
-import org.bdgenomics.guacamole.{ Bases, TestUtil }
+import org.bdgenomics.guacamole.TestUtil
+import org.bdgenomics.guacamole.TestUtil.Implicits._
 import org.scalatest.Matchers
 
 class UnmappedReadSuite extends TestUtil.SparkFunSuite with Matchers {
@@ -8,7 +9,7 @@ class UnmappedReadSuite extends TestUtil.SparkFunSuite with Matchers {
   test("unmappedread is not mapped") {
     val read = UnmappedRead(
       5, // token
-      Bases.stringToBases("TCGACCCTCGA"),
+      "TCGACCCTCGA",
       Array[Byte]((10 to 20).map(_.toByte): _*),
       true,
       "some sample name",


### PR DESCRIPTION
This seems like a clear cleanliness win in test code; more subjective in the src cases that I picked out. In a few places I left at least one direct Bases.stringToBases call in the wild because I didn't feel like switching it, but maybe having the option is worthwhile.

Aside: some of the `==` String comparisons make me nervous. foursquare had a `=?` strongly-typed-equality operator that used implicits that was used over `==` everywhere, I'll see about whether adding such a thing could be a win, e.g.:

```
final class Identity[A](val _value: A) extends AnyVal {
  def =?(other: A): Boolean = _value == other
  def !=?(other: A): Boolean = _value != other
}
object Identity {
  implicit def wrapIdentity[A](anything: A): Identity[A] = new Identity(anything)
  implicit def unwrapIdentity[A](id: Identity[A]): A = id._value
}
```
