### PR TITLE
Add cluster profile to move Hadoop/Spark dependencies to provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -356,5 +356,23 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>cluster</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-client</artifactId>
+          <version>${hadoop.version}</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-core_${scala.version.prefix}</artifactId>
+          <version>${spark.version}</version>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
This add a maven profile so that building with `-Pcluster` will not include Hadoop and Spark in the jar, since these will be available on the cluster anyways.  This reduces the jar size from 114MB to 75MB
