### PR TITLE
Set release dependencies in maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <parent>
+    <groupId>org.sonatype.oss</groupId>
+    <artifactId>oss-parent</artifactId>
+    <version>7</version>
+    <relativePath />
+  </parent>
+
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.hammerlab.guacamole</groupId>
   <artifactId>guacamole</artifactId>
-  <version>0.0.1</version>
+  <version>0.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>guacamole: variant caller</name>
 
@@ -18,12 +25,13 @@
     <spark.version>1.1.0</spark.version>
     <scoverage-plugin.version>0.99.11</scoverage-plugin.version>
     <maven.plugin.scoverage.version>0.99.10</maven.plugin.scoverage.version>
+    <maven.release.plugin.version>2.4.1</maven.release.plugin.version>
   </properties>
 
   <licenses>
     <license>
       <name>Apache License</name>
-      <url>https://raw.github.com/hammerlab/adam/master/LICENSE.txt</url>
+      <url>https://raw.github.com/hammerlab/guacamole/master/LICENSE</url>
       <distribution>repo</distribution>
     </license>
   </licenses>
@@ -41,15 +49,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <version>2.1</version>
         <configuration>
@@ -62,7 +61,8 @@
             </transformer>
             <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
           </transformers>
-          <finalName>guacamole-${project.version}</finalName>
+          <shadedArtifactAttached>true</shadedArtifactAttached>
+          <finalName>guacamole-with-dependencies-${project.version}</finalName>
           <filters>
             <filter>
               <artifact>*:*</artifact>
@@ -86,9 +86,9 @@
             <relocation>
               <pattern>com.google.common</pattern>
               <shadedPattern>org.bdgenomics.guavarelocated</shadedPattern>
-                <includes>
-                  <include>com.google.common.collect.**</include>
-                </includes>
+              <includes>
+                <include>com.google.common.collect.**</include>
+              </includes>
             </relocation>
           </relocations>
         </configuration>
@@ -110,6 +110,7 @@
             <id>scala-compile-first</id>
             <phase>process-resources</phase>
             <goals>
+              <goal>add-source</goal>
               <goal>compile</goal>
             </goals>
             <configuration>
@@ -208,8 +209,38 @@
         <artifactId>maven-scoverage-plugin</artifactId>
         <version>${maven.plugin.scoverage.version}</version>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>${maven.release.plugin.version}</version>
+        <configuration>
+          <branchName>branch-@{project.version}</branchName>
+          <goals>deploy</goals>
+          <tagNameFormat>guacamole-@{project.version}</tagNameFormat>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-provider-gitexe</artifactId>
+            <version>1.8.1</version>
+          </dependency>
+        </dependencies>
+      </plugin>
     </plugins>
+
   </build>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>sonatype-nexus-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </snapshotRepository>
+    <repository>
+      <id>sonatype-nexus-staging</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
   <repositories>
     <repository>
       <id>sonatype-nexus-snapshots</id>
@@ -373,6 +404,41 @@
           <scope>provided</scope>
         </dependency>
       </dependencies>
+    </profile>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>2.1.2</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>

--- a/release/README.md
+++ b/release/README.md
@@ -1,0 +1,24 @@
+
+## Releasing through Maven
+
+```sh
+mvn release:prepare release:perform
+```
+
+If you are simply interested in the testing the commands above without actually performing the updates add the `-DdryRun=true` flag.
+
+## Rolling back a release
+
+If there are any issues during the release, the release can be rolled-back with the following command:
+
+```sh
+mvn release:rollback
+```
+
+## Cleaning up a release
+
+To remove any temporary files created during the release process run the following command:
+
+```sh
+mvn release:clean
+```


### PR DESCRIPTION
This commit:
- Updates the version to a -SNAPSHOT and updates it from 0.0.1 to 0.1.0
- Add `distributionMangement` to place where the uploaded jars go
- Updates the license to the correct path
- Add the release plugin
- Add the ability to sign a jar and create a -sources jar

This also changes the build process to create 2 artifacts, both a shaded jar and just the guacamole jar.  Both recreated before, but now the non-shaded guacamole jar has the name guacamole- while the other is renamed guacamole-with-dependencies

There some documentation on how to release, but needs and added piece of signing the jar.

Closes #262 and #260 

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/269)

<!-- Reviewable:end -->
