### PR TITLE
Variant support/read evidence module

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/Guacamole.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Guacamole.scala
@@ -18,11 +18,12 @@
 
 package org.hammerlab.guacamole
 
-import org.apache.spark.Logging
 import java.util.logging.Level
-import org.hammerlab.guacamole.commands._
+
+import org.apache.spark.Logging
 import org.bdgenomics.adam.util.ParquetLogger
 import org.hammerlab.guacamole.Common.progress
+import org.hammerlab.guacamole.commands._
 
 /**
  * Guacamole main class.
@@ -36,7 +37,8 @@ object Guacamole extends Logging {
   private val commands: Seq[Command[_]] = List(
     GermlineThreshold.Caller,
     GermlineStandard.Caller,
-    SomaticStandard.Caller
+    SomaticStandard.Caller,
+    ReadEvidence.Caller
   )
 
   private def printUsage() = {

--- a/src/main/scala/org/hammerlab/guacamole/ReadSet.scala
+++ b/src/main/scala/org/hammerlab/guacamole/ReadSet.scala
@@ -72,14 +72,17 @@ object ReadSet {
    *
    * @param sc spark context
    * @param filename bam or sam file to read from
+   * @param requireMDTagsOnMappedReads*
    * @param filters input filters to filter reads while reading.
    * @param token token field for the reads
    * @param contigLengthsFromDictionary see [[ReadSet]] doc for description
+   *
    * @return
    */
   def apply(
     sc: SparkContext,
     filename: String,
+    requireMDTagsOnMappedReads: Boolean,
     filters: Read.InputFilters = Read.InputFilters.empty,
     token: Int = 0,
     contigLengthsFromDictionary: Boolean = true): ReadSet = {
@@ -89,7 +92,8 @@ object ReadSet {
         filename,
         sc,
         token = token,
-        filters = filters
+        filters = filters,
+        requireMDTagsOnMappedReads
       )
 
     new ReadSet(reads, Some(sequenceDictionary), filename, filters, token, contigLengthsFromDictionary)

--- a/src/main/scala/org/hammerlab/guacamole/commands/ReadEvidence.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/ReadEvidence.scala
@@ -1,0 +1,105 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hammerlab.guacamole.commands
+
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.rdd.variation.VariationContext
+import org.bdgenomics.formats.avro.Variant
+import org.hammerlab.guacamole._
+import org.hammerlab.guacamole.pileup.Pileup
+import org.hammerlab.guacamole.reads.MappedRead
+import org.hammerlab.guacamole.reads.Read.InputFilters
+import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
+
+object ReadEvidence {
+
+  protected class Arguments extends DistributedUtil.Arguments {
+    @Args4jOption(name = "--input-variant", required = true, aliases = Array("-v"),
+      usage = "")
+    var variants: String = ""
+
+    @Args4jOption(name = "--output", metaVar = "OUT", required = true, aliases = Array("-o"),
+      usage = "Output path for CSV")
+    var output: String = ""
+
+    @Argument(required = true, multiValued = true,
+      usage = "Retrieve read data from BAMs at each variant position")
+    var bams: Array[String] = Array.empty
+
+  }
+
+  object Caller extends SparkCommand[Arguments] {
+
+    override val name = "variant-support"
+    override val description = "Find number of reads that support each variant across BAMs"
+
+    case class AlleleCount(sample: String, contig: String, locus: Long, reference: String, alternate: String, count: Int) {
+      override def toString: String = {
+        s"$sample, $contig, $locus, $reference, $alternate, $count"
+      }
+    }
+
+    override def run(args: Arguments, sc: SparkContext): Unit = {
+
+      val adamContext = new VariationContext(sc)
+      val variants: RDD[Variant] = adamContext.adamVCFLoad(args.variants).map(_.variant)
+      val reads: Seq[RDD[MappedRead]] = args.bams.zipWithIndex.map(
+        bamFile =>
+          ReadSet(
+            sc,
+            bamFile._1,
+            requireMDTagsOnMappedReads = false,
+            InputFilters.empty,
+            token = bamFile._2,
+            contigLengthsFromDictionary = false).mappedReads
+      )
+
+      val lociSet = LociSet.parse(
+        variants.map(
+          variant => s"${variant.getContig.getContigName}:${variant.getStart}-${variant.getEnd}")
+          .collect().mkString(","))
+
+      val lociPartitions = DistributedUtil.partitionLociUniformly(args.parallelism, lociSet)
+
+      val alleleCounts =
+        reads.map(sampleReads =>
+          DistributedUtil.pileupFlatMap[AlleleCount](
+            sampleReads,
+            lociPartitions,
+            true,
+            pileupToAlleleCounts
+          )
+        ).reduce(_ ++ _)
+
+      alleleCounts.saveAsTextFile(args.output)
+
+    }
+
+    def pileupToAlleleCounts(pileup: Pileup): Iterator[AlleleCount] = {
+      val alleles = pileup.elements.groupBy(_.allele)
+      alleles.map(kv => AlleleCount(pileup.sampleName,
+        pileup.referenceName,
+        pileup.locus,
+        Bases.basesToString(kv._1.refBases),
+        Bases.basesToString(kv._1.altBases),
+        kv._2.size)).iterator
+    }
+  }
+}

--- a/src/main/scala/org/hammerlab/guacamole/commands/ReadEvidence.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/ReadEvidence.scala
@@ -73,10 +73,10 @@ object ReadEvidence {
       )
 
       // Build a loci set from the variant positions
-      val lociSet = LociSet.parse(
+      val lociSet = LociSet.union(
         variants.map(
-          variant => s"${variant.getContig.getContigName}:${variant.getStart}-${variant.getEnd}")
-          .collect().mkString(","))
+          variant => LociSet(variant.getContig.getContigName, variant.getStart, variant.getEnd))
+          .collect():_*)
 
       val lociPartitions = DistributedUtil.partitionLociUniformly(args.parallelism, lociSet)
 

