### PR TITLE
Shade and relocate guava dependency to avoid conflicts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,15 @@
               <exclude>org.apache.maven:lib:tests</exclude>
             </excludes>
           </artifactSet>
+          <relocations>
+            <relocation>
+              <pattern>com.google.common</pattern>
+              <shadedPattern>org.bdgenomics.guavarelocated</shadedPattern>
+                <includes>
+                  <include>com.google.common.collect.**</include>
+                </includes>
+            </relocation>
+          </relocations>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
In Spark 1.2 guava is not a transitive depenency (had originally used 14.1).  When running on the cluster this creates classpath conflicts with hadoop jars that use guava-11.0.2.

This commit moves the guava classes to an internal package guaranteeing our code uses the newer version
