### PR TITLE
refactor PileupElement, elementAtGreaterLocus

### DIFF
--- a/src/main/scala/org/bdgenomics/guacamole/pileup/Pileup.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/pileup/Pileup.scala
@@ -107,7 +107,7 @@ case class Pileup(locus: Long, elements: Seq[PileupElement]) {
       Pileup(newLocus, Seq.empty[PileupElement])
     } else {
       val reusableElements = elements.filter(element => element.read.overlapsLocus(newLocus))
-      val updatedElements = reusableElements.map(_.elementAtGreaterLocus(newLocus))
+      val updatedElements = reusableElements.map(_.advanceToLocus(newLocus))
       val newElements = newReads.map(PileupElement(_, newLocus))
       Pileup(newLocus, updatedElements ++ newElements)
     }

--- a/src/main/scala/org/bdgenomics/guacamole/pileup/PileupElement.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/pileup/PileupElement.scala
@@ -11,7 +11,8 @@ import scala.annotation.tailrec
  * @param read The read this [[PileupElement]] is coming from.
  * @param locus The reference locus.
  * @param readPosition The offset into the sequence of bases in the read that this element corresponds to.
- * @param remainingReadCigar A list of remaining parsed cigar elements of this read.
+ * @param cigarElementIdx The idx in [[read.cigarElements]] of the [[CigarElement]] corresponding to the current
+ *                        readPosition.
  * @param cigarElementLocus The reference START position of the cigar element.
  *                          If the element is an INSERTION this the PRECEDING reference base
  * @param indexWithinCigarElement The offset of this element within the current cigar element.
