### PR TITLE
Change task depth count to use countbyvalue

### DIFF
--- a/src/main/scala/org/bdgenomics/guacamole/DistributedUtil.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/DistributedUtil.scala
@@ -151,10 +151,9 @@ object DistributedUtil extends Logging {
     val regionCounts = regionRDDs.map(regions => {
       progress("Collecting region counts for RDD %d of %d.".format(num, regionRDDs.length))
       num += 1
-      val microPartitionCounts = regions
-        .flatMap(region => broadcastMicroPartitions.value.onContig(region.referenceContig).getAll(region.start, region.end))
-        .countByValue()
-      microPartitionCounts
+      regions.flatMap(region =>
+        broadcastMicroPartitions.value.onContig(region.referenceContig).getAll(region.start, region.end)
+      ).countByValue()
     })
 
     val counts: Seq[Long] = (0 until numMicroPartitions).map(i => regionCounts.map(_.getOrElse(i, 0L)).sum)


### PR DESCRIPTION
This generally works better when the parallelism flag value is fairly high (> 10k) while the older method would take 3-4 min on the same datasets
