### PR TITLE
Bump java version dependency in pom 1.7 -> 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <properties>
     <adam.version>0.14.0</adam.version>
     <bdg-formats.version>0.2.0</bdg-formats.version>
-    <java.version>1.7.4</java.version>
+    <java.version>1.8</java.version>
     <scala.version>2.10.3</scala.version>
     <scala.version.prefix>2.10</scala.version.prefix>
     <hadoop.version>2.3.0</hadoop.version>


### PR DESCRIPTION
Although Guacamole builds with either java 7 or java 8, the resulting jar file is too large (or has too many files) to run with java 7.

It seems odd to require java 8 to run but java 7 to build, so this commit changes our pom to specify java 8. It avoids specifying an exactly version, but instead just specifies 1.8. I've seen some examples of this in other project's pom.xml files but am not completely sure it is right.
