### PR TITLE
Remove mapping complexity and regional analysis filters

### DIFF
--- a/src/test/scala/org/hammerlab/guacamole/commands/SomaticStandardCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/SomaticStandardCallerSuite.scala
@@ -100,7 +100,7 @@ class SomaticStandardCallerSuite extends GuacFunSuite with Matchers with TableDr
     val (tumorReads, normalReads) = TestUtil.loadTumorNormalReads(sc,
       "synthetic.challenge.set1.tumor.v2.withMDTags.chr2.complexvar.sam",
       "synthetic.challenge.set1.normal.v2.withMDTags.chr2.complexvar.sam")
-    val negativePositions = Array[Long](148487667, 134307261, 90376213, 3638733, 112529049, 91662497, 109347468)
+    val negativePositions = Array[Long](148487667, 134307261, 90376213, 3638733, 109347468)
     testVariants(tumorReads, normalReads, negativePositions, shouldFindVariant = false)
 
     val positivePositions = Array[Long](82949713, 130919744)

--- a/src/test/scala/org/hammerlab/guacamole/commands/SomaticStandardCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/SomaticStandardCallerSuite.scala
@@ -61,8 +61,6 @@ class SomaticStandardCallerSuite extends GuacFunSuite with Matchers with TableDr
           tumorPileup,
           normalPileup,
           logOddsThreshold,
-          maxMappingComplexity,
-          minAlignmentForComplexity,
           minAlignmentQuality,
           filterMultiAllelic
         )


### PR DESCRIPTION
Mostly code deletion, after a lot of the validation tests these filters did not add much and actually were wrong in many cases.  These were throwing out variants based on the synthetic rules in SMC challenge that we should not do.

This may result in some tests failing in the SomaticStandardSuite, but those tests can also be cleaned up.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/300)
<!-- Reviewable:end -->
