### PR TITLE
Support pileup flatmapping over any number of RDDs

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/DistributedUtil.scala
+++ b/src/main/scala/org/hammerlab/guacamole/DistributedUtil.scala
@@ -341,7 +341,7 @@ object DistributedUtil extends Logging {
         val advancedPileups = maybePileups match {
           case Some(existingPileups) => {
             existingPileups.zip(windows).map(
-              pileup_and_window => initOrMovePileup(Some(pileup_and_window._1), pileup_and_window._2))
+              pileupAndWindow => initOrMovePileup(Some(pileupAndWindow._1), pileupAndWindow._2))
           }
           case None => windows.map(initOrMovePileup(None, _))
         }

--- a/src/main/scala/org/hammerlab/guacamole/DistributedUtil.scala
+++ b/src/main/scala/org/hammerlab/guacamole/DistributedUtil.scala
@@ -21,14 +21,13 @@ package org.hammerlab.guacamole
 import org.apache.commons.math3
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{ Partitioner, AccumulatorParam, SparkConf, Logging }
-import org.apache.spark.SparkContext._
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.serializer.JavaSerializer
 import org.hammerlab.guacamole.Common.Arguments.{ Base, Loci }
 import org.hammerlab.guacamole.Common._
 import org.hammerlab.guacamole.pileup.Pileup
 import org.hammerlab.guacamole.reads.MappedRead
-import org.hammerlab.guacamole.windowing.{ SlidingWindow }
+import org.hammerlab.guacamole.windowing.{ SplitIterator, SlidingWindow }
 import org.kohsuke.args4j.{ Option => Args4jOption }
 
 import scala.collection.mutable.{ HashMap => MutableHashMap }
