### PR TITLE
Check for output file existence first

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/Common.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Common.scala
@@ -27,6 +27,7 @@ import org.apache.avro.io.EncoderFactory
 import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{ FileSystem, Path }
+import org.apache.hadoop.mapred.FileAlreadyExistsException
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{ Logging, SparkConf, SparkContext }
 import org.bdgenomics.adam.cli.{ Args4jBase, ParquetArgs }
@@ -375,6 +376,21 @@ object Common extends Logging {
     }
     if (pieces.hasNext) builder.append(ellipses)
     builder.result
+  }
+
+  /**
+   * Perform validation of command line arguments at startup.
+   * This allows some late failures (e.g. output file already exists) to be surfaced more quickly.
+   */
+  def validateArguments(args: Arguments.GenotypeOutput) = {
+    val outputPath = args.variantOutput.stripMargin
+    if (outputPath.toLowerCase.endsWith(".vcf")) {
+      val filesystem = FileSystem.get(new Configuration())
+      val path = new Path(outputPath)
+      if (filesystem.exists(path)) {
+        throw new FileAlreadyExistsException("Output directory " + path + " already exists")
+      }
+    }
   }
 }
 

--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineStandardCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineStandardCaller.scala
@@ -48,7 +48,7 @@ object GermlineStandard {
     override val description = "call variants using a simple quality-based probability"
 
     override def run(args: Arguments, sc: SparkContext): Unit = {
-
+      Common.validateArguments(args)
       val readSet = Common.loadReadsFromArguments(args, sc, Read.InputFilters(mapped = true, nonDuplicate = true))
       readSet.mappedReads.persist()
       Common.progress(

--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineThresholdCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineThresholdCaller.scala
@@ -56,7 +56,7 @@ object GermlineThreshold {
     override val description = "call variants by thresholding read counts (toy example)"
 
     override def run(args: Arguments, sc: SparkContext): Unit = {
-
+      Common.validateArguments(args)
       val readSet = Common.loadReadsFromArguments(args, sc, Read.InputFilters(mapped = true, nonDuplicate = true))
 
       readSet.mappedReads.persist()

--- a/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
@@ -56,7 +56,7 @@ object SomaticStandard {
     override val description = "call somatic variants using independent callers on tumor and normal"
 
     override def run(args: Arguments, sc: SparkContext): Unit = {
-
+      Common.validateArguments(args)
       val filters = Read.InputFilters(mapped = true, nonDuplicate = true, passedVendorQualityChecks = true)
       val (tumorReads, normalReads) = Common.loadTumorNormalReadsFromArguments(args, sc, filters)
 


### PR DESCRIPTION
This moves the failure before the entire job runs, rather than after.

It wasn't clear to me if this was an issue for JSON and Parquet output, so I'm only doing the check for VCF output. @arahuja @ryan-williams should I be doing the check for those, too?

I could move the `Common.validateArguments` call into `Command.scala` to reduce duplication. Thoughts?

Fixes #305 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/307)
<!-- Reviewable:end -->
