### PR TITLE
Update README.md with required mvn version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For hacking Guacamole, see our [code docs](http://www.hammerlab.org/guacamole/do
 
 # Running Guacamole on a Single Node
 
-Guacamole requires [Apache Maven](http://maven.apache.org/).
+Guacamole requires [Apache Maven](http://maven.apache.org/) (version 3.0.4 or higher).
 
 Build:
 


### PR DESCRIPTION
Trying to `package` the application with Maven version `< 3.0.4` fails:

```bash
$ mvn --version
Apache Maven 3.0.3 (r1075438; 2011-02-28 12:31:09-0500)
Maven home: /usr/share/maven
Java version: 1.7.0_45, vendor: Oracle Corporation
Java home: /Library/Java/JavaVirtualMachines/jdk1.7.0_45.jdk/Contents/Home/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "10.7.5", arch: "x86_64", family: "mac"
$ mvn package
[INFO] Scanning for projects...
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building guacamole: variant caller 0.0.1-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-enforcer-plugin:1.0:enforce (enforce-maven) @ guacamole ---
[INFO] 
[INFO] --- scalariform-maven-plugin:0.1.4:format (default) @ guacamole ---
[INFO] Modified 0 of 70 .scala files
[INFO] 
[INFO] --- maven-resources-plugin:2.4.3:resources (default-resources) @ guacamole ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /Users/aksoyb/Projects/guacamole/src/main/resources
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 47.282s
[INFO] Finished at: Mon Jun 01 15:38:42 EDT 2015
[INFO] Final Memory: 18M/311M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal net.alchim31.maven:scala-maven-plugin:3.1.5:add-source (scala-compile-first) on project guacamole: The plugin net.alchim31.maven:scala-maven-plugin:3.1.5 requires Maven version 3.0.4 -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginIncompatibleException
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/293)
<!-- Reviewable:end -->