@@ -323,6 +322,34 @@ object DistributedUtil extends Logging {
   }
 
   /**
+   * Flatmap across loci and any number of RDDs of MappedReads.
+   *
+   * @see the windowTaskFlatMapMultipleRDDs function for other argument descriptions.
+   */
+  def pileupFlatMapMultipleRDDs[T: ClassTag](
+    readsRDDs: Seq[RDD[MappedRead]],
+    lociPartitions: LociMap[Long],
+    skipEmpty: Boolean,
+    function: Seq[Pileup] => Iterator[T]): RDD[T] = {
+    windowFlatMapWithState(
+      readsRDDs,
+      lociPartitions,
+      skipEmpty,
+      halfWindowSize = 0L,
+      initialState = None,
+      function = (maybePileups: Option[Seq[Pileup]], windows: PerSample[SlidingWindow[MappedRead]]) => {
+        val advancedPileups = maybePileups match {
+          case Some(existingPileups) => {
+            existingPileups.zip(windows).map(
+              pileup_and_window => initOrMovePileup(Some(pileup_and_window._1), pileup_and_window._2))
+          }
+          case None => windows.map(initOrMovePileup(None, _))
+        }
+        (Some(advancedPileups), function(advancedPileups))
+      })
+  }
+
+  /**
    * FlatMap across loci, and any number of RDDs of regions, where at each locus the provided function is passed a
    * sliding window instance for each RDD containing the regions overlapping an interval of halfWindowSize to either side
    * of a locus.
@@ -489,10 +516,7 @@ object DistributedUtil extends Logging {
   }
 
   /**
-   * FlatMap across sets of regions overlapping genomic partitions, on multiple RDDs.
-   *
-   * Although this function would from its interface appear to support any number of RDDs, as a matter of implementation
-   * we currently only support working with 1 or 2 region RDDs. That is, the regionRDDs param must currently be length 1 or 2.
+   * FlatMap across sets of regions (e.g. reads) overlapping genomic partitions, on multiple RDDs.
    *
    * This function works as follows:
    *
@@ -524,7 +548,8 @@ object DistributedUtil extends Logging {
     // TODO(ryan): factor this function type out (as a PartialFunction?)
     function: (Long, LociSet, PerSample[Iterator[M]]) => Iterator[T]): RDD[T] = {
 
-    assume(regionRDDs.length > 0)
+    val numRDDs = regionRDDs.length
+    assume(numRDDs > 0)
     val sc = regionRDDs(0).sparkContext
     progress("Loci partitioning: %s".format(lociPartitions.truncatedString()))
     val lociPartitionsBoxed: Broadcast[LociMap[Long]] = sc.broadcast(lociPartitions)
@@ -578,65 +603,20 @@ object DistributedUtil extends Logging {
     // Accumulator to track the number of loci in each task
     val lociAccumulator = sc.accumulator[Long](0, "NumLoci")
 
-    // Here, we special case for different numbers of RDDs.
-    val results = taskNumberRegionPairsRDDs match {
+    // Build an RDD of (read set num, read), take union of this over all RDDs, and partition by task.
+    val partitioned = sc.union(
+      taskNumberRegionPairsRDDs.zipWithIndex.map({
+        case (taskNumberRegionPairs, rddIndex: Int) => {
+          taskNumberRegionPairs.map(pair => (pair._1, (rddIndex, pair._2)))
+        }
+      })).repartitionAndSortWithinPartitions(new PartitionByKey(numTasks.toInt)).map(_._2)
 
-      // One RDD.
-      case taskNumberRegionPairs :: Nil => {
-        // Each key (i.e. task) gets its own partition.
-        val partitioned = taskNumberRegionPairs
-          .repartitionAndSortWithinPartitions(new PartitionByKey(numTasks.toInt))
-        partitioned.mapPartitionsWithIndex((taskNum: Int, taskNumAndRegions) => {
-          val taskLoci = lociPartitionsBoxed.value.asInverseMap(taskNum.toLong)
-
-          // Add number of loci covered to accumulator
-          lociAccumulator += taskLoci.count
-
-          function(taskNum, taskLoci, Seq(taskNumAndRegions.map(_._2)))
-        })
-      }
-
-      // Two RDDs.
-      case taskNumberRegionPairs1 :: taskNumberRegionPairs2 :: Nil => {
-        val sortedtaskNumberRegionPairs1 =
-          taskNumberRegionPairs1
-            .repartitionAndSortWithinPartitions(new PartitionByKey(numTasks.toInt))
-        val sortedtaskNumberRegionPairs2 =
-          taskNumberRegionPairs2
-            .repartitionAndSortWithinPartitions(new PartitionByKey(numTasks.toInt))
-
-        // TODO: A zipPartitionsWithIndex with would make this cleaner
-        sortedtaskNumberRegionPairs1.zipPartitions(sortedtaskNumberRegionPairs2, preservesPartitioning = true)(
-          (taskNumAndRegionPairs1: Iterator[(TaskPosition, M)], taskNumAndRegionPairs2: Iterator[(TaskPosition, M)]) => {
-            if (taskNumAndRegionPairs1.isEmpty && taskNumAndRegionPairs2.isEmpty) {
-              Iterator.empty
-            } else {
-
-              // Both iterators are buffered so we can retrieve the task number for this partition
-              // TODO: a zipPartitionsWithIndex would allow us to have direct access to the task number
-              val bufferTaskNumAndRegionPairs1 = taskNumAndRegionPairs1.buffered
-              val bufferTaskNumAndRegionPairs2 = taskNumAndRegionPairs2.buffered
-
-              // Take the task number from the first element of either non-empty iterator
-              val taskNum = if (bufferTaskNumAndRegionPairs1.hasNext)
-                bufferTaskNumAndRegionPairs1.head._1.task
-              else
-                bufferTaskNumAndRegionPairs2.head._1.task
-
-              val taskLoci = lociPartitionsBoxed.value.asInverseMap(taskNum.toLong)
-
-              // Add number of loci processed on this partition to the accumulator
-              lociAccumulator += taskLoci.count
-
-              function(taskNum, taskLoci, Seq(bufferTaskNumAndRegionPairs1.map(_._2), bufferTaskNumAndRegionPairs2.map(_._2)))
-            }
-          })
-      }
-
-      // We currently do not support the general case.
-      case _ => throw new AssertionError("Unsupported number of RDDs: %d".format(taskNumberRegionPairsRDDs.length))
-    }
-    results
+    partitioned.mapPartitionsWithIndex((taskNum, values) => {
+      val iterators = SplitIterator.split(numRDDs, values)
+      val taskLoci = lociPartitionsBoxed.value.asInverseMap(taskNum)
+      lociAccumulator += taskLoci.count
+      function(taskNum, taskLoci, iterators)
+    })
   }
 
   /**

--- a/src/main/scala/org/hammerlab/guacamole/windowing/SplitIterator.scala
+++ b/src/main/scala/org/hammerlab/guacamole/windowing/SplitIterator.scala
@@ -1,0 +1,62 @@
+package org.hammerlab.guacamole.windowing
+
+object SplitIterator {
+  /**
+   * Split an iterator of key value pairs into separate iterators, one for each key, without buffering more data into
+   * memory than necessary. The keys must be integers between 0 and the provided upper bound.
+   *
+   * Given an iterator of (k, v) where 0 <= k < num and v is of arbitrary type, returns a sequence of length num. The
+   * i'th element in the sequence is an iterator over the values v where k = i.
+   *
+   * @param num number of keys. Each key k must be 0 <= k < num.
+   * @param iterator source iterator of (key, value) pairs. It will be consumed as the result iterators are read.
+   * @tparam V
+   * @return a buffered iterator for each key in 0 .. num.
+   */
+  def split[V](num: Int, iterator: Iterator[(Int, V)]): Seq[BufferedIterator[V]] = {
+    val buffers = (0 until num).map(_ => new collection.mutable.Queue[V])
+    (0 until num).map(index => new SplitIterator[V](index, buffers, iterator))
+  }
+}
+
+/**
+ * An iterator over values that pulls from a common source (key, value) iterator and yields values associated with a
+ * particular key. Buffers any elements that don't match the key we're interested in into a shared collection of queues.
+ *
+ * @param myIndex which key this is an iterator over
+ * @param buffers queues to buffer elements
+ * @param source source (key, value) iterator
+ * @tparam V
+ */
+private class SplitIterator[V](myIndex: Int,
+                               buffers: Seq[collection.mutable.Queue[V]],
+                               source: Iterator[(Int, V)]) extends BufferedIterator[V] {
+
+  val myBuffer = buffers(myIndex)
+
+  override def hasNext: Boolean = {
+    while (myBuffer.isEmpty && source.hasNext) {
+      advance()
+    }
+    myBuffer.nonEmpty
+  }
+
+  override def next(): V = {
+    val result = head
+    myBuffer.dequeue()
+    result
+  }
+
+  override def head: V = {
+    while (myBuffer.isEmpty) {
+      advance() // may throw.
+    }
+    myBuffer.head
+  }
+
+  private def advance(): Unit = {
+    val (index, element) = source.next() // may throw.
+    buffers(index) += element
+  }
+}
+

