### PR TITLE
Fixing check of standard bases

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/Bases.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Bases.scala
@@ -59,13 +59,13 @@ object Bases {
   }
 
   /** Are all the given bases standard? */
-  def allStandardBases(bases: Seq[Byte]) = {
-    assert(bases.forall(b => isStandardBase(b)), "Invalid base array: %s".format(bases.map(_.toChar).mkString))
+  def allStandardBases(bases: Seq[Byte]): Boolean = {
+    bases.forall(b => isStandardBase(b))
   }
 
   /** Throw an error if any of the given bases are not standard. */
   def assertAllStandardBases(bases: Seq[Byte]) = {
-    assert(bases.forall(b => isStandardBase(b)), "Invalid base array: %s".format(bases.map(_.toChar).mkString))
+    assert(allStandardBases(bases), "Invalid base array: %s".format(bases.map(_.toChar).mkString))
   }
 
   /** Convert a string (e.g. "AAAGGC") to a byte array. */


### PR DESCRIPTION
These functions are duplicated.  believe the first, `allStandardBases`, should return a boolean and the second should throw an error on non-standard bases

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/277)
<!-- Reviewable:end -->
