### PR TITLE
Add javadoc to release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -425,6 +425,19 @@
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.9.1</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>1.5</version>
             <executions>


### PR DESCRIPTION
For the last release the javadoc jar was not signed by the gpg plugin.  This PR is adding it to the release profile to ensure that happens

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/274)

<!-- Reviewable:end -->
