### PR TITLE
Extract read name from Alignments

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/reads/MappedRead.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/MappedRead.scala
@@ -45,7 +45,8 @@ case class MappedRead(
     mdTagString: String,
     failedVendorQualityChecks: Boolean,
     isPositiveStrand: Boolean,
-    matePropertiesOpt: Option[MateProperties]) extends Read with HasReferenceRegion {
+    matePropertiesOpt: Option[MateProperties],
+    readName: String) extends Read with HasReferenceRegion {
 
   assert(baseQualities.length == sequence.length,
     "Base qualities have length %d but sequence has length %d".format(baseQualities.length, sequence.length))

--- a/src/main/scala/org/hammerlab/guacamole/reads/MappedReadSerializer.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/MappedReadSerializer.scala
@@ -40,6 +40,7 @@ class MappedReadSerializer extends Serializer[MappedRead] with CanSerializeMateP
     output.writeString(obj.mdTagString)
     output.writeBoolean(obj.failedVendorQualityChecks)
     output.writeBoolean(obj.isPositiveStrand)
+    output.writeString(obj.readName)
 
     write(kryo, output, obj.matePropertiesOpt)
   }
@@ -58,6 +59,7 @@ class MappedReadSerializer extends Serializer[MappedRead] with CanSerializeMateP
     val mdTagString = input.readString()
     val failedVendorQualityChecks = input.readBoolean()
     val isPositiveStrand = input.readBoolean()
+    val readName = input.readString()
 
     val matePropertiesOpt = read(kryo, input)
 
@@ -75,7 +77,8 @@ class MappedReadSerializer extends Serializer[MappedRead] with CanSerializeMateP
       mdTagString,
       failedVendorQualityChecks,
       isPositiveStrand,
-      matePropertiesOpt
+      matePropertiesOpt,
+      readName
     )
   }
 }

--- a/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
@@ -80,6 +80,7 @@ trait Read {
   /** Whether read is from a paired-end library */
   val isPaired: Boolean = matePropertiesOpt.isDefined
 
+  val readName: String
 }
 
 object Read extends Logging {
@@ -119,7 +120,8 @@ object Read extends Logging {
     mdTagString: String,
     failedVendorQualityChecks: Boolean = false,
     isPositiveStrand: Boolean = true,
-    matePropertiesOpt: Option[MateProperties] = None) = {
+    matePropertiesOpt: Option[MateProperties] = None,
+    readName: String = "foo") = {
 
     val sequenceArray = sequence.map(_.toByte).toArray
     val qualityScoresArray = baseQualityStringToArray(baseQualities, sequenceArray.length)
@@ -138,7 +140,8 @@ object Read extends Logging {
       mdTagString,
       failedVendorQualityChecks,
       isPositiveStrand,
-      matePropertiesOpt = matePropertiesOpt
+      matePropertiesOpt = matePropertiesOpt,
+      readName
     )
   }
 
@@ -217,7 +220,8 @@ object Read extends Logging {
             mdTagString = mdTagString,
             failedVendorQualityChecks = record.getReadFailsVendorQualityCheckFlag,
             isPositiveStrand = !record.getReadNegativeStrandFlag,
-            matePropertiesOpt = matePropertiesOpt
+            matePropertiesOpt = matePropertiesOpt,
+            record.getReadName
           )
 
           // We subtract 1 from start, since samtools is 1-based and we're 0-based.
@@ -241,7 +245,8 @@ object Read extends Logging {
         sampleName,
         record.getReadFailsVendorQualityCheckFlag,
         !record.getReadNegativeStrandFlag,
-        matePropertiesOpt = matePropertiesOpt
+        matePropertiesOpt = matePropertiesOpt,
+        record.getReadName
       )
       Some(result)
     }