--- a/src/test/scala/org/hammerlab/guacamole/commands/VariantSupportSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/VariantSupportSuite.scala
@@ -2,8 +2,8 @@ package org.hammerlab.guacamole.commands
 
 import org.hammerlab.guacamole.Bases
 import org.hammerlab.guacamole.pileup.Pileup
-import org.hammerlab.guacamole.reads.{MappedRead, Read}
-import org.hammerlab.guacamole.util.{GuacFunSuite, TestUtil}
+import org.hammerlab.guacamole.reads.{ MappedRead, Read }
+import org.hammerlab.guacamole.util.{ GuacFunSuite, TestUtil }
 import org.hammerlab.guacamole.windowing.SlidingWindow
 import org.scalatest.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
@@ -14,15 +14,16 @@ class VariantSupportSuite extends GuacFunSuite with Matchers with TableDrivenPro
                        variantAlleleLoci: (String, Long, Map[String, Int])*) = {
     val variantAlleleLociTable = Table(
       heading = ("contig", "locus", "alleleCounts"),
-      variantAlleleLoci:_*
+      variantAlleleLoci: _*
     )
 
     forAll(variantAlleleLociTable) {
-      (contig: String, locus: Long, alleleCountMap) => {
-        window.setCurrentLocus(locus)
-        val pileup = Pileup(window.currentRegions(), locus, Bases.N)
-        assertAlleleCounts(pileup, alleleCountMap)
-      }
+      (contig: String, locus: Long, alleleCountMap) =>
+        {
+          window.setCurrentLocus(locus)
+          val pileup = Pileup(window.currentRegions(), locus, Bases.N)
+          assertAlleleCounts(pileup, alleleCountMap)
+        }
     }
   }
 
@@ -45,9 +46,8 @@ class VariantSupportSuite extends GuacFunSuite with Matchers with TableDrivenPro
     sc,
     "gatk_mini_bundle_extract.bam",
     Read.InputFilters(mapped = true, nonDuplicate = true)).mappedReads.collect().sortBy(_.start)
-  
-  lazy val rna_reads = TestUtil.loadReads(sc, "rna_chr17_41244936.sam").mappedReads.collect().sortBy(_.start)
 
+  lazy val rna_reads = TestUtil.loadReads(sc, "rna_chr17_41244936.sam").mappedReads.collect().sortBy(_.start)
 
   sparkTest("read evidence for simple snvs") {
 
@@ -61,13 +61,11 @@ class VariantSupportSuite extends GuacFunSuite with Matchers with TableDrivenPro
     assertAlleleCounts(pileup, Map(("", 5), ("C", 1)))
   }
 
-
   sparkTest("read evidence for simple snvs 2") {
 
     val pileup = Pileup(gatk_reads, 10009053)
     assertAlleleCounts(pileup, Map(("AT", 3)))
   }
