### PR TITLE
Standardize opt to Args4jOption

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/Common.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Common.scala
@@ -36,7 +36,7 @@ import org.bdgenomics.formats.avro.Genotype
 import org.hammerlab.guacamole.Concordance.ConcordanceArgs
 import org.hammerlab.guacamole.reads.Read
 import org.codehaus.jackson.JsonFactory
-import org.kohsuke.args4j.{ Option => Opt }
+import org.kohsuke.args4j.{ Option => Args4jOption }
 
 /**
  * Basic functions that most commands need, and specifications of command-line arguments that they use.
@@ -46,64 +46,64 @@ object Common extends Logging {
   object Arguments {
     /** Common argument(s) we always want.*/
     trait Base extends Args4jBase with ParquetArgs {
-      @Opt(name = "--debug", usage = "If set, prints a higher level of debug output.")
+      @Args4jOption(name = "--debug", usage = "If set, prints a higher level of debug output.")
       var debug = false
     }
 
     /** Argument for accepting a set of loci. */
     trait Loci extends Base {
-      @Opt(name = "--loci", usage = "Loci at which to call variants. Either 'all' or contig:start-end,contig:start-end,...",
+      @Args4jOption(name = "--loci", usage = "Loci at which to call variants. Either 'all' or contig:start-end,contig:start-end,...",
         forbids = Array("-loci-from-file"))
       var loci: String = ""
 
-      @Opt(name = "--loci-from-file", usage = "Path to file giving loci at which to call variants.",
+      @Args4jOption(name = "--loci-from-file", usage = "Path to file giving loci at which to call variants.",
         forbids = Array("-loci"))
       var lociFromFile: String = ""
     }
 
     /** Argument for using / not using sequence dictionaries to get contigs and lengths. */
     trait NoSequenceDictionary extends Base {
-      @Opt(name = "--no-sequence-dictionary",
+      @Args4jOption(name = "--no-sequence-dictionary",
         usage = "If set, get contigs and lengths directly from reads instead of from sequence dictionary.")
       var noSequenceDictionary: Boolean = false
     }
 
     /** Argument for accepting a single set of reads (for non-somatic variant calling). */
     trait Reads extends Base with NoSequenceDictionary {
-      @Opt(name = "--reads", metaVar = "X", required = true, usage = "Aligned reads")
+      @Args4jOption(name = "--reads", metaVar = "X", required = true, usage = "Aligned reads")
       var reads: String = ""
     }
 
     /** Arguments for accepting two sets of reads (tumor + normal). */
     trait TumorNormalReads extends Base with NoSequenceDictionary {
-      @Opt(name = "--normal-reads", metaVar = "X", required = true, usage = "Aligned reads: normal")
+      @Args4jOption(name = "--normal-reads", metaVar = "X", required = true, usage = "Aligned reads: normal")
       var normalReads: String = ""
 
-      @Opt(name = "--tumor-reads", metaVar = "X", required = true, usage = "Aligned reads: tumor")
+      @Args4jOption(name = "--tumor-reads", metaVar = "X", required = true, usage = "Aligned reads: tumor")
       var tumorReads: String = ""
     }
 
     /** Argument for writing output genotypes. */
     trait GenotypeOutput extends Base {
-      @Opt(name = "--out", metaVar = "VARIANTS_OUT", required = false,
+      @Args4jOption(name = "--out", metaVar = "VARIANTS_OUT", required = false,
         usage = "Variant output path. If not specified, print to screen.")
       var variantOutput: String = ""
 
-      @Opt(name = "--out-chunks", metaVar = "X", required = false,
+      @Args4jOption(name = "--out-chunks", metaVar = "X", required = false,
         usage = "When writing out to json format, number of chunks to coalesce the genotypes RDD into.")
       var outChunks: Int = 1
 
-      @Opt(name = "--max-genotypes", metaVar = "X", required = false,
+      @Args4jOption(name = "--max-genotypes", metaVar = "X", required = false,
         usage = "Maximum number of genotypes to output. 0 (default) means output all genotypes.")
       var maxGenotypes: Int = 0
     }
 
     /** Arguments for accepting a reference genome. */
     trait Reference extends Base {
-      @Opt(required = false, name = "--reference", usage = "ADAM or FASTA reference genome data")
+      @Args4jOption(required = false, name = "--reference", usage = "ADAM or FASTA reference genome data")
       var referenceInput: String = ""
 
-      @Opt(required = false, name = "--fragment-length",
+      @Args4jOption(required = false, name = "--fragment-length",
         usage = "Sets maximum fragment length. Default value is 10,000. Values greater than 1e9 should be avoided.")
       var fragmentLength: Long = 10000L
     }

--- a/src/main/scala/org/hammerlab/guacamole/DistributedUtil.scala
+++ b/src/main/scala/org/hammerlab/guacamole/DistributedUtil.scala
@@ -29,7 +29,7 @@ import org.hammerlab.guacamole.Common._
 import org.hammerlab.guacamole.pileup.Pileup
 import org.hammerlab.guacamole.reads.MappedRead
 import org.hammerlab.guacamole.windowing.{ SlidingWindow }
-import org.kohsuke.args4j.{ Option => Opt }
+import org.kohsuke.args4j.{ Option => Args4jOption }
 
 import scala.collection.mutable.{ HashMap => MutableHashMap }
 import scala.reflect.ClassTag
@@ -39,10 +39,10 @@ import scala.reflect.ClassTag
  */
 object DistributedUtil extends Logging {
   trait Arguments extends Base with Loci {
-    @Opt(name = "--parallelism", usage = "Num variant calling tasks. Set to 0 (default) to use the number of Spark partitions.")
+    @Args4jOption(name = "--parallelism", usage = "Num variant calling tasks. Set to 0 (default) to use the number of Spark partitions.")
     var parallelism: Int = 0
 
-    @Opt(name = "--partition-accuracy",
+    @Args4jOption(name = "--partition-accuracy",
       usage = "Num micro partitions to use per task in loci partitioning. Set to 0 to partition loci uniformly. Default: 250.")
     var partitioningAccuracy: Int = 250
   }

--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineThresholdCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineThresholdCaller.scala
@@ -27,7 +27,7 @@ import org.apache.spark.SparkContext._
 import org.hammerlab.guacamole.reads.Read
 import org.hammerlab.guacamole.variants.Allele
 import scala.collection.JavaConversions
-import org.kohsuke.args4j.Option
+import org.kohsuke.args4j.{ Option => Args4jOption }
 import org.apache.spark.rdd.RDD
 import org.hammerlab.guacamole.pileup.Pileup
 
@@ -40,13 +40,13 @@ import org.hammerlab.guacamole.pileup.Pileup
 object GermlineThreshold {
 
   protected class Arguments extends GermlineCallerArgs {
-    @Option(name = "--threshold", metaVar = "X", usage = "Make a call if at least X% of reads support it. Default: 8")
+    @Args4jOption(name = "--threshold", metaVar = "X", usage = "Make a call if at least X% of reads support it. Default: 8")
     var threshold: Int = 8
 
-    @Option(name = "--emit-ref", usage = "Output homozygous reference calls.")
+    @Args4jOption(name = "--emit-ref", usage = "Output homozygous reference calls.")
     var emitRef: Boolean = false
 
-    @Option(name = "--emit-no-call", usage = "Output no call calls.")
+    @Args4jOption(name = "--emit-no-call", usage = "Output no call calls.")
     var emitNoCall: Boolean = false
   }
 

--- a/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
@@ -30,7 +30,7 @@ import org.hammerlab.guacamole.reads.Read
 import org.hammerlab.guacamole.variants.{ AlleleConversions, AlleleEvidence, CalledSomaticAllele }
 import org.hammerlab.guacamole.windowing.SlidingWindow
 import org.hammerlab.guacamole.{ Common, DelayedMessages, DistributedUtil, SparkCommand }
-import org.kohsuke.args4j.{ Option => Opt }
+import org.kohsuke.args4j.{ Option => Args4jOption }
 
 /**
  * Simple subtraction based somatic variant caller
@@ -46,7 +46,7 @@ object SomaticStandard {
 
   protected class Arguments extends SomaticCallerArgs with PileupFilterArguments with SomaticGenotypeFilterArguments {
 
-    @Opt(name = "--odds", usage = "Minimum log odds threshold for possible variant candidates")
+    @Args4jOption(name = "--odds", usage = "Minimum log odds threshold for possible variant candidates")
     var oddsThreshold: Int = 20
 
   }

--- a/src/main/scala/org/hammerlab/guacamole/commands/VAFHistogram.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/VAFHistogram.scala
@@ -11,7 +11,7 @@ import org.hammerlab.guacamole.filters.PileupFilter.PileupFilterArguments
 import org.hammerlab.guacamole.pileup.Pileup
 import org.hammerlab.guacamole.reads.Read.InputFilters
 import org.hammerlab.guacamole.reads.{ MappedRead, Read }
-import org.kohsuke.args4j.{ Argument, Option => Opt }
+import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
 
 /**
  * VariantLocus is locus and the variant allele frequency at that locus
@@ -41,23 +41,23 @@ object VAFHistogram {
 
   protected class Arguments extends DistributedUtil.Arguments with PileupFilterArguments {
 
-    @Opt(name = "--out", required = false,
+    @Args4jOption(name = "--out", required = false,
       usage = "Path to save the variant allele frequency histogram. (Print to screen if not provided)")
     var output: String = ""
 
-    @Opt(name = "--bins", required = false,
+    @Args4jOption(name = "--bins", required = false,
       usage = "Number of bins for the variant allele frequency histogram (Default: 20)")
     var bins: Int = 20
 
-    @Opt(name = "--cluster", required = false,
+    @Args4jOption(name = "--cluster", required = false,
       usage = "Cluster the variant allele frequencies using a Gaussian mixture model")
     var cluster: Boolean = false
 
-    @Opt(name = "--num-clusters", required = false, depends = Array("--cluster"),
+    @Args4jOption(name = "--num-clusters", required = false, depends = Array("--cluster"),
       usage = "Number of clusters for the Gaussian mixture model (Default: 3)")
     var numClusters: Int = 3
 
-    @Opt(name = "--samplePercent", usage = "Percent of variant to use for the calculations (Default: 25)")
+    @Args4jOption(name = "--samplePercent", usage = "Percent of variant to use for the calculations (Default: 25)")
     var samplePercent: Int = 25
 
     @Argument(required = true, multiValued = true,

--- a/src/main/scala/org/hammerlab/guacamole/filters/GenotypeFilter.scala
+++ b/src/main/scala/org/hammerlab/guacamole/filters/GenotypeFilter.scala
@@ -22,7 +22,7 @@ import org.apache.spark.rdd.RDD
 import org.hammerlab.guacamole.Common
 import org.hammerlab.guacamole.Common.Arguments.Base
 import org.hammerlab.guacamole.variants.{ CalledAllele, AlleleEvidence }
-import org.kohsuke.args4j.Option
+import org.kohsuke.args4j.{ Option => Args4jOption }
 
 /**
  * Filter to remove genotypes where the likelihood is low
@@ -120,19 +120,19 @@ object GenotypeFilter {
 
   trait GenotypeFilterArguments extends Base {
 
-    @Option(name = "--min-read-depth", usage = "Minimum number of reads for a genotype call")
+    @Args4jOption(name = "--min-read-depth", usage = "Minimum number of reads for a genotype call")
     var minReadDepth: Int = 0
 
-    @Option(name = "--max-read-depth", usage = "Maximum number of reads for a genotype call")
+    @Args4jOption(name = "--max-read-depth", usage = "Maximum number of reads for a genotype call")
     var maxReadDepth: Int = Int.MaxValue
 
-    @Option(name = "--min-alternate-read-depth", usage = "Minimum number of reads with alternate allele for a genotype call")
+    @Args4jOption(name = "--min-alternate-read-depth", usage = "Minimum number of reads with alternate allele for a genotype call")
     var minAlternateReadDepth: Int = 0
 
-    @Option(name = "--debug-genotype-filters", usage = "Print count of genotypes after each filtering step")
+    @Args4jOption(name = "--debug-genotype-filters", usage = "Print count of genotypes after each filtering step")
     var debugGenotypeFilters = false
 
-    @Option(name = "--min-likelihood", usage = "Minimum Phred-scaled likelihood. Default: 0 (off)")
+    @Args4jOption(name = "--min-likelihood", usage = "Minimum Phred-scaled likelihood. Default: 0 (off)")
     var minLikelihood: Int = 0
 
   }

--- a/src/main/scala/org/hammerlab/guacamole/filters/PileupFilter.scala
+++ b/src/main/scala/org/hammerlab/guacamole/filters/PileupFilter.scala
@@ -20,7 +20,7 @@ package org.hammerlab.guacamole.filters
 
 import org.hammerlab.guacamole.Common.Arguments.Base
 import org.hammerlab.guacamole.pileup.{ Pileup, PileupElement }
-import org.kohsuke.args4j.Option
+import org.kohsuke.args4j.{ Option => Args4jOption }
 
 /**
  * Filter to remove pileups which may produce multi-allelic variant calls.
@@ -47,13 +47,13 @@ object PileupFilter {
 
   trait PileupFilterArguments extends Base {
 
-    @Option(name = "--min-mapq", usage = "Minimum read mapping quality for a read (Phred-scaled). (default: 1)")
+    @Args4jOption(name = "--min-mapq", usage = "Minimum read mapping quality for a read (Phred-scaled). (default: 1)")
     var minAlignmentQuality: Int = 1
-    
-    @Option(name = "--filter-multi-allelic", usage = "Filter any pileups > 2 bases considered")
+
+    @Args4jOption(name = "--filter-multi-allelic", usage = "Filter any pileups > 2 bases considered")
     var filterMultiAllelic: Boolean = false
 
-    @Option(name = "--min-edge-distance", usage = "Filter reads where the base in the pileup is closer than minEdgeDistance to the (directional) end of the read")
+    @Args4jOption(name = "--min-edge-distance", usage = "Filter reads where the base in the pileup is closer than minEdgeDistance to the (directional) end of the read")
     var minEdgeDistance: Int = 0
 
   }

--- a/src/main/scala/org/hammerlab/guacamole/filters/SomaticGenotypeFilter.scala
+++ b/src/main/scala/org/hammerlab/guacamole/filters/SomaticGenotypeFilter.scala
@@ -22,7 +22,7 @@ import org.apache.spark.rdd.RDD
 import org.hammerlab.guacamole.Common.Arguments.Base
 import org.hammerlab.guacamole._
 import org.hammerlab.guacamole.variants.{ CalledAllele, AlleleEvidence, CalledSomaticAllele }
-import org.kohsuke.args4j.Option
+import org.kohsuke.args4j.{ Option => Args4jOption }
 
 /**
  * Filter to remove genotypes where the somatic likelihood is low
@@ -220,34 +220,34 @@ object SomaticGenotypeFilter {
 
   trait SomaticGenotypeFilterArguments extends Base {
 
-    @Option(name = "--min-likelihood", usage = "Minimum likelihood (Phred-scaled)")
+    @Args4jOption(name = "--min-likelihood", usage = "Minimum likelihood (Phred-scaled)")
     var minLikelihood: Int = 0
 
-    @Option(name = "--min-vaf", usage = "Minimum variant allele frequency")
+    @Args4jOption(name = "--min-vaf", usage = "Minimum variant allele frequency")
     var minVAF: Int = 0
 
-    @Option(name = "--min-lod", metaVar = "X", usage = "Make a call if the log odds of variant is greater than this value (Phred-scaled)")
+    @Args4jOption(name = "--min-lod", metaVar = "X", usage = "Make a call if the log odds of variant is greater than this value (Phred-scaled)")
     var minLOD: Int = 0
 
-    @Option(name = "--min-average-mapping-quality", metaVar = "X", usage = "Make a call average mapping quality of reads is greater than this value")
+    @Args4jOption(name = "--min-average-mapping-quality", metaVar = "X", usage = "Make a call average mapping quality of reads is greater than this value")
     var minAverageMappingQuality: Int = 0
 
-    @Option(name = "--min-average-base-quality", metaVar = "X", usage = "Make a call average base quality of bases in the pileup is greater than this value")
+    @Args4jOption(name = "--min-average-base-quality", metaVar = "X", usage = "Make a call average base quality of bases in the pileup is greater than this value")
     var minAverageBaseQuality: Int = 0
 
-    @Option(name = "--min-tumor-read-depth", usage = "Minimum number of reads in tumor sample for a genotype call")
+    @Args4jOption(name = "--min-tumor-read-depth", usage = "Minimum number of reads in tumor sample for a genotype call")
     var minTumorReadDepth: Int = 0
 
-    @Option(name = "--min-normal-read-depth", usage = "Minimum number of reads in normal sample for a genotype call")
+    @Args4jOption(name = "--min-normal-read-depth", usage = "Minimum number of reads in normal sample for a genotype call")
     var minNormalReadDepth: Int = 0
 
-    @Option(name = "--max-tumor-read-depth", usage = "Maximum number of reads in tumor sample for a genotype call")
+    @Args4jOption(name = "--max-tumor-read-depth", usage = "Maximum number of reads in tumor sample for a genotype call")
     var maxTumorReadDepth: Int = Int.MaxValue
 
-    @Option(name = "--min-tumor-alternate-read-depth", usage = "Minimum number of reads with alternate allele for a genotype call")
+    @Args4jOption(name = "--min-tumor-alternate-read-depth", usage = "Minimum number of reads with alternate allele for a genotype call")
     var minTumorAlternateReadDepth: Int = 0
 
-    @Option(name = "--debug-genotype-filters", usage = "Print count of genotypes after each filtering step")
+    @Args4jOption(name = "--debug-genotype-filters", usage = "Print count of genotypes after each filtering step")
     var debugGenotypeFilters = false
 
   }


### PR DESCRIPTION
This moves all `Option` from `Args4J` to `Args4jOption` to avoid colliding with scala `Option` and to standardize across the codebase.

Closes #306

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/328)
<!-- Reviewable:end -->