@@ -329,6 +334,7 @@ object Read extends Logging {
     // Build a projection that will only load the fields we will need to populate a Read
     val ADAMSpecificProjection = Projection(
       AlignmentRecordField.recordGroupSample,
+      AlignmentRecordField.readName,
 
       AlignmentRecordField.sequence,
       AlignmentRecordField.qual,
@@ -403,7 +409,8 @@ object Read extends Logging {
         mdTagString = alignmentRecord.getMismatchingPositions.toString,
         failedVendorQualityChecks = alignmentRecord.getFailedVendorQualityChecks,
         isPositiveStrand = !alignmentRecord.getReadNegativeStrand,
-        matePropertiesOpt = mateProperties
+        matePropertiesOpt = mateProperties,
+        readName = alignmentRecord.getReadName
       )
     } else {
       UnmappedRead(
@@ -414,7 +421,8 @@ object Read extends Logging {
         sampleName = alignmentRecord.getRecordGroupSample.toString.intern(),
         failedVendorQualityChecks = alignmentRecord.getFailedVendorQualityChecks,
         isPositiveStrand = !alignmentRecord.getReadNegativeStrand,
-        matePropertiesOpt = mateProperties
+        matePropertiesOpt = mateProperties,
+        readName = alignmentRecord.getReadName
       )
     }
   }

--- a/src/main/scala/org/hammerlab/guacamole/reads/UnmappedRead.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/UnmappedRead.scala
@@ -30,7 +30,8 @@ case class UnmappedRead(
     sampleName: String,
     failedVendorQualityChecks: Boolean,
     isPositiveStrand: Boolean,
-    matePropertiesOpt: Option[MateProperties]) extends Read {
+    matePropertiesOpt: Option[MateProperties],
+    readName: String) extends Read {
 
   assert(baseQualities.length == sequence.length)
 }

--- a/src/main/scala/org/hammerlab/guacamole/reads/UnmappedReadSerializer.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/UnmappedReadSerializer.scala
@@ -33,6 +33,7 @@ class UnmappedReadSerializer extends Serializer[UnmappedRead] with CanSerializeM
     output.writeString(obj.sampleName)
     output.writeBoolean(obj.failedVendorQualityChecks)
     output.writeBoolean(obj.isPositiveStrand)
+    output.writeString(obj.readName)
 
     write(kryo, output, obj.matePropertiesOpt)
   }
@@ -46,6 +47,7 @@ class UnmappedReadSerializer extends Serializer[UnmappedRead] with CanSerializeM
     val sampleName = input.readString().intern()
     val failedVendorQualityChecks = input.readBoolean()
     val isPositiveStrand = input.readBoolean()
+    val readName = input.readString()
 
     val matePropertiesOpt = read(kryo, input)
 
@@ -57,7 +59,8 @@ class UnmappedReadSerializer extends Serializer[UnmappedRead] with CanSerializeM
       sampleName.intern,
       failedVendorQualityChecks,
       isPositiveStrand,
-      matePropertiesOpt
+      matePropertiesOpt,
+      readName
     )
   }
 }

--- a/src/test/scala/org/hammerlab/guacamole/reads/MappedReadSerializerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/MappedReadSerializerSuite.scala
@@ -48,7 +48,8 @@ class MappedReadSerializerSuite extends GuacFunSuite with Matchers {
           Some(100L),
           false
         )
-      )
+      ),
+      "readName"
     )
 
     val serialized = TestUtil.serialize(read)
@@ -73,6 +74,7 @@ class MappedReadSerializerSuite extends GuacFunSuite with Matchers {
     deserialized.failedVendorQualityChecks should equal(read.failedVendorQualityChecks)
     deserialized.isPositiveStrand should equal(read.isPositiveStrand)
     deserialized.matePropertiesOpt should equal(read.matePropertiesOpt)
+    deserialized.readName should equal(read.readName)
   }
 
   test("serialize / deserialize mapped read with mdtag") {
@@ -98,7 +100,8 @@ class MappedReadSerializerSuite extends GuacFunSuite with Matchers {
           Some(100L),
           false
         )
-      )
+      ),
+      "readName"
     )
 
     val serialized = TestUtil.serialize(read)
