### PR TITLE
Move removing nearby or correlated snps to second pass

### DIFF
--- a/src/main/scala/org/bdgenomics/guacamole/callers/SomaticLogOddsVariantCaller.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/callers/SomaticLogOddsVariantCaller.scala
@@ -3,20 +3,15 @@ package org.bdgenomics.guacamole.callers
 import org.apache.spark.Logging
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.cli.Args4j
-import org.bdgenomics.adam.util.PhredUtils
-import org.bdgenomics.formats.avro.{ Contig, Genotype, GenotypeAllele, Variant }
 import org.bdgenomics.guacamole.Common.Arguments.{ Output, TumorNormalReads }
 import org.bdgenomics.guacamole._
-import org.bdgenomics.guacamole.concordance.GenotypesEvaluator.GenotypeConcordance
 import org.bdgenomics.guacamole.filters.PileupFilter.PileupFilterArguments
-import org.bdgenomics.guacamole.filters.{ SomaticGenotypeFilter, GenotypeFilter, PileupFilter }
 import org.bdgenomics.guacamole.filters.SomaticGenotypeFilter.SomaticGenotypeFilterArguments
+import org.bdgenomics.guacamole.filters._
 import org.bdgenomics.guacamole.pileup.Pileup
 import org.bdgenomics.guacamole.reads.Read
-import org.bdgenomics.guacamole.variants._
+import org.bdgenomics.guacamole.variants.{ CalledSomaticGenotype, GenotypeConversions, GenotypeEvidence }
 import org.kohsuke.args4j.{ Option => Opt }
