### PR TITLE
Speedup LociSet union

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/LociSet.scala
+++ b/src/main/scala/org/hammerlab/guacamole/LociSet.scala
@@ -150,7 +150,11 @@ object LociSet {
 
   /** Returns union of specified [[LociSet]] instances. */
   def union(lociSets: LociSet*): LociSet = {
-    lociSets.reduce(_.union(_))
+    val result = LociSet.newBuilder
+    lociSets.foreach(lociSet => {
+      result.put(lociSet)
+    })
+    result.result
   }
 
   /**

--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineStandardCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineStandardCaller.scala
@@ -54,7 +54,6 @@ object GermlineStandard {
       Common.progress(
         "Loaded %,d mapped non-duplicate reads into %,d partitions.".format(readSet.mappedReads.count, readSet.mappedReads.partitions.length))
 
-
       val loci = Common.loci(args, readSet)
       val lociPartitions = DistributedUtil.partitionLociAccordingToArgs(args, loci, readSet.mappedReads)
 

--- a/src/test/scala/org/hammerlab/guacamole/HasReferenceRegionSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/HasReferenceRegionSuite.scala
@@ -1,7 +1,6 @@
 package org.hammerlab.guacamole
 
-import org.scalatest.{Matchers, FunSuite}
-
+import org.scalatest.{ Matchers, FunSuite }
 
 class HasReferenceRegionSuite extends FunSuite with Matchers {
 


### PR DESCRIPTION
This change gives a better LociSet union implementation when unioning many sets.

Since `LociSet.parse` uses `union`, this speeds up parsing of large LociSets.

Also two unrelated minor formatting fixes suggested by my IDE.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/286)
<!-- Reviewable:end -->
