### PR TITLE
Delaying coalesce of variants

### DIFF
--- a/src/main/scala/org/bdgenomics/guacamole/Common.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/Common.scala
@@ -237,7 +237,7 @@ object Common extends Logging {
     } else if (outputPath.toLowerCase.endsWith(".vcf")) {
       progress("Writing genotypes to VCF file: %s.".format(outputPath))
       val sc = subsetGenotypes.sparkContext
-      sc.adamVCFSave(outputPath, subsetGenotypes.toVariantContext.coalesce(1))
+      sc.adamVCFSave(outputPath, subsetGenotypes.toVariantContext.coalesce(1, shuffle = true))
     } else {
       progress("Writing genotypes to: %s.".format(outputPath))
       subsetGenotypes.adamSave(outputPath,


### PR DESCRIPTION
This speeds up VCF output by performing some of the conversion operations in parallel before the coalesce