@@ -123,6 +126,7 @@ class MappedReadSerializerSuite extends GuacFunSuite with Matchers {
     deserialized.failedVendorQualityChecks should equal(read.failedVendorQualityChecks)
     deserialized.isPositiveStrand should equal(read.isPositiveStrand)
     deserialized.matePropertiesOpt should equal(read.matePropertiesOpt)
+    deserialized.readName should equal(read.readName)
   }
 
   test("serialize / deserialize mapped read with unmapped pair") {
@@ -148,7 +152,8 @@ class MappedReadSerializerSuite extends GuacFunSuite with Matchers {
           None,
           false
         )
-      )
+      ),
+      "readName"
     )
 
     val serialized = TestUtil.serialize(read)
@@ -173,6 +178,7 @@ class MappedReadSerializerSuite extends GuacFunSuite with Matchers {
     deserialized.failedVendorQualityChecks should equal(read.failedVendorQualityChecks)
     deserialized.isPositiveStrand should equal(read.isPositiveStrand)
     deserialized.matePropertiesOpt should equal(read.matePropertiesOpt)
+    deserialized.readName should equal(read.readName)
   }
 
 }

--- a/src/test/scala/org/hammerlab/guacamole/reads/MappedReadSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/MappedReadSuite.scala
@@ -48,7 +48,8 @@ class MappedReadSuite extends GuacFunSuite with Matchers {
           Some(100L),
           false
         )
-      )
+      ),
+      "readName"
     )
 
     read.isMapped should be(true)
@@ -74,7 +75,8 @@ class MappedReadSuite extends GuacFunSuite with Matchers {
           Some(100L),
           false
         )
-      )
+      ),
+      "readName"
     )
 
     val mread = MappedRead(
@@ -99,7 +101,8 @@ class MappedReadSuite extends GuacFunSuite with Matchers {
           Some(100L),
           false
         )
-      )
+      ),
+      "readName"
     )
 
     val collectionMappedReads: Seq[Read] = Seq(uread, mread)

--- a/src/test/scala/org/hammerlab/guacamole/reads/ReadSetSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/ReadSetSuite.scala
@@ -89,6 +89,7 @@ class ReadSetSuite extends GuacFunSuite with Matchers {
       deserialized.failedVendorQualityChecks should equal(read.failedVendorQualityChecks)
       deserialized.isPositiveStrand should equal(read.isPositiveStrand)
       deserialized.matePropertiesOpt should equal(read.matePropertiesOpt)
+      deserialized.readName should equal(read.readName)
     }
 
   }

--- a/src/test/scala/org/hammerlab/guacamole/reads/UnmappedReadSerializerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/UnmappedReadSerializerSuite.scala
@@ -42,7 +42,8 @@ class UnmappedReadSerializerSuite extends GuacFunSuite with Matchers {
           Some(100L),
           false
         )
-      )
+      ),
+      "readName"
     )
 
     val serialized = TestUtil.serialize(read)
@@ -62,6 +63,7 @@ class UnmappedReadSerializerSuite extends GuacFunSuite with Matchers {
     deserialized.failedVendorQualityChecks should equal(read.failedVendorQualityChecks)
     deserialized.isPositiveStrand should equal(read.isPositiveStrand)
     deserialized.matePropertiesOpt should equal(read.matePropertiesOpt)
+    deserialized.readName should equal(read.readName)
   }
 
 }

--- a/src/test/scala/org/hammerlab/guacamole/reads/UnmappedReadSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/UnmappedReadSuite.scala
@@ -42,7 +42,8 @@ class UnmappedReadSuite extends GuacFunSuite with Matchers {
           Some(100L),
           false
         )
-      )
+      ),
+      "readName"
     )
 
     read.isMapped should be(false)

--- a/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
@@ -78,8 +78,8 @@ object TestUtil extends Matchers {
       qualityScores.get.map(q => q + 33).map(_.toChar).mkString
     } else {
       sequence.map(x => '@').mkString
-    } 
-    
+    }
+
     Read(
       sequence,
       cigarString = cigar,


### PR DESCRIPTION
This is partially pulled from the Cornell code.

You get paired reads by grouping by read name, so this is a pre-req for doing structural variant calling.

Two questions:
- Are there performance concerns about parsing read names?
- I'm surprised how many files I had to modify to do this (5 main + 5 test). What's the point of the case classes and kryo serialization? Why not use the ADAM Avro format everywhere?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/308)
<!-- Reviewable:end -->
