### PR TITLE
get reference as seq bytes from mdtag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,13 @@
           <id>central</id>
           <url>http://repo1.maven.org/maven2</url>
       </repository>
+      <repository>
+          <snapshots>
+              <enabled>false</enabled>
+          </snapshots>
+          <id>spire</id>
+          <url>http://dl.bintray.com/non/maven</url>
+      </repository>
   </repositories>
 
   <dependencies>
@@ -269,6 +276,11 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>18.0</version>
+    </dependency>
+    <dependency>
+        <groupId>org.spire-math</groupId>
+        <artifactId>debox_${scala.version.prefix}</artifactId>
+        <version>0.6.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/scala/org/bdgenomics/guacamole/pileup/PileupElement.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/pileup/PileupElement.scala
@@ -59,7 +59,8 @@ case class PileupElement(
   lazy val referenceStringIdx =
     (cigarElementLocus - read.start).toInt +
       (if (cigarElement.getOperator.consumesReferenceBases()) indexWithinCigarElement else 0)
-  lazy val referenceBase = read.referenceString.charAt(referenceStringIdx).toUpper.toByte
+
+  lazy val referenceBase = read.referenceBases(referenceStringIdx)
 
   lazy val cigarElementReadLength = CigarUtils.getReadLength(cigarElement)
   lazy val cigarElementReferenceLength = CigarUtils.getReferenceLength(cigarElement)
@@ -77,11 +78,11 @@ case class PileupElement(
 
     def makeInsertion(cigarElem: CigarElement) =
       Insertion(
-        read.sequence.slice(
+        read.sequence.view(
           readPosition,
           readPosition + CigarUtils.getReadLength(cigarElem) + 1
         ),
-        read.baseQualities.slice(
+        read.baseQualities.view(
           readPosition,
           readPosition + CigarUtils.getReadLength(cigarElem) + 1
         )
@@ -106,7 +107,7 @@ case class PileupElement(
       case (CigarOperator.I, _) => throw new InvalidCigarElementException(this)
 
       case (CigarOperator.M | CigarOperator.EQ | CigarOperator.X, Some(CigarOperator.D)) =>
-        val deletedBases = read.referenceString.substring(
+        val deletedBases = read.referenceBases.view(
           referenceStringIdx,
           referenceStringIdx + 1 + nextCigarElement.get.getLength
         )

--- a/src/main/scala/org/bdgenomics/guacamole/reads/MDTagUtils.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/reads/MDTagUtils.scala
@@ -1,0 +1,73 @@
+package org.bdgenomics.guacamole.reads
+
+import htsjdk.samtools.{ CigarOperator, Cigar }
+import org.bdgenomics.adam.util.MdTag
+
+import scala.collection.JavaConversions
+import debox.Buffer
+
+object MDTagUtils {
+
+  /**
+   * Adopted from ADAM's mdTag.getReference to operate on Seq[Byte] instead of strings
+   * Also we use a Buffer from spire here instead to avoid an additional array allocation and ensure
+   * we return an Array[Byte]
+   *
+   * Given a mdtag, read sequence, cigar, and a reference start position, returns the reference.
+   *
+   * @param readSequence The base sequence of the read.
+   * @param cigar The cigar for the read.
+   * @param referenceFrom The starting point of this read alignment vs. the reference.
+   * @return A sequence of bytes corresponding to the reference overlapping this read.
+   */
+  def getReference(mdTag: MdTag, readSequence: Seq[Byte], cigar: Cigar, referenceFrom: Long): Seq[Byte] = {
+
+    var referencePos = mdTag.start
+    var readPos = 0
+    var reference: Buffer[Byte] = Buffer.empty
+
+    // loop over all cigar elements
+    JavaConversions.asScalaBuffer(cigar.getCigarElements).foreach(cigarElement => {
+      cigarElement.getOperator match {
+        case CigarOperator.M | CigarOperator.EQ | CigarOperator.X => {
+          // if we are a match, loop over bases in element
+          for (i <- 0 until cigarElement.getLength) {
+            // if a mismatch, get from the mismatch set, else pull from read
+            mdTag.mismatches.get(referencePos) match {
+              case Some(base) => reference += base.toByte
+              case _          => reference += readSequence(readPos).toByte
+            }
+
+            readPos += 1
+            referencePos += 1
+          }
+        }
+        case CigarOperator.D => {
+          // if a delete, get from the delete pool
+          for (i <- 0 until cigarElement.getLength) {
+            reference += {
+              mdTag.deletions.get(referencePos) match {
+                case Some(base) => base.toByte
+                case _          => throw new IllegalStateException("Could not find deleted base at cigar offset " + i)
+              }
+            }
+
+            referencePos += 1
+          }
+        }
+        case _ => {
+          // ignore inserts
+          if (cigarElement.getOperator.consumesReadBases) {
+            readPos += cigarElement.getLength
+          }
+          if (cigarElement.getOperator.consumesReferenceBases) {
+            throw new IllegalArgumentException("Cannot handle operator: " + cigarElement.getOperator)
+          }
+        }
+      }
+    })
+
+    reference.elems
+  }
+
+}

--- a/src/main/scala/org/bdgenomics/guacamole/reads/MappedRead.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/reads/MappedRead.scala
@@ -54,14 +54,12 @@ case class MappedRead(
 
   lazy val mdTag = MdTag(mdTagString, start)
 
-  lazy val referenceString =
+  lazy val referenceBases =
     try {
-      mdTag.getReference(sequenceStr, cigar, start)
+      MDTagUtils.getReference(mdTag, sequence, cigar, start)
     } catch {
       case e: IllegalStateException => throw new CigarMDTagMismatchException(cigar, mdTag, e)
     }
-
-  lazy val referenceBases = Bases.stringToBases(referenceString)
 
   lazy val alignmentLikelihood = PhredUtils.phredToSuccessProbability(alignmentQuality)
 

--- a/src/main/scala/org/bdgenomics/guacamole/reads/Read.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/reads/Read.scala
@@ -19,17 +19,16 @@
 package org.bdgenomics.guacamole.reads
 
 import htsjdk.samtools._
-import org.apache.spark.{ Logging, SparkContext }
-import org.apache.spark.rdd.RDD
-import org.apache.hadoop.io.LongWritable
-import org.seqdoop.hadoop_bam.{ AnySAMInputFormat, SAMRecordWritable }
-import org.seqdoop.hadoop_bam.util.SAMHeaderReader
-import scala.collection.mutable.ArrayBuffer
-import org.bdgenomics.adam.models.SequenceDictionary
-import org.bdgenomics.guacamole.Bases
-
 import org.apache.hadoop.fs.Path
+import org.apache.hadoop.io.LongWritable
+import org.apache.spark.rdd.RDD
+import org.apache.spark.{ Logging, SparkContext }
+import org.bdgenomics.adam.models.SequenceDictionary
+import org.seqdoop.hadoop_bam.util.SAMHeaderReader
+import org.seqdoop.hadoop_bam.{ AnySAMInputFormat, SAMRecordWritable }
+
 import scala.collection.JavaConversions
+import scala.collection.mutable.ArrayBuffer
 
 /**
  * The fields in the Read trait are common to any read, whether mapped (aligned) or not.
@@ -50,7 +49,6 @@ trait Read {
 
   /** The nucleotide sequence. */
   val sequence: Seq[Byte]
-  lazy val sequenceStr = Bases.basesToString(sequence)
 
   /** The base qualities, phred scaled.  These are numbers, and are NOT character encoded. */
   val baseQualities: Seq[Byte]


### PR DESCRIPTION
Current to get the reference base at some position in the read we need  to
- Convert the sequence to a string
- Parse the mdTag to get the reference bases as a string
- Convert the reference bases to a Seq[Byte]

This also meant we kept the string representations of the reference and sequence when they were not needed.  This bypasses that and create a Seq[Byte] reference directly from a Seq[Byte] sequence.

The spire dependency is to build an Array that wille be an Array[byte] as opposed to Array[java.lang.Byte] which is what you get when using scala.mutable.ArrayBuffer and is much larger.
