### PR TITLE
Remove getMappedReadOpt property

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/ReadSet.scala
+++ b/src/main/scala/org/hammerlab/guacamole/ReadSet.scala
@@ -21,7 +21,7 @@ package org.hammerlab.guacamole
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models.SequenceDictionary
-import org.hammerlab.guacamole.reads.Read
+import org.hammerlab.guacamole.reads.{ UnmappedRead, MappedRead, Read }
 
 /**
  * A ReadSet contains an RDD of reads along with some metadata about them.
@@ -43,7 +43,12 @@ case class ReadSet(
     contigLengthsFromDictionary: Boolean) {
 
   /** Only mapped reads. */
-  lazy val mappedReads = reads.flatMap(_.getMappedReadOpt)
+  lazy val mappedReads = reads.flatMap(read =>
+    read match {
+      case r: MappedRead   => Some(r)
+      case r: UnmappedRead => None
+    }
+  )
 
   /**
    * A map from contig name -> length of contig.

--- a/src/main/scala/org/hammerlab/guacamole/reads/MappedRead.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/MappedRead.scala
@@ -50,8 +50,6 @@ case class MappedRead(
   assert(baseQualities.length == sequence.length,
     "Base qualities have length %d but sequence has length %d".format(baseQualities.length, sequence.length))
 
-  final override lazy val getMappedReadOpt = Some(this)
-
   def mdTag = MdTag(mdTagString, start)
 
   lazy val referenceBases: Seq[Byte] =

--- a/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
@@ -61,13 +61,13 @@ trait Read {
   val isDuplicate: Boolean
 
   /** Is this read mapped? */
-  final val isMapped: Boolean = getMappedReadOpt.isDefined
+  final val isMapped: Boolean = this match {
+    case r: MappedRead   => true
+    case r: UnmappedRead => false
+  }
 
   /** The sample (e.g. "tumor" or "patient3636") name. */
   val sampleName: String
-
-  /** Returns this Read as a MappedRead iff isMapped=true, otherwise None. */
-  def getMappedReadOpt: Option[MappedRead] = None
 
   /** Whether the read failed predefined vendor checks for quality */
   val failedVendorQualityChecks: Boolean
@@ -119,40 +119,27 @@ object Read extends Logging {
     mdTagString: String,
     failedVendorQualityChecks: Boolean = false,
     isPositiveStrand: Boolean = true,
-    matePropertiesOpt: Option[MateProperties] = None): Read = {
+    matePropertiesOpt: Option[MateProperties] = None) = {
 
     val sequenceArray = sequence.map(_.toByte).toArray
     val qualityScoresArray = baseQualityStringToArray(baseQualities, sequenceArray.length)
 
-    if (referenceContig.isEmpty) {
-      UnmappedRead(
-        token,
-        sequenceArray,
-        qualityScoresArray,
-        isDuplicate,
-        sampleName.intern,
-        failedVendorQualityChecks,
-        isPositiveStrand,
-        matePropertiesOpt = matePropertiesOpt
-      )
-    } else {
-      val cigar = TextCigarCodec.getSingleton.decode(cigarString)
-      MappedRead(
-        token,
-        sequenceArray,
-        qualityScoresArray,
-        isDuplicate,
-        sampleName.intern,
-        referenceContig,
-        alignmentQuality,
-        start,
-        cigar,
-        mdTagString,
-        failedVendorQualityChecks,
-        isPositiveStrand,
-        matePropertiesOpt = matePropertiesOpt
-      )
-    }
+    val cigar = TextCigarCodec.getSingleton.decode(cigarString)
+    MappedRead(
+      token,
+      sequenceArray,
+      qualityScoresArray,
+      isDuplicate,
+      sampleName.intern,
+      referenceContig,
+      alignmentQuality,
+      start,
+      cigar,
+      mdTagString,
+      failedVendorQualityChecks,
+      isPositiveStrand,
+      matePropertiesOpt = matePropertiesOpt
+    )
   }
 
   /**

--- a/src/test/scala/org/hammerlab/guacamole/reads/MappedReadSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/MappedReadSuite.scala
@@ -54,8 +54,6 @@ class MappedReadSuite extends GuacFunSuite with Matchers {
     read.isMapped should be(true)
     read.asInstanceOf[Read].isMapped should be(true)
 
-    read.getMappedReadOpt.exists(_.isMapped) should be(true)
-
   }
 
   test("mixed collections mapped and unmapped reads") {

--- a/src/test/scala/org/hammerlab/guacamole/reads/UnmappedReadSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/UnmappedReadSuite.scala
@@ -47,7 +47,6 @@ class UnmappedReadSuite extends GuacFunSuite with Matchers {
 
     read.isMapped should be(false)
     read.asInstanceOf[Read].isMapped should be(false)
-    read.getMappedReadOpt should be(None)
 
     val collectionMappedReads: Seq[Read] = Seq(read)
     collectionMappedReads(0).isMapped should be(false)

--- a/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
@@ -78,8 +78,8 @@ object TestUtil extends Matchers {
       qualityScores.get.map(q => q + 33).map(_.toChar).mkString
     } else {
       sequence.map(x => '@').mkString
-    }
-
+    } 
+    
     Read(
       sequence,
       cigarString = cigar,
@@ -88,7 +88,8 @@ object TestUtil extends Matchers {
       referenceContig = chr,
       baseQualities = qualityScoreString,
       alignmentQuality = alignmentQuality
-    ).getMappedReadOpt.get
+    )
+
   }
 
   def makePairedRead(
@@ -125,7 +126,7 @@ object TestUtil extends Matchers {
           isMatePositiveStrand = isMatePositiveStrand
         )
       )
-    ).getMappedReadOpt.get
+    )
   }
 
   def assertBases(bases1: Iterable[Byte], bases2: String) = Bases.basesToString(bases1) should equal(bases2)


### PR DESCRIPTION
Not sure if there was another reason to have this, but for it's current uses we can check the type.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/299)
<!-- Reviewable:end -->
