### PR TITLE
Find regions with abnormally large inserts.

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/Guacamole.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Guacamole.scala
@@ -39,7 +39,8 @@ object Guacamole extends Logging {
     GermlineStandard.Caller,
     SomaticStandard.Caller,
     VariantSupport.Caller,
-    VAFHistogram.Caller
+    VAFHistogram.Caller,
+    StructuralVariant.Caller
   )
 
   private def printUsage() = {

--- a/src/main/scala/org/hammerlab/guacamole/commands/StructuralVariantCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/StructuralVariantCaller.scala
@@ -14,6 +14,10 @@ import scala.collection.mutable.ArrayBuffer
  * This currently looks for regions with abnormally large insert sizes. This typically indicates
  * that there's been a large deletion.
  *
+ * It does this by finding the average insert size of all mate pairs which overlap each 25-base pair "block" of the
+ * genome. If this average is significantly different than the average insert size genome-wide, then it's evidence that
+ * there may be a structural variant.
+ * 
  * The output is a text file of genomic ranges where there's some evidence of an SV.
  */
 object StructuralVariant {

--- a/src/main/scala/org/hammerlab/guacamole/commands/StructuralVariantCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/StructuralVariantCaller.scala
@@ -1,0 +1,133 @@
+package org.hammerlab.guacamole.commands
+
+import org.apache.spark.SparkContext
+import org.apache.spark.util.StatCounter
+import org.hammerlab.guacamole.{ DistributedUtil, SparkCommand, Common }
+import org.hammerlab.guacamole.reads.{ Read, MappedRead }
+import org.kohsuke.args4j.{ Option => Args4JOption }
+
+import scala.collection.mutable.ArrayBuffer
+
+/**
+ * Structural Variant caller
+ *
+ * This currently looks for regions with abnormally large insert sizes. This typically indicates
+ * that there's been a large deletion.
+ *
+ * The output is a text file of genomic ranges where there's some evidence of an SV.
+ */
+object StructuralVariant {
+
+  val MAX_INSERT_SIZE = 25000
+  val BLOCK_SIZE = 25
+
+  protected class Arguments extends Common.Arguments.Reads with DistributedUtil.Arguments {
+    @Args4JOption(name = "--filter-contig", usage = "Filter to alignments where either mate is in this contig.")
+    var filterContig: String = ""
+
+    @Args4JOption(name = "--output", usage = "Path to output text file.")
+    var output: String = ""
+  }
+
+  case class Location(
+    contig: String,
+    position: Long) {
+  }
+
+  case class GenomeRange(
+    contig: String,
+    start: Long,
+    stop: Long
+  )
+
+  object Caller extends SparkCommand[Arguments] {
+    override val name = "structural-variant"
+    override val description = "Find structural variants, i.e. large insertions or deletions, inversions and translocations."
+
+    def isFirstInPair(read: MappedRead) = {
+      read.matePropertiesOpt match {
+        case Some(mateProps) => mateProps.isFirstInPair
+        case None            => false
+      }
+    }
+
+    // The sign of inferredInsertSize follows the orientation of the read. This returns
+    // an insert size which is positive in the common case, regardless of the orientation.
+    def orientedInsertSize(r: MappedRead): Option[Int] = {
+      r.matePropertiesOpt.flatMap(_.inferredInsertSize.map(x => x * (if (r.isPositiveStrand) { 1 } else { -1 })))
+    }
+
+    // Coalesce sequences of values separated by blockSize into single ranges.
+    // The sequence of values must be sorted.
+    def coalesceAdjacent(xs: IndexedSeq[Long], blockSize: Long): Iterator[(Long, Long)] = {
+      val rangeStarts = ArrayBuffer(0)
+      for (i <- 1 until xs.length) {
+        if (xs(i - 1) + blockSize != xs(i)) {
+          rangeStarts += i
+        }
+      }
+      rangeStarts += xs.length
+
+      rangeStarts.sliding(2).map(items => {
+        val startIdx = items(0)
+        val nextStartIdx = items(1)
+        (xs(startIdx), xs(nextStartIdx - 1))
+      })
+    }
+
+    // Returns a sequence of all blocks which overlap the read, its mate or the insert between them.
+    def matedReadBlocks(r: MappedRead): Seq[Long] = {
+      val mateStart = r.matePropertiesOpt.map(_.mateStart.getOrElse(r.start)).getOrElse(r.start)
+      val start = List(r.start, r.end, mateStart).min
+      val roundedStart = (1.0 * start / BLOCK_SIZE).toLong * BLOCK_SIZE
+      val insertSize = orientedInsertSize(r).getOrElse(0)
+
+      (roundedStart to (roundedStart + insertSize) by BLOCK_SIZE)
+    }
+
+    override def run(args: Arguments, sc: SparkContext): Unit = {
+      val readSet = Common.loadReadsFromArguments(args, sc, Read.InputFilters(nonDuplicate = true))
+      val pairedMappedReads = readSet.mappedReads.filter(_.isPaired)
+      val firstInPair = pairedMappedReads.filter(isFirstInPair)
+
+      // Pare down to mate pairs which aren't highly displaced & aren't inverted.
+      val readsInRange = firstInPair.filter(r => {
+        val insertSize = orientedInsertSize(r).getOrElse(0)
+        (insertSize > 0) && (insertSize < MAX_INSERT_SIZE)
+      })
+      readsInRange.persist()
+
+      val insertSizes = readsInRange.flatMap(orientedInsertSize)
+      val insertStats = insertSizes.stats()
+      println("Stats on inferredInsertSize: " + insertStats)
+
+      // Create a map from (block) -> [insert sizes]
+      // TODO: take greater advantage of data locality than .groupByKey() does?
+      val insertsByBlock = readsInRange.flatMap(r => {
+        val insertSize = orientedInsertSize(r).getOrElse(0)
+        matedReadBlocks(r).map(pos => (Location(r.referenceContig, pos), insertSize))
+      }).groupByKey()
+
+      // Find blocks where the average insert size is 2 sigma from the average for the whole genome.
+      val exceptionalThreshold = insertStats.mean + 2 * insertStats.stdev
+      val exceptionalBlocks = insertsByBlock.filter(pair => {
+        val inserts = pair._2
+        val stats = new StatCounter()
+        stats.merge(inserts.map(_.toDouble))
+        (stats.mean > exceptionalThreshold)
+      })
+
+      // Group adjacent blocks on the same contig
+      val exceptionalRanges = exceptionalBlocks.groupBy(_._1.contig).flatMap(kv => {
+        val contig = kv._1
+        val locations = kv._2.map(_._1.position).toArray.sorted
+        coalesceAdjacent(locations, BLOCK_SIZE).map(x => GenomeRange(contig, x._1, x._2))
+      })
+
+      println("Number of exceptional blocks: " + exceptionalBlocks.count())
+      exceptionalRanges.coalesce(1).saveAsTextFile(args.output)
+    }
+
+  }
+
+}

--- a/src/test/scala/org/hammerlab/guacamole/commands/StructuralVariantCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/StructuralVariantCallerSuite.scala
@@ -6,10 +6,10 @@ import org.scalatest.Matchers
 class StructuralVariantCallerSuite extends GuacFunSuite with Matchers {
   test("coalesce intervals") {
     val nums = Array(0L, 10L, 20L, 30L,
-                     50L,
-                     70L, 80L,
-                     100L, 110L, 120L,
-                     150L)
+      50L,
+      70L, 80L,
+      100L, 110L, 120L,
+      150L)
     val ranges = StructuralVariant.Caller.coalesceAdjacent(nums, 10)
     assert(ranges.toList === List((0L, 30L), (50L, 50L), (70L, 80L), (100L, 120L), (150L, 150L)))
   }

--- a/src/test/scala/org/hammerlab/guacamole/commands/StructuralVariantCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/StructuralVariantCallerSuite.scala
@@ -1,0 +1,16 @@
+package org.hammerlab.guacamole.commands
+
+import org.hammerlab.guacamole.util.GuacFunSuite
+import org.scalatest.Matchers
+
+class StructuralVariantCallerSuite extends GuacFunSuite with Matchers {
+  test("coalesce intervals") {
+    val nums = Array(0L, 10L, 20L, 30L,
+                     50L,
+                     70L, 80L,
+                     100L, 110L, 120L,
+                     150L)
+    val ranges = StructuralVariant.Caller.coalesceAdjacent(nums, 10)
+    assert(ranges.toList === List((0L, 30L), (50L, 50L), (70L, 80L), (100L, 120L), (150L, 150L)))
+  }
+}


### PR DESCRIPTION
This is pretty simple and will conflict with @arahuja's #325, but it is at least able to find interesting regions  in synth4.

For example, here's one of the output lines when I run it on synth4 tumor:

    GenomeRange(21,10744200,10760575)

and the corresponding view in IGV:

![large gaps](https://cloud.githubusercontent.com/assets/98301/8833677/1615b138-307e-11e5-8131-fd58cec3e95a.png)

it's sorted by insert size, so you're just seeing the big gaps. But there does seem to be some evidence for a large, consistent deletion.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/334)
<!-- Reviewable:end -->
