### PR TITLE
Drop spark args and setting spark properties through code

### DIFF
--- a/scripts/guacamole-spark-defaults.conf
+++ b/scripts/guacamole-spark-defaults.conf
@@ -1,0 +1,4 @@
+spark.serializer               org.apache.spark.serializer.KryoSerializer
+spark.kryo.registrator         org.bdgenomics.guacamole.GuacamoleKryoRegistrator
+spark.kryoserializer.buffer.mb 4
+spark.kryo.referenceTracking   true

--- a/src/main/scala/org/bdgenomics/guacamole/callers/BayesianQualityVariantCaller.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/callers/BayesianQualityVariantCaller.scala
@@ -35,7 +35,7 @@ object BayesianQualityVariantCaller extends Command with Serializable with Loggi
 
   override def run(rawArgs: Array[String]): Unit = {
     val args = Args4j[Arguments](rawArgs)
-    val sc = Common.createSparkContext(args, appName = Some(name))
+    val sc = Common.createSparkContext(appName = Some(name))
 
     val readSet = Common.loadReadsFromArguments(args, sc, Read.InputFilters(mapped = true, nonDuplicate = true))
     readSet.mappedReads.persist()

--- a/src/main/scala/org/bdgenomics/guacamole/callers/SomaticLogOddsVariantCaller.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/callers/SomaticLogOddsVariantCaller.scala
@@ -58,7 +58,7 @@ object SomaticLogOddsVariantCaller extends Command with Serializable with Loggin
   override def run(rawArgs: Array[String]): Unit = {
 
     val args = Args4j[Arguments](rawArgs)
-    val sc = Common.createSparkContext(args, appName = Some(name))
+    val sc = Common.createSparkContext(appName = Some(name))
 
     val filters = Read.InputFilters(mapped = true, nonDuplicate = true, passedVendorQualityChecks = true)
     val (tumorReads, normalReads) = Common.loadTumorNormalReadsFromArguments(args, sc, filters)

--- a/src/main/scala/org/bdgenomics/guacamole/callers/SomaticThresholdVariantCaller.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/callers/SomaticThresholdVariantCaller.scala
@@ -55,7 +55,7 @@ object SomaticThresholdVariantCaller extends Command with Serializable with Logg
 
   override def run(rawArgs: Array[String]): Unit = {
     val args = Args4j[Arguments](rawArgs)
-    val sc = Common.createSparkContext(args, appName = Some(name))
+    val sc = Common.createSparkContext(appName = Some(name))
 
     val filters = Read.InputFilters(mapped = true, nonDuplicate = true)
     val (tumorReads, normalReads) = Common.loadTumorNormalReadsFromArguments(args, sc, filters)

--- a/src/main/scala/org/bdgenomics/guacamole/callers/ThresholdVariantCaller.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/callers/ThresholdVariantCaller.scala
@@ -56,7 +56,7 @@ object ThresholdVariantCaller extends Command with Serializable with Logging {
 
   override def run(rawArgs: Array[String]): Unit = {
     val args = Args4j[Arguments](rawArgs)
-    val sc = Common.createSparkContext(args, appName = Some(name))
+    val sc = Common.createSparkContext(appName = Some(name))
 
     val readSet = Common.loadReadsFromArguments(args, sc, Read.InputFilters(mapped = true, nonDuplicate = true))
 

--- a/src/main/scala/org/bdgenomics/guacamole/concordance/GenotypesEvaluator.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/concordance/GenotypesEvaluator.scala
@@ -37,7 +37,7 @@ object GenotypesEvaluator extends Command with Logging {
 
   override def run(rawArgs: Array[String]): Unit = {
     val args = Args4j[Arguments](rawArgs)
-    val sc = Common.createSparkContext(args, appName = Some(name))
+    val sc = Common.createSparkContext(appName = Some(name))
 
     val calledGenotypes = Common.loadGenotypes(args.testGenotypesFile, sc)
     printGenotypeConcordance(args, calledGenotypes, sc)

--- a/src/main/scala/org/bdgenomics/guacamole/somatic/SimpleSomaticVariantCaller.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/somatic/SimpleSomaticVariantCaller.scala
@@ -358,7 +358,7 @@ object SimpleSomaticVariantCaller extends Command {
 
   override def run(rawArgs: Array[String]): Unit = {
     val args = Args4j[Arguments](rawArgs)
-    val context: SparkContext = Common.createSparkContext(args)
+    val context: SparkContext = Common.createSparkContext(appName = Some(name))
     val genotypes: RDD[Genotype] = callVariantsFromArgs(context, args)
     Common.progress("Found %d variants".format(genotypes.count))
     Common.writeVariantsFromArguments(args, genotypes)


### PR DESCRIPTION
This is similar to https://github.com/bigdatagenomics/adam/pull/374  Also drop SparkArgs since that will be removed from ADAM

Basically when we are using spark-submit, we want to use that to set spark-master and spark-jar properties, without need to respecify them in the app.  Doing so can lead to an issue like I had earlier: http://mail-archives.apache.org/mod_mbox/spark-user/201408.mbox

For now all the Kryo properties are defaulted, but those can also be specified through a config file.
