### PR TITLE
Fix scripts/guacamole to run correct jar

### DIFF
--- a/scripts/guacamole
+++ b/scripts/guacamole
@@ -6,7 +6,7 @@
 echo "$@" >> ~/.guacamole.invocations.log
 
 if [ -z "${GUACAMOLE_JAR}" ]; then
-    jar=$(ls -tc target/guacamole-?.*.jar | head -n 1)
+    jar=$(ls -tc target/guacamole-with-dependencies-*.jar | head -n 1)
     if [ -z "$jar" ]; then
         echo "Couldn't find a Guacamole jar in the target/ directory."
         echo "Are you in the root directory of the Guacamole repo, and have you built Guacamole?"


### PR DESCRIPTION
Invoke target/guacamole-with-dependencies-*-.jar, not target/guacamole-*.jar.

Otherwise, we were seeing errors when running scripts/guacamole.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/282)
<!-- Reviewable:end -->
