### PR TITLE
Removing bdgformats dependecy to use adam version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,6 @@
   
   <properties>
     <adam.version>0.14.0</adam.version>
-    <bdg-formats.version>0.2.0</bdg-formats.version>
     <java.version>1.8</java.version>
     <scala.version>2.10.3</scala.version>
     <scala.version.prefix>2.10</scala.version.prefix>
@@ -235,11 +234,6 @@
       <groupId>org.bdgenomics.adam</groupId>
       <artifactId>adam-cli</artifactId>
       <version>${adam.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.bdgenomics.bdg-formats</groupId>
-      <artifactId>bdg-formats</artifactId>
-      <version>${bdg-formats.version}</version>
     </dependency>
     <dependency>
       <groupId>colt</groupId>


### PR DESCRIPTION
I want to remove the explicit dependency on this. I can't think of a reason that this shouldn't match the transitive depdency ADAM brings and being able to set them to different versions can create errors

Example I ran into, when bdg-formats was set to 0.3.2 and ADAM was 14.1-SNAPSHOT (which just upgraded from 0.3.2 to 0.4.0

```
java.lang.NoSuchMethodError: org.bdgenomics.formats.avro.Contig.getContigName()Ljava/lang/String;
        at org.bdgenomics.adam.models.ReferencePosition$.apply(ReferencePosition.scala:213)
        at org.bdgenomics.adam.models.VariantContext.<init>(VariantContext.scala:90)
```