-
 
   sparkTest("read evidence for simple snvs 3") {
     val loci = Seq(
@@ -77,7 +75,7 @@ class VariantSupportSuite extends GuacFunSuite with Matchers with TableDrivenPro
     )
 
     val window = SlidingWindow[MappedRead](0L, gatk_reads.toIterator)
-    testAlleleCounts(window, loci:_*)
+    testAlleleCounts(window, loci: _*)
   }
 
   sparkTest("read evidence for simple snvs no filters") {
@@ -89,7 +87,7 @@ class VariantSupportSuite extends GuacFunSuite with Matchers with TableDrivenPro
     )
 
     val window = SlidingWindow[MappedRead](0L, gatk_reads.toIterator)
-    testAlleleCounts(window, loci:_*)
+    testAlleleCounts(window, loci: _*)
 
   }
 
@@ -102,7 +100,7 @@ class VariantSupportSuite extends GuacFunSuite with Matchers with TableDrivenPro
     )
 
     val window = SlidingWindow[MappedRead](0L, non_duplicate_gatk_reads.toIterator)
-    testAlleleCounts(window, loci:_*)
+    testAlleleCounts(window, loci: _*)
 
   }
 }

--- a/src/test/scala/org/hammerlab/guacamole/reads/ReadSetSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/ReadSetSuite.scala
@@ -37,7 +37,7 @@ class ReadSetSuite extends GuacFunSuite with Matchers {
     val nonDuplicateReads = TestUtil.loadReads(sc, "mdtagissue.sam", Read.InputFilters(mapped = true, nonDuplicate = true))
     nonDuplicateReads.reads.count() should be(4)
   }
-  
+
   sparkTest("load RNA reads") {
     val readSet = TestUtil.loadReads(sc, "rna_chr17_41244936.sam")
     readSet.reads.count should be(23)

--- a/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
@@ -43,10 +43,6 @@ object TestUtil extends Matchers {
     "TestUtil." + UUID.randomUUID() + suffix
   }
 
-  // As a hack to run a single unit test, you can set this to the name of a test to run only it. See the top of
-  // DistributedUtilSuite for an example.
-  var runOnly: String = ""
-
   // Serialization helper functions.
   lazy val kryoPool = {
     val instantiator = new KryoInstantiator().setRegistrationRequired(true).withRegistrar(new IKryoRegistrar {

--- a/src/test/scala/org/hammerlab/guacamole/windowing/SplitIteratorSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/windowing/SplitIteratorSuite.scala
@@ -1,0 +1,75 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hammerlab.guacamole.windowing
+
+import org.scalatest.{ FunSuite, Matchers }
+
+class SplitIteratorSuite extends FunSuite with Matchers {
+  val data1 = Seq(
+    (0, "a"),
+    (0, "b"),
+    (3, "c"),
+    (2, "d"),
+    (3, "e"),
+    (0, "f"),
+    (1, "g"),
+    (1, "h"),
+    (3, "i"),
+    (2, "j"),
+    (3, "k"),
+    (1, "l"),
+    (0, "m"),
+    (0, "n"),
+    (0, "o")
+  )
+
+  test("test split iterator elements") {
+    val iterator = data1.iterator
+    val splitIterators = SplitIterator.split[String](4, iterator)
+    assert(iterator.hasNext)
+    val split = splitIterators.map(_.toList)
+    assert(!iterator.hasNext)
+
+    split(0) should equal(Seq("a", "b", "f", "m", "n", "o"))
+    split(1) should equal(Seq("g", "h", "l"))
+    split(2) should equal(Seq("d", "j"))
+    split(3) should equal(Seq("c", "e", "i", "k"))
+
+  }
+
+  test("test split iterator head") {
+    val split = SplitIterator.split[String](4, data1.iterator).map(_.head)
+    split should equal(Seq("a", "g", "d", "c"))
+  }
+
+  test("test split iterator hasNext") {
+    val iterator = data1.iterator
+    val iterators = SplitIterator.split[String](5, iterator)
+    assert(iterator.hasNext)
+    val nexts = iterators.map(_.hasNext)
+    nexts should equal(Seq(true, true, true, true, false))
+
+    assert(!iterator.hasNext) // should have forced a buffering of all elements.
+    val split = iterators.map(_.toList)
+    split(0) should equal(Seq("a", "b", "f", "m", "n", "o"))
+    split(1) should equal(Seq("g", "h", "l"))
+    split(2) should equal(Seq("d", "j"))
+    split(3) should equal(Seq("c", "e", "i", "k"))
+  }
+}


### PR DESCRIPTION
Generalizes `windowTaskFlatMapMultipleRDDs` to handle any number of RDDs.

Closes #317. Also closes #321.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/324)
<!-- Reviewable:end -->
