### PR TITLE
add warning around opening suspicious ADAM files

### DIFF
--- a/src/main/scala/org/bdgenomics/guacamole/reads/Read.scala
+++ b/src/main/scala/org/bdgenomics/guacamole/reads/Read.scala
@@ -302,6 +302,9 @@ object Read extends Logging {
     var (reads, sequenceDictionary) = if (filename.endsWith(".bam") || filename.endsWith(".sam")) {
       loadReadRDDAndSequenceDictionaryFromBAM(filename, sc, token)
     } else {
+      if (!filename.endsWith(".adam") && !filename.endsWith(".adam.gz")) {
+        logWarning(s"Attempting to open $filename as an ADAM file despite not having '.adam' extension")
+      }
       loadReadRDDAndSequenceDictionaryFromADAM(filename, sc, token)
     }
     if (filters.mapped) reads = reads.filter(_.isMapped)


### PR DESCRIPTION
I just got bit by trying to open a path that was a directory (I meant to pass a BAM); failure mode was not the most clear:

```
Exception in thread "Driver" java.io.IOException: Could not read footer: java.lang.RuntimeException: hdfs://demeter-nn1.demeter.hpc.mssm.edu:8020/user/willir31/data/set3/normal/set3.normal.fq/part-01487 is not a Parquet file. expected magic number at tail [80, 65, 82, 49] but found [67, 68, 67, 10]
    at parquet.hadoop.ParquetFileReader.readAllFootersInParallel(ParquetFileReader.java:238)
    at parquet.hadoop.ParquetFileReader.readAllFootersInParallelUsingSummaryFiles(ParquetFileReader.java:179)
    at parquet.hadoop.ParquetInputFormat.getFooters(ParquetInputFormat.java:389)
    at parquet.hadoop.ParquetInputFormat.getFooters(ParquetInputFormat.java:361)
    at parquet.hadoop.ParquetInputFormat.getSplits(ParquetInputFormat.java:245)
```

Something like this maybe makes sense; what file extensions are common for ADAM files?