--- a/src/test/scala/org/hammerlab/guacamole/LociSetSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/LociSetSuite.scala
@@ -20,6 +20,7 @@ package org.hammerlab.guacamole
 
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.FileUtil
+import org.apache.spark.rdd.RDD
 import org.hammerlab.guacamole.reads.Read
 import org.scalatest.Matchers
 
@@ -108,7 +109,8 @@ class LociSetSuite extends TestUtil.SparkFunSuite with Matchers {
 
   sparkTest("loci argument parsing in Common") {
     val read = TestUtil.makeRead("C", "1M", "1", 500, "20")
-    val emptyReadSet = ReadSet(sc.parallelize(Seq(read)), None, "", Read.InputFilters.empty, 0, false)
+    val reads: RDD[Read] = sc.parallelize(Seq(read))
+    val emptyReadSet = new ReadSet(reads, None, "", Read.InputFilters.empty, 0, false)
     class TestArgs extends Common.Arguments.Base with Common.Arguments.Loci {}
 
     // Test -loci argument

--- a/src/test/scala/org/hammerlab/guacamole/TestUtil.scala
+++ b/src/test/scala/org/hammerlab/guacamole/TestUtil.scala
@@ -147,7 +147,7 @@ object TestUtil extends Matchers {
     val path = testDataPath(filename)
     assert(sc != null)
     assert(sc.hadoopConfiguration != null)
-    ReadSet(sc, path)
+    ReadSet(sc, path, requireMDTagsOnMappedReads = false)
   }
 
   def loadTumorNormalReads(sc: SparkContext,
@@ -164,7 +164,7 @@ object TestUtil extends Matchers {
     val path = testDataPath(filename)
     assert(sc != null)
     assert(sc.hadoopConfiguration != null)
-    ReadSet(sc, path, filters = filters)
+    ReadSet(sc, path, requireMDTagsOnMappedReads = false, filters = filters)
   }
 
   def loadTumorNormalPileup(tumorReads: Seq[MappedRead],

--- a/src/test/scala/org/hammerlab/guacamole/reads/ReadSetSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/ReadSetSuite.scala
@@ -64,7 +64,12 @@ class ReadSetSuite extends TestUtil.SparkFunSuite with Matchers {
       case (guacRead, adamRead) => guacRead should be(adamRead)
     })
 
-    val (filteredReads, _) = Read.loadReadRDDAndSequenceDictionary(adamOut, sc, token = 1, Read.InputFilters(mapped = true, nonDuplicate = true))
+    val (filteredReads, _) = Read.loadReadRDDAndSequenceDictionary(
+      adamOut,
+      sc,
+      token = 1,
+      Read.InputFilters(mapped = true, nonDuplicate = true),
+      requireMDTagsOnMappedReads = true)
     filteredReads.count() should be(4)
     filteredReads.collect().forall(_.token == 1) should be(true)
 


### PR DESCRIPTION
This computes the count per allele at a set of variant sites.

Future TODOs:
- Support filtering the VCF to only passing variants
- Support not requiring non-MDTag reads. 

The second one will require changing other pieces of code as well, so I will do that in a second PR and after some discussion of what that looks like.  Simplest thing is an `Option[MdTag]`, but that usually means that each pileup element also will have some option for the `referenceBases` in `Allele`.

Sample output:
```
Normal_Exome, chr1, 10340, A, A, 8
Normal_Exome, chr1, 13011, G, G, 18
Normal_Exome, chr1, 13115, T, G, 4
Normal_Exome, chr1, 13115, T, T, 2
Normal_Exome, chr1, 13117, A, G, 4
Normal_Exome, chr1, 13117, A, A, 2
Normal_Exome, chr1, 13280, C, C, 10
Normal_Exome, chr1, 13301, C, C, 7
```

This takes about 5min our cluster on 2 exome BAMs.  There are some smaller overhead that we can look into (there is a variant count print (~20s)) and if we had pre-converted BAMs to parquet we would be able to filter to the correct loci efficiently (without a full-scan/conversion of each BAM record).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/288)
<!-- Reviewable:end -->