-
-import scala.collection.JavaConversions
 
 /**
  * Simple subtraction based somatic variant caller
@@ -32,24 +27,13 @@ object SomaticLogOddsVariantCaller extends Command with Serializable with Loggin
   override val name = "logodds-somatic"
   override val description = "call somatic variants using a two independent caller on tumor and normal"
 
-  private class Arguments
-      extends DistributedUtil.Arguments
-      with Output
-      with GenotypeConcordance
-      with SomaticGenotypeFilterArguments
-      with PileupFilterArguments
-      with TumorNormalReads {
-    @Opt(name = "-log-odds", metaVar = "X", usage = "Make a call if the probability of variant is greater than this value (Phred-scaled)")
-    var logOdds: Int = 35
+  private class Arguments extends DistributedUtil.Arguments with Output with SomaticGenotypeFilterArguments with PileupFilterArguments with TumorNormalReads {
 
     @Opt(name = "-snvWindowRange", usage = "Number of bases before and after to check for additional matches or deletions")
     var snvWindowRange: Int = 20
 
-    @Opt(name = "-snvCorrelationPercent", usage = "Maximum % of reads that can have additional mismatches or deletions")
-    var snvCorrelationPercent: Int = 35
-
-    @Opt(name = "-maxNormalAlternateReadDepth", usage = "Maximum number of alternate base reads the normal sample can have")
-    var maxNormalAlternateReadDepth: Int = 3
+    @Opt(name = "-odds", usage = "Minimum log odds threshold for possible variant candidates")
+    var oddsThreshold: Int = 20
 
   }
 
@@ -65,64 +49,96 @@ object SomaticLogOddsVariantCaller extends Command with Serializable with Loggin
       "Tumor and normal samples have different sequence dictionaries. Tumor dictionary: %s.\nNormal dictionary: %s."
         .format(tumorReads.sequenceDictionary, normalReads.sequenceDictionary))
 
-    val minTumorAlternateReadDepth = args.minTumorAlternateReadDepth
-
     val snvWindowRange = args.snvWindowRange
-    val snvCorrelationPercent = args.snvCorrelationPercent
-
-    val maxNormalAlternateReadDepth = args.maxNormalAlternateReadDepth
-    val minNormalReadDepth = args.minNormalReadDepth
-
-    val logOddsThreshold = args.logOdds
 
     val maxMappingComplexity = args.maxMappingComplexity
     val minAlignmentForComplexity = args.minAlignmentForComplexity
 
     val filterMultiAllelic = args.filterMultiAllelic
     val minAlignmentQuality = args.minAlignmentQuality
+    val maxReadDepth = args.maxTumorReadDepth
+
+    val oddsThreshold = args.oddsThreshold
 
     val loci = Common.loci(args, normalReads)
-    val lociPartitions = DistributedUtil.partitionLociAccordingToArgs(args, loci, tumorReads.mappedReads, normalReads.mappedReads)
+    val lociPartitions = DistributedUtil.partitionLociAccordingToArgs(
+      args,
+      loci,
+      tumorReads.mappedReads,
+      normalReads.mappedReads
+    )
 
-    val genotypes: RDD[CalledSomaticGenotype] = DistributedUtil.pileupFlatMapTwoRDDs[CalledSomaticGenotype](
+    var potentialGenotypes: RDD[CalledSomaticGenotype] = DistributedUtil.pileupFlatMapTwoRDDs[CalledSomaticGenotype](
       tumorReads.mappedReads,
       normalReads.mappedReads,
       lociPartitions,
-      true, // skip empty pileups
-      (pileupTumor, pileupNormal) => callSomaticVariantsAtLocus(
+      skipEmpty = true, // skip empty pileups
+      (pileupTumor, pileupNormal) => findPotentialVariantAtLocus(
         pileupTumor,
         pileupNormal,
-        logOddsThreshold,
-        snvWindowRange,
-        snvCorrelationPercent,
-        minNormalReadDepth,
-        maxNormalAlternateReadDepth,
-        minTumorAlternateReadDepth,
+        oddsThreshold,
         maxMappingComplexity,
         minAlignmentForComplexity,
         minAlignmentQuality,
-        filterMultiAllelic).iterator)
+        filterMultiAllelic,
+        maxReadDepth).iterator)
 
+    // Filter potential genotypes to min read values
+    potentialGenotypes = SomaticReadDepthFilter(potentialGenotypes, args.minTumorReadDepth, args.maxTumorReadDepth, args.minNormalReadDepth)
+    potentialGenotypes = SomaticAlternateReadDepthFilter(potentialGenotypes, args.minTumorAlternateReadDepth)
+
+    potentialGenotypes.persist()
+    Common.progress("Computed %,d potential genotypes".format(potentialGenotypes.count))
+
+    val genotypeLociPartitions = DistributedUtil.partitionLociUniformly(args.parallelism, loci)
+    val genotypes: RDD[CalledSomaticGenotype] = DistributedUtil.windowFlatMapWithState[CalledSomaticGenotype, CalledSomaticGenotype, Option[String]](
+      Seq(potentialGenotypes),
+      genotypeLociPartitions,
+      skipEmpty = true,
+      snvWindowRange.toLong,
+      None,
+      removeCorrelatedGenotypes)
     genotypes.persist()
+    Common.progress("Computed %,d genotypes after regional analysis".format(genotypes.count))
+
     val filteredGenotypes: RDD[CalledSomaticGenotype] = SomaticGenotypeFilter(genotypes, args)
-    Common.progress("Computed %,d genotypes".format(filteredGenotypes.count))
+    Common.progress("Computed %,d genotypes after basic filtering".format(filteredGenotypes.count))
 
     Common.writeVariantsFromArguments(args, filteredGenotypes.flatMap(GenotypeConversions.calledSomaticGenotypeToADAMGenotype(_)))
+
     DelayedMessages.default.print()
   }
 
-  def callSomaticVariantsAtLocus(tumorPileup: Pileup,
-                                 normalPileup: Pileup,
-                                 logOddsThreshold: Int,
-                                 snvWindowRange: Int = 25,
-                                 snvCorrelationPercent: Int = 20,
-                                 minNormalReadDepth: Int = 5,
-                                 maxNormalAlternateReadDepth: Int = 5,
-                                 minAlternateReadDepth: Int = 2,
-                                 maxMappingComplexity: Int = 100,
-                                 minAlignmentForComplexity: Int = 1,
-                                 minAlignmentQuality: Int = 1,
-                                 filterMultiAllelic: Boolean = false): Seq[CalledSomaticGenotype] = {
+  /**
+   * Remove genotypes if there are others in a nearby window
+   *
+   * @param state Unused
+   * @param genotypeWindows Collection of potential genotypes in the window
+   * @return Set of genotypes if there are no others in the window
+   */
+  def removeCorrelatedGenotypes(state: Option[String],
+                                genotypeWindows: Seq[SlidingWindow[CalledSomaticGenotype]]): (Option[String], Iterator[CalledSomaticGenotype]) = {
+    val genotypeWindow = genotypeWindows(0)
+    val locus = genotypeWindow.currentLocus
+    val currentGenotypes = genotypeWindow.currentRegions.filter(_.overlapsLocus(locus))
+
+    assert(currentGenotypes.length <= 1, "There cannot be more than one called genotype at the given locus")
+
+    if (currentGenotypes.size == genotypeWindow.currentRegions().size) {
+      (None, currentGenotypes.iterator)
+    } else {
+      (None, Iterator.empty)
+    }
+  }
+
+  def findPotentialVariantAtLocus(tumorPileup: Pileup,
+                                  normalPileup: Pileup,
+                                  oddsThreshold: Int,
+                                  maxMappingComplexity: Int = 100,
+                                  minAlignmentForComplexity: Int = 1,
+                                  minAlignmentQuality: Int = 1,
+                                  filterMultiAllelic: Boolean = false,
+                                  maxReadDepth: Int = Int.MaxValue): Seq[CalledSomaticGenotype] = {
 
     val filteredNormalPileup = PileupFilter(normalPileup,
       filterMultiAllelic,
@@ -142,46 +158,39 @@ object SomaticLogOddsVariantCaller extends Command with Serializable with Loggin
     // For now, we skip loci that have no reads mapped. We may instead want to emit NoCall in this case.
     if (filteredTumorPileup.elements.isEmpty
       || filteredNormalPileup.elements.isEmpty
-      || filteredNormalPileup.depth < minNormalReadDepth)
+      || filteredTumorPileup.referenceDepth == filteredTumorPileup.depth // skip computation if no alternate bases
+      || filteredTumorPileup.depth > maxReadDepth // skip  abnormally deep pileups
+      || filteredNormalPileup.depth > maxReadDepth)
       return Seq.empty
 
-    val referenceBase = normalPileup.referenceBase
     val tumorSampleName = tumorPileup.elements(0).read.sampleName
+    val referenceBase = tumorPileup.referenceBase
 
-    val (alternateBase, tumorVariantLikelihood): (Option[Seq[Byte]], Double) = callVariantInTumor(referenceBase, filteredTumorPileup)
+    val (alternateBase, tumorVariantLikelihood) = callVariantInTumor(referenceBase, filteredTumorPileup)
     alternateBase match {
-
-      case Some(alternate) => {
-
+      case Some(alternate) if alternate.nonEmpty => {
         val tumorEvidence = GenotypeEvidence(tumorVariantLikelihood, alternate, filteredTumorPileup)
 
         val normalLikelihoods =
           BayesianQualityVariantCaller.computeLikelihoods(filteredNormalPileup,
             includeAlignmentLikelihood = false,
-            normalize = true)
+            normalize = true).toMap
 
         val (normalVariantGenotypes, normalReferenceGenotype) = normalLikelihoods.partition(_._1.isVariant)
 
         val normalEvidence = GenotypeEvidence(normalVariantGenotypes.map(_._2).sum, alternate, filteredNormalPileup)
+        val somaticOdds = tumorVariantLikelihood / normalVariantGenotypes.map(_._2).sum
 
-        val somaticLogOdds = math.log(tumorVariantLikelihood) - math.log(normalVariantGenotypes.map(_._2).sum)
-        val normalReferenceLikelihood = normalReferenceGenotype.map(_._2).sum
-
-        val somaticVariantProbability = tumorVariantLikelihood * normalReferenceLikelihood
-        val phredScaledSomaticLikelihood = PhredUtils.successProbabilityToPhred(somaticVariantProbability - 1e-10)
-
-        if (somaticLogOdds.isInfinite || phredScaledSomaticLikelihood >= logOddsThreshold) {
+        if (somaticOdds * 100 >= oddsThreshold) {
           Seq(
-            CalledSomaticGenotype(
-              tumorSampleName,
-              normalPileup.referenceName,
-              normalPileup.locus,
+            CalledSomaticGenotype(tumorSampleName,
+              tumorPileup.referenceName,
+              tumorPileup.locus,
               referenceBase,
               alternate,
-              somaticLogOdds,
-              tumorEvidence = tumorEvidence,
-              normalEvidence = normalEvidence
-            )
+              math.log(somaticOdds),
+              tumorEvidence,
+              normalEvidence)
           )
         } else {
           Seq.empty
@@ -201,15 +210,10 @@ object SomaticLogOddsVariantCaller extends Command with Serializable with Loggin
    */
   def callVariantInTumor(referenceBase: Byte,
                          tumorPileup: Pileup): (Option[Seq[Byte]], Double) = {
-    def normalPrior(gt: GenotypeAlleles, hetVariantPrior: Double = 1e-4): Double = {
-      val numberVariants = gt.numberOfVariants
-      if (numberVariants > 0) math.pow(hetVariantPrior / gt.uniqueAllelesCount, numberVariants) else 1
-    }
 
     val tumorLikelihoods = BayesianQualityVariantCaller.computeLikelihoods(tumorPileup,
       includeAlignmentLikelihood = true,
-      normalize = true,
-      prior = normalPrior(_)).toMap
+      normalize = true).toMap
 
     val tumorMostLikelyGenotype = tumorLikelihoods.maxBy(_._2)
 
@@ -221,21 +225,4 @@ object SomaticLogOddsVariantCaller extends Command with Serializable with Loggin
     }
 
   }
-
-  /**
-   *
-   * Find the number of reads and number of forwards reads that support a given base in a pileup
-   *
-   * @param pileup pileup of reads at a certain locus
-   * @param base base to search for in that pileup
-   * @return Number of reads that support the given base and number of reads in the forward direction that support it
-   */
-  def computeDepthAndForwardDepth(pileup: Pileup, base: Seq[Byte]): (Int, Int) = {
-    val baseElements = pileup.elements.view.filter(el => el.sequencedBases == base)
-    val readDepth = baseElements.length
-    val baseForwardReadDepth = baseElements.count(_.read.isPositiveStrand)
-    (readDepth, baseForwardReadDepth)
-  }
-
 }
-

--- a/src/main/scala/org/bdgenomics/guacamole/filters/GenotypeFilter.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/filters/GenotypeFilter.scala
@@ -7,7 +7,7 @@ import org.bdgenomics.guacamole.variants.{ CalledGenotype, GenotypeEvidence }
 import org.kohsuke.args4j.Option
 
 /**
- * Filter to remove genotypes where the number of reads at the locus is low
+ * Filter to remove genotypes where the likelihood is low
  */
 object MinimumLikelihoodFilter {
 
@@ -21,7 +21,7 @@ object MinimumLikelihoodFilter {
    *  Apply the filter to an RDD of genotypes
    *
    * @param genotypes RDD of genotypes to filter
-   * @param minLikelihood minimum quality score for this genotype
+   * @param minLikelihood minimum quality score for this genotype (Phred-scaled)
    * @param debug if true, compute the count of genotypes after filtering
    * @return Genotypes with quality >= minLikelihood
    */

--- a/src/main/scala/org/bdgenomics/guacamole/variants/CalledGenotype.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/variants/CalledGenotype.scala
@@ -6,7 +6,6 @@ import org.bdgenomics.formats.avro.{ Genotype, GenotypeAllele }
 
 import scala.collection.JavaConversions
 
-
 /**
  *
  * A variant that exists in the sample; includes supporting read statistics

--- a/src/main/scala/org/bdgenomics/guacamole/variants/CalledSomaticGenotype.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/variants/CalledSomaticGenotype.scala
@@ -1,7 +1,9 @@
 package org.bdgenomics.guacamole.variants
 
-import com.esotericsoftware.kryo.io.{Input, Output}
-import com.esotericsoftware.kryo.{Kryo, Serializer}
+import com.esotericsoftware.kryo.io.{ Input, Output }
+import com.esotericsoftware.kryo.{ Kryo, Serializer }
+import org.bdgenomics.adam.util.PhredUtils
+import org.bdgenomics.guacamole.Bases
 
 /**
  *
@@ -27,6 +29,10 @@ case class CalledSomaticGenotype(sampleName: String,
                                  normalEvidence: GenotypeEvidence,
                                  length: Int = 1) extends ReferenceVariant {
   val end: Long = start + 1L
+
+  // P ( variant in tumor AND no variant in normal) = P(variant in tumor) * ( 1 - P(variant in normal) )
+  lazy val phredScaledSomaticLikelihood =
+    PhredUtils.successProbabilityToPhred(tumorEvidence.likelihood * (1 - normalEvidence.likelihood) - 1e-10)
 }
 
 class CalledSomaticGenotypeSerializer extends Serializer[CalledSomaticGenotype] {

--- a/src/main/scala/org/bdgenomics/guacamole/variants/GenotypeConversions.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/variants/GenotypeConversions.scala
@@ -1,6 +1,6 @@
 package org.bdgenomics.guacamole.variants
 
-import org.bdgenomics.formats.avro.{GenotypeAllele, Genotype}
+import org.bdgenomics.formats.avro.{ GenotypeAllele, Genotype }
 
 import scala.collection.JavaConversions
 
@@ -22,7 +22,7 @@ object GenotypeConversions {
     Seq(Genotype.newBuilder
       .setAlleles(JavaConversions.seqAsJavaList(Seq(GenotypeAllele.Ref, GenotypeAllele.Alt)))
       .setSampleId(calledGenotype.sampleName.toCharArray)
-      .setGenotypeQuality(calledGenotype.tumorEvidence.phredScaledLikelihood)
+      .setGenotypeQuality(calledGenotype.phredScaledSomaticLikelihood)
       .setReadDepth(calledGenotype.tumorEvidence.readDepth)
       .setExpectedAlleleDosage(calledGenotype.tumorEvidence.alternateReadDepth.toFloat / calledGenotype.tumorEvidence.readDepth)
       .setAlternateReadDepth(calledGenotype.tumorEvidence.alternateReadDepth)


### PR DESCRIPTION
Final piece of #147 pulled out  - includes #163 but will rebase once that is merged in 
- Removed check for correlated (nearby) SNVs from caller - moved this to a second pass over genotypes in some window
- Adding average mapping quality filter
- Adding average base quality filter