@@ -20,36 +21,65 @@ case class PileupElement(
     read: MappedRead,
     locus: Long,
     readPosition: Int,
-    remainingReadCigar: List[CigarElement],
+    cigarElementIdx: Int,
     cigarElementLocus: Long,
     indexWithinCigarElement: Int) {
 
   assume(locus >= read.start)
   assume(locus < read.end)
 
-  lazy val cigarElement = remainingReadCigar.head
-  lazy val nextCigarElement = remainingReadCigar.tail.headOption
+  lazy val cigarElement = read.cigarElements(cigarElementIdx)
+  lazy val nextCigarElement =
+    if (cigarElementIdx + 1 < read.cigarElements.size) {
+      Some(read.cigarElements(cigarElementIdx + 1))
+    } else {
+      None
+    }
 
-  /*
-   * True if this is the last base of the current cigar element.
-   */
-  def isFinalCigarBase: Boolean = indexWithinCigarElement == cigarElement.getLength - 1
+  lazy val cigarElementReadLength = CigarUtils.getReadLength(cigarElement)
+  lazy val cigarElementReferenceLength = CigarUtils.getReferenceLength(cigarElement)
+  lazy val cigarElementEndLocus = cigarElementLocus + cigarElementReferenceLength
 
   lazy val alignment: Alignment = {
+
+    /*
+     * True if this is the last base of the current cigar element.
+     */
+    def isFinalCigarBase: Boolean = indexWithinCigarElement == cigarElement.getLength - 1
     val cigarOperator = cigarElement.getOperator
     val nextBaseCigarElement = if (isFinalCigarBase) nextCigarElement else Some(cigarElement)
     val nextBaseCigarOperator = nextBaseCigarElement.map(_.getOperator)
+
+    def makeInsertion(cigarElem: CigarElement) =
+      Insertion(
+        read.sequence.slice(
+          readPosition,
+          readPosition + CigarUtils.getReadLength(cigarElem) + 1
+        ),
+        read.baseQualities.slice(
+          readPosition,
+          readPosition + CigarUtils.getReadLength(cigarElem) + 1
+        )
+      )
+
     (cigarOperator, nextBaseCigarOperator) match {
+
       // Since insertions by definition have no corresponding reference loci, there is a choice in whether we "attach"
       // them to the preceding or following locus. Here we attach them to the preceding base, since that seems to be the
       // conventional choice. That is, if we have a match followed by an insertion, the final base of the match will
       // get combined with the insertion into one Alignment, at the match's reference locus.
-      case (CigarOperator.M, Some(CigarOperator.I)) | (CigarOperator.EQ, Some(CigarOperator.I)) | (CigarOperator.I, _) =>
-        val startReadOffset: Int = readPosition
-        val endReadOffset: Int = readPosition + CigarUtils.getReadLength(nextBaseCigarElement.get) + 1
-        val bases = read.sequence.slice(startReadOffset, endReadOffset)
-        val qualities = read.baseQualities.slice(startReadOffset, endReadOffset)
-        Insertion(bases, qualities)
+      case (CigarOperator.M, Some(CigarOperator.I)) | (CigarOperator.EQ, Some(CigarOperator.I)) =>
+        makeInsertion(nextCigarElement.get)
+
+      // The exception to the above is insertion at the start of a contig, where there is no preceding reference base to
+      // anchor to; in this case, the spec calls for including the reference base immediately after the insertion (the
+      // first reference base of the contig).
+      case (CigarOperator.I, Some(_)) if cigarElementLocus == 0 =>
+        makeInsertion(cigarElement)
+
+      // In general, a PileupElement pointing at an Insertion cigar-element is an error.
+      case (CigarOperator.I, _) => throw new InvalidCigarElementException(this)
+
       case (CigarOperator.M, _) | (CigarOperator.EQ, _) | (CigarOperator.X, _) =>
         val base: Byte = read.sequence(readPosition)
         val quality = read.baseQualities(readPosition)
@@ -113,6 +143,40 @@ case class PileupElement(
   }
 
   /**
+   * Returns a new [[PileupElement]] of the same read, advanced by one [[CigarElement]].
+   */
+  def advanceToNextCigarElement: PileupElement = {
+    val readPositionOffset =
+      if (cigarElement.getOperator.consumesReadBases()) {
+        // If this [[CigarElement]] consumes read bases then [[readPosition]] will advance by the rest of this
+        // [[CigarElement]].
+        cigarElement.getLength - indexWithinCigarElement
+      } else {
+        // Otherwise, [[readPosition]] will stay the same.
+        0
+      }
+
+    PileupElement(
+      read,
+      locus + (cigarElementReferenceLength - indexWithinCigarElement),
+      readPosition + readPositionOffset,
+      cigarElementIdx + 1,
+      cigarElementLocus + cigarElementReferenceLength,
+      // Even if we are somewhere in the middle of the current cigar element, lock to the beginning of the next one.
+      indexWithinCigarElement = 0
+    )
+  }
+
+  /**
+   * Returns whether the current [[CigarElement]] of this [[MappedRead]] contains the given @referenceLocus.
+   *
+   * Can only return true if [[cigarElement]] actually consumes reference bases.
+   */
+  def currentCigarElementContainsLocus(referenceLocus: Long): Boolean = {
+    cigarElementLocus <= referenceLocus && referenceLocus < cigarElementEndLocus
+  }
+
+  /**
    * Returns a new [[PileupElement]] of the same read at a different locus.
    *
    * To enable an efficient implementation, newLocus must be greater than the current locus.
@@ -122,58 +186,33 @@ case class PileupElement(
    *
    * @return A new [[PileupElement]] at the given locus.
    */
-  def elementAtGreaterLocus(newLocus: Long): PileupElement = {
-    if (newLocus == locus) { return this }
-
-    assume(newLocus > locus, "Can't rewind to locus %d from %d. Pileups only advance.".format(newLocus, locus))
+  @tailrec
+  final def advanceToLocus(newLocus: Long): PileupElement = {
+    assume(newLocus >= locus, "Can't rewind to locus %d from %d. Pileups only advance.".format(newLocus, locus))
     assume(newLocus < read.end, "This read stops at position %d. Can't advance to %d".format(read.end, newLocus))
-
-    val currentCigarReadPosition = if (cigarElement.getOperator.consumesReadBases()) {
-      readPosition - indexWithinCigarElement
-    } else {
-      readPosition
-    }
-    // Iterate through the remaining cigar elements to find one overlapping the current position.
-    @tailrec
-    def getCurrentElement(remainingCigarElements: List[CigarElement],
-                          cigarReadPosition: Int,
-                          cigarReferencePosition: Long): PileupElement = {
-      if (remainingCigarElements.isEmpty) {
-        throw new RuntimeException(
-          "Couldn't find cigar element for locus %d, cigar string only extends to %d".format(newLocus, cigarReferencePosition))
-      }
-      val nextCigarElement = remainingCigarElements.head
-      val cigarOperator = nextCigarElement.getOperator
-      val cigarElementReadLength = CigarUtils.getReadLength(nextCigarElement)
-      val cigarElementReferenceLength = CigarUtils.getReferenceLength(nextCigarElement)
-      // The 'P' (padding) operator is used to indicate a deletion-in-an-insertion. This only comes up when the
-      // aligner attempted not only to align reads to the reference, but also to align inserted sequences within reads
-      // to each other. In particular, a de novo assembler would automatically be doing this.
-      // We ignore this operator, since our simple Alignment handling code does not expose within-insertion alignments.
-      // See: http://davetang.org/wiki/tiki-index.php?page=SAM
-      if (cigarOperator != CigarOperator.P) {
-        val currentElementEnd = cigarReferencePosition + cigarElementReferenceLength
-        if (currentElementEnd > newLocus) {
-          val offset = (newLocus - cigarReferencePosition).toInt
-          val finalReadPos = if (cigarOperator.consumesReadBases) cigarReadPosition + offset else cigarReadPosition
-          return PileupElement(
-            read,
-            newLocus,
-            finalReadPos,
-            remainingCigarElements,
-            cigarReferencePosition,
-            offset
-          )
+    if (currentCigarElementContainsLocus(newLocus)) {
+      // Aside: the current cigar element must consume reference bases if we've gotten here.
+      val readPositionOffset =
+        if (cigarElement.getOperator.consumesReadBases()) {
+          (newLocus - cigarElementLocus - indexWithinCigarElement).toInt
+        } else {
+          // If this cigar doesn't consume read bases, then advancing within it will not consume [[readPosition]]
+          0
         }
-      }
-      getCurrentElement(
-        remainingCigarElements.tail,
-        cigarReadPosition + cigarElementReadLength,
-        cigarReferencePosition + cigarElementReferenceLength
-      )
-    }
 
-    getCurrentElement(remainingReadCigar, currentCigarReadPosition, cigarElementLocus)
+      this.copy(
+        locus = newLocus,
+        readPosition = readPosition + readPositionOffset,
+        indexWithinCigarElement = (newLocus - cigarElementLocus).toInt
+      )
+    } else if (newLocus == 0 && cigarElement.getOperator == CigarOperator.I) {
+      // NOTE(ryan): this is the rare case where we allow a [[PileupElement]] to exist at a non-reference-consuming
+      // CigarElement (namely, an Insertion at the start of a contig). It is correct for us to emit an Insertion
+      // alignment in such a case, where typically an Insertion [[CigarElement]] would get skipped over by subsequent
+      // [[advanceToLocus]] calls, since it represents a zero-width interval of reference bases.
+      this
+    } else
+      advanceToNextCigarElement.advanceToLocus(newLocus)
   }
 
   /**
@@ -190,16 +229,23 @@ object PileupElement {
    * Create a new [[PileupElement]] backed by the given read at the specified locus. The read must overlap the locus.
    */
   def apply(read: MappedRead, locus: Long): PileupElement = {
-    assume(locus >= read.start)
-    assume(locus < read.end)
-    val startElement = PileupElement(
+    PileupElement(
       read = read,
       locus = read.start,
       readPosition = 0,
-      remainingReadCigar = read.cigarElements.toList,
+      cigarElementIdx = 0,
       cigarElementLocus = read.start,
       indexWithinCigarElement = 0
-    )
-    startElement.elementAtGreaterLocus(locus)
+    ).advanceToLocus(locus)
   }
 }
+
+case class InvalidCigarElementException(elem: PileupElement)
+  extends Exception(
+    "Should not have a PileupElement at non-reference-consuming cigar-operator I. " +
+      "Locus: %d, readPosition: %d, cigar: %s (elem idx %d)".format(
+        elem.locus,
+        elem.readPosition,
+        elem.read.cigar.toString, elem.cigarElementIdx
+      )
+  )

--- a/src/test/scala/org/bdgenomics/guacamole/pileup/PileupSuite.scala
+++ b/src/test/scala/org/bdgenomics/guacamole/pileup/PileupSuite.scala
@@ -18,6 +18,7 @@
 
 package org.bdgenomics.guacamole.pileup
 
+import net.sf.samtools.{ CigarOperator, CigarElement }
 import org.bdgenomics.guacamole.{ Bases, TestUtil }
 import org.bdgenomics.guacamole.TestUtil.assertBases
 import org.bdgenomics.guacamole.TestUtil.Implicits._
@@ -137,11 +138,11 @@ class PileupSuite extends TestUtil.SparkFunSuite with Matchers with TableDrivenP
     firstElement.isMatch should be(true)
     firstElement.indexWithinCigarElement should be(0L)
 
-    val secondElement = firstElement.elementAtGreaterLocus(1L)
+    val secondElement = firstElement.advanceToLocus(1L)
     secondElement.isMatch should be(true)
     secondElement.indexWithinCigarElement should be(1L)
 
-    val thirdElement = secondElement.elementAtGreaterLocus(2L)
+    val thirdElement = secondElement.advanceToLocus(2L)
     thirdElement.isMatch should be(true)
     thirdElement.indexWithinCigarElement should be(2L)
 
@@ -160,6 +161,25 @@ class PileupSuite extends TestUtil.SparkFunSuite with Matchers with TableDrivenP
 
   }
 
+  test("insertion at contig start includes trailing base") {
+    val contigStartInsertionRead = TestUtil.makeRead("AAAAAACGT", "5I4M", "4", 0, "chr1")
+    val pileup = PileupElement(contigStartInsertionRead, 0)
+    pileup.alignment should equal(Insertion("AAAAAA", List(31, 31, 31, 31, 31, 31)))
+  }
+
+  test("pileup alignment at insertion cigar-element throws") {
+    val contigStartInsertionRead = TestUtil.makeRead("AAAAAACGT", "5I4M", "4", 0, "chr1")
+    val pileup = PileupElement(
+      read = contigStartInsertionRead,
+      locus = 1,
+      readPosition = 0,
+      cigarElementIdx = 0,
+      cigarElementLocus = 1,
+      indexWithinCigarElement = 0
+    )
+    the[InvalidCigarElementException] thrownBy pileup.alignment
+  }
+
   sparkTest("test pileup element creation with deletion cigar elements") {
     val read = TestUtil.makeRead("AATTGAATTG", "5M1D5M", "5^C5", 0, "chr1")
     val firstElement = PileupElement(read, 0)
@@ -167,19 +187,19 @@ class PileupSuite extends TestUtil.SparkFunSuite with Matchers with TableDrivenP
     firstElement.isMatch should be(true)
     firstElement.indexWithinCigarElement should be(0L)
 
-    val matchElement = firstElement.elementAtGreaterLocus(4L)
+    val matchElement = firstElement.advanceToLocus(4L)
     matchElement.isMatch should be(true)
     matchElement.indexWithinCigarElement should be(4L)
 
-    val deletionElement = matchElement.elementAtGreaterLocus(5L)
+    val deletionElement = matchElement.advanceToLocus(5L)
     deletionElement.isDeletion should be(true)
     deletionElement.indexWithinCigarElement should be(0L)
 
-    val pastDeletionElement = matchElement.elementAtGreaterLocus(6L)
+    val pastDeletionElement = matchElement.advanceToLocus(6L)
     pastDeletionElement.isMatch should be(true)
     pastDeletionElement.indexWithinCigarElement should be(0L)
 
-    val continuePastDeletionElement = pastDeletionElement.elementAtGreaterLocus(9L)
+    val continuePastDeletionElement = pastDeletionElement.advanceToLocus(9L)
     continuePastDeletionElement.isMatch should be(true)
     continuePastDeletionElement.indexWithinCigarElement should be(3L)
 
@@ -242,23 +262,23 @@ class PileupSuite extends TestUtil.SparkFunSuite with Matchers with TableDrivenP
     val read2At20 = PileupElement(read2Record, 20)
     assertBases(read2At20.sequencedBases: String, "A")
 
-    // elementAtGreaterLocus is a no-op on the same locus, 
+    // advanceToLocus is a no-op on the same locus,
     // and fails in lower loci
     forAll(Table("locus", List(5, 33, 34, 43, 44, 74): _*)) { locus =>
       val elt = PileupElement(decadentRead1, locus)
-      assert(elt.elementAtGreaterLocus(locus) === elt)
-      intercept[AssertionError] { elt.elementAtGreaterLocus(locus - 1) }
-      intercept[AssertionError] { elt.elementAtGreaterLocus(75) }
+      assert(elt.advanceToLocus(locus) === elt)
+      intercept[AssertionError] { elt.advanceToLocus(locus - 1) }
+      intercept[AssertionError] { elt.advanceToLocus(75) }
     }
 
     val read3Record = testAdamRecords(2) // read3
     val read3At15 = PileupElement(read3Record, 15)
     assert(read3At15 != null)
     assertBases(read3At15.sequencedBases, "A")
-    assertBases(read3At15.elementAtGreaterLocus(16).sequencedBases, "T")
-    assertBases(read3At15.elementAtGreaterLocus(17).sequencedBases, "C")
-    assertBases(read3At15.elementAtGreaterLocus(16).elementAtGreaterLocus(17).sequencedBases, "C")
-    assertBases(read3At15.elementAtGreaterLocus(18).sequencedBases, "G")
+    assertBases(read3At15.advanceToLocus(16).sequencedBases, "T")
+    assertBases(read3At15.advanceToLocus(17).sequencedBases, "C")
+    assertBases(read3At15.advanceToLocus(16).advanceToLocus(17).sequencedBases, "C")
+    assertBases(read3At15.advanceToLocus(18).sequencedBases, "G")
   }
 
   sparkTest("Read4 has CIGAR: 10M10I10D40M; ACGT repeated 15 times") {
@@ -268,13 +288,13 @@ class PileupSuite extends TestUtil.SparkFunSuite with Matchers with TableDrivenP
     val read4At20 = PileupElement(decadentRead4, 20)
     assert(read4At20 != null)
     for (i <- 0 until 2) {
-      assert(read4At20.elementAtGreaterLocus(20 + i * 4 + 0).sequencedBases(0) == 'A')
-      assert(read4At20.elementAtGreaterLocus(20 + i * 4 + 1).sequencedBases(0) == 'C')
-      assert(read4At20.elementAtGreaterLocus(20 + i * 4 + 2).sequencedBases(0) == 'G')
-      assert(read4At20.elementAtGreaterLocus(20 + i * 4 + 3).sequencedBases(0) == 'T')
+      assert(read4At20.advanceToLocus(20 + i * 4 + 0).sequencedBases(0) == 'A')
+      assert(read4At20.advanceToLocus(20 + i * 4 + 1).sequencedBases(0) == 'C')
+      assert(read4At20.advanceToLocus(20 + i * 4 + 2).sequencedBases(0) == 'G')
+      assert(read4At20.advanceToLocus(20 + i * 4 + 3).sequencedBases(0) == 'T')
     }
 
-    val read4At30 = read4At20.elementAtGreaterLocus(20 + 9)
+    val read4At30 = read4At20.advanceToLocus(20 + 9)
     read4At30.isInsertion should be(true)
     (read4At30.sequencedBases: String) should equal("CGTACGTACGT")
   }
@@ -286,14 +306,14 @@ class PileupSuite extends TestUtil.SparkFunSuite with Matchers with TableDrivenP
     val decadentRead5 = testAdamRecords(4)
     val read5At10 = PileupElement(decadentRead5, 10)
     assert(read5At10 != null)
-    assertBases(read5At10.elementAtGreaterLocus(10).sequencedBases, "A")
-    assertBases(read5At10.elementAtGreaterLocus(14).sequencedBases, "A")
-    assertBases(read5At10.elementAtGreaterLocus(18).sequencedBases, "A")
-    assertBases(read5At10.elementAtGreaterLocus(19).sequencedBases, "C")
-    assertBases(read5At10.elementAtGreaterLocus(20).sequencedBases, "G")
-    assertBases(read5At10.elementAtGreaterLocus(21).sequencedBases, "T")
-    assertBases(read5At10.elementAtGreaterLocus(22).sequencedBases, "A")
-    assertBases(read5At10.elementAtGreaterLocus(24).sequencedBases, "G")
+    assertBases(read5At10.advanceToLocus(10).sequencedBases, "A")
+    assertBases(read5At10.advanceToLocus(14).sequencedBases, "A")
+    assertBases(read5At10.advanceToLocus(18).sequencedBases, "A")
+    assertBases(read5At10.advanceToLocus(19).sequencedBases, "C")
+    assertBases(read5At10.advanceToLocus(20).sequencedBases, "G")
+    assertBases(read5At10.advanceToLocus(21).sequencedBases, "T")
+    assertBases(read5At10.advanceToLocus(22).sequencedBases, "A")
+    assertBases(read5At10.advanceToLocus(24).sequencedBases, "G")
   }
 
   sparkTest("read6: ACGTACGTACGT 4=1N4=4S") {
@@ -302,15 +322,15 @@ class PileupSuite extends TestUtil.SparkFunSuite with Matchers with TableDrivenP
     val decadentRead6 = testAdamRecords(5)
     val read6At40 = PileupElement(decadentRead6, 40)
     assert(read6At40 != null)
-    assertBases(read6At40.elementAtGreaterLocus(40).sequencedBases, "A")
-    assertBases(read6At40.elementAtGreaterLocus(41).sequencedBases, "C")
-    assertBases(read6At40.elementAtGreaterLocus(42).sequencedBases, "G")
-    assertBases(read6At40.elementAtGreaterLocus(43).sequencedBases, "T")
-    assertBases(read6At40.elementAtGreaterLocus(44).sequencedBases, "")
-    assertBases(read6At40.elementAtGreaterLocus(45).sequencedBases, "A")
-    assertBases(read6At40.elementAtGreaterLocus(48).sequencedBases, "T")
+    assertBases(read6At40.advanceToLocus(40).sequencedBases, "A")
+    assertBases(read6At40.advanceToLocus(41).sequencedBases, "C")
+    assertBases(read6At40.advanceToLocus(42).sequencedBases, "G")
+    assertBases(read6At40.advanceToLocus(43).sequencedBases, "T")
+    assertBases(read6At40.advanceToLocus(44).sequencedBases, "")
+    assertBases(read6At40.advanceToLocus(45).sequencedBases, "A")
+    assertBases(read6At40.advanceToLocus(48).sequencedBases, "T")
     intercept[AssertionError] {
-      read6At40.elementAtGreaterLocus(49).sequencedBases
+      read6At40.advanceToLocus(49).sequencedBases
     }
   }
 
@@ -318,15 +338,15 @@ class PileupSuite extends TestUtil.SparkFunSuite with Matchers with TableDrivenP
     val decadentRead7 = testAdamRecords(6)
     val read7At40 = PileupElement(decadentRead7, 40)
     assert(read7At40 != null)
-    assertBases(read7At40.elementAtGreaterLocus(40).sequencedBases, "A")
-    assertBases(read7At40.elementAtGreaterLocus(41).sequencedBases, "C")
-    assertBases(read7At40.elementAtGreaterLocus(42).sequencedBases, "G")
-    assertBases(read7At40.elementAtGreaterLocus(43).sequencedBases, "T")
-    assertBases(read7At40.elementAtGreaterLocus(44).sequencedBases, "")
-    assertBases(read7At40.elementAtGreaterLocus(45).sequencedBases, "A")
-    assertBases(read7At40.elementAtGreaterLocus(48).sequencedBases, "T")
+    assertBases(read7At40.advanceToLocus(40).sequencedBases, "A")
+    assertBases(read7At40.advanceToLocus(41).sequencedBases, "C")
+    assertBases(read7At40.advanceToLocus(42).sequencedBases, "G")
+    assertBases(read7At40.advanceToLocus(43).sequencedBases, "T")
+    assertBases(read7At40.advanceToLocus(44).sequencedBases, "")
+    assertBases(read7At40.advanceToLocus(45).sequencedBases, "A")
+    assertBases(read7At40.advanceToLocus(48).sequencedBases, "T")
     intercept[AssertionError] {
-      read7At40.elementAtGreaterLocus(49).sequencedBases
+      read7At40.advanceToLocus(49).sequencedBases
     }
   }
 
@@ -339,16 +359,16 @@ class PileupSuite extends TestUtil.SparkFunSuite with Matchers with TableDrivenP
     val decadentRead8 = testAdamRecords(7)
     val read8At40 = PileupElement(decadentRead8, 40)
     assert(read8At40 != null)
-    assertBases(read8At40.elementAtGreaterLocus(40).sequencedBases, "A")
-    assertBases(read8At40.elementAtGreaterLocus(41).sequencedBases, "C")
-    assertBases(read8At40.elementAtGreaterLocus(42).sequencedBases, "G")
-    assertBases(read8At40.elementAtGreaterLocus(43).sequencedBases, "T")
-    assertBases(read8At40.elementAtGreaterLocus(44).sequencedBases, "A")
-    assertBases(read8At40.elementAtGreaterLocus(45).sequencedBases, "C")
-    assertBases(read8At40.elementAtGreaterLocus(46).sequencedBases, "G")
-    assertBases(read8At40.elementAtGreaterLocus(47).sequencedBases, "T")
+    assertBases(read8At40.advanceToLocus(40).sequencedBases, "A")
+    assertBases(read8At40.advanceToLocus(41).sequencedBases, "C")
+    assertBases(read8At40.advanceToLocus(42).sequencedBases, "G")
+    assertBases(read8At40.advanceToLocus(43).sequencedBases, "T")
+    assertBases(read8At40.advanceToLocus(44).sequencedBases, "A")
+    assertBases(read8At40.advanceToLocus(45).sequencedBases, "C")
+    assertBases(read8At40.advanceToLocus(46).sequencedBases, "G")
+    assertBases(read8At40.advanceToLocus(47).sequencedBases, "T")
     intercept[RuntimeException] {
-      read8At40.elementAtGreaterLocus(48).sequencedBases
+      read8At40.advanceToLocus(48).sequencedBases
     }
   }
 


### PR DESCRIPTION
- elementAtGreaterLocus was mimicking the vals in PileupElement;
  cleaner to advance through loci by making new PileupElements
  at each CigarElement
- keep all CigarElements around in PileupElement; track current 
  idx into that array
  - used especially in indel code downstream
- correctly handle insertions at the start of a contig (include
  trailing reference base)
- correctly handle insertions at the start of a read (skip them;
  they don't count for reference locus that lands at the first
  read-base after them)
