### PR TITLE
Upgrade args4j and add forbids argument to loci args 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
     <dependency>
       <groupId>args4j</groupId>
       <artifactId>args4j</artifactId>
-      <version>[2.0.23,)</version>
+      <version>[2.0.29,)</version>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.adam</groupId>

--- a/src/main/scala/org/bdgenomics/guacamole/Common.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/Common.scala
@@ -24,7 +24,7 @@ import java.util.Calendar
 
 import org.apache.avro.generic.GenericDatumWriter
 import org.apache.avro.io.EncoderFactory
-import org.apache.commons.io.{ IOUtils, FileUtils }
+import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{ FileSystem, Path }
 import org.apache.spark.rdd.RDD
@@ -52,10 +52,10 @@ object Common extends Logging {
 
     /** Argument for accepting a set of loci. */
     trait Loci extends Base {
-      @Opt(name = "-loci", usage = "Loci at which to call variants. Either 'all' or contig:start-end,contig:start-end,...")
+      @Opt(name = "-loci", usage = "Loci at which to call variants. Either 'all' or contig:start-end,contig:start-end,...", forbids = Array("-loci-from-file"))
       var loci: String = ""
 
-      @Opt(name = "-loci-from-file", usage = "Path to file giving loci at which to call variants.")
+      @Opt(name = "-loci-from-file", usage = "Path to file giving loci at which to call variants.", forbids = Array("-loci"))
       var lociFromFile: String = ""
     }
 


### PR DESCRIPTION
This was added in args4j 2.0.28 and will prevent users from specifying both loci and a loci-file.

It will give the following error

```
Exception in thread "main" java.lang.IllegalArgumentException: Specify at most one of the 'loci' and 'loci-from-file' arguments
```
