### PR TITLE
 Add referenceName to Pileup and fix warning

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/DistributedUtil.scala
+++ b/src/main/scala/org/hammerlab/guacamole/DistributedUtil.scala
@@ -257,7 +257,7 @@ object DistributedUtil extends Logging {
     val locus = window.currentLocus
     val referenceBase = Pileup.referenceBaseAtLocus(window.currentRegions(), locus)
     existing match {
-      case None         => Pileup(window.currentRegions(), locus, referenceBase)
+      case None         => Pileup(window.currentRegions(), window.referenceName, locus, referenceBase)
       case Some(pileup) => pileup.atGreaterLocus(locus, referenceBase, window.newRegions.iterator)
     }
   }
@@ -466,7 +466,7 @@ object DistributedUtil extends Logging {
 
     taskLoci.contigs.flatMap(contig => {
       val regionIterator: PerSample[Iterator[M]] = regionSplitByContigPerSample.map(_.next(contig))
-      val windows: PerSample[SlidingWindow[M]] = regionIterator.map(SlidingWindow[M](halfWindowSize, _))
+      val windows: PerSample[SlidingWindow[M]] = regionIterator.map(SlidingWindow[M](contig, halfWindowSize, _))
       generateFromWindows(taskLoci.onContig(contig), windows)
     }).iterator
   }

--- a/src/main/scala/org/hammerlab/guacamole/ReadSet.scala
+++ b/src/main/scala/org/hammerlab/guacamole/ReadSet.scala
@@ -53,8 +53,8 @@ case class ReadSet(
 
   lazy val mappedPairedReads: RDD[PairedRead[MappedRead]] = reads.flatMap(read =>
     read match {
-      case rp if rp.isMapped => Some(rp.asInstanceOf[PairedRead[MappedRead]])
-      case _                 => None
+      case rp: PairedRead[_] if rp.isMapped => Some(rp.asInstanceOf[PairedRead[MappedRead]])
+      case _                                => None
     }
   )
 

--- a/src/main/scala/org/hammerlab/guacamole/ReadSet.scala
+++ b/src/main/scala/org/hammerlab/guacamole/ReadSet.scala
@@ -53,8 +53,8 @@ case class ReadSet(
 
   lazy val mappedPairedReads: RDD[PairedRead[MappedRead]] = reads.flatMap(read =>
     read match {
-      case rp: PairedRead[MappedRead] => Some(rp)
-      case _                          => None
+      case rp if rp.isMapped => Some(rp.asInstanceOf[PairedRead[MappedRead]])
+      case _                 => None
     }
   )
 

--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineStandardCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineStandardCaller.scala
@@ -99,7 +99,7 @@ object GermlineStandard {
             Seq.empty
           } else {
             val genotypeLikelihoods = Likelihood.likelihoodsOfAllPossibleGenotypesFromPileup(
-              Pileup(samplePileup.locus, samplePileup.referenceBase, filteredPileupElements),
+              Pileup(samplePileup.referenceName, samplePileup.locus, samplePileup.referenceBase, filteredPileupElements),
               logSpace = true,
               normalize = true)
             val mostLikelyGenotypeAndProbability = genotypeLikelihoods.maxBy(_._2)

--- a/src/main/scala/org/hammerlab/guacamole/filters/PileupFilter.scala
+++ b/src/main/scala/org/hammerlab/guacamole/filters/PileupFilter.scala
@@ -85,6 +85,6 @@ object PileupFilter {
       elements = EdgeBaseFilter(elements, minEdgeDistance)
     }
 
-    Pileup(pileup.locus, pileup.referenceBase, elements)
+    Pileup(pileup.referenceName, pileup.locus, pileup.referenceBase, elements)
   }
 }

--- a/src/main/scala/org/hammerlab/guacamole/pileup/Pileup.scala
+++ b/src/main/scala/org/hammerlab/guacamole/pileup/Pileup.scala
@@ -27,23 +27,22 @@ import org.hammerlab.guacamole.variants.{ Allele, Genotype }
  * locus. Each [[PileupElement]] specifies the base read at the given locus in a particular read. It also keeps track
  * of the read itself and the offset of the base in the read.
  *
+ * @param referenceName The contig name for all elements in this pileup.
  * @param locus The locus on the reference genome
  * @param referenceBase The reference base at [[locus]] on the reference genome
  * @param elements Sequence of [[PileupElement]] instances giving the sequenced bases that align to a particular
  *                 reference locus, in arbitrary order.
  */
-case class Pileup(locus: Long, referenceBase: Byte, elements: Seq[PileupElement]) {
+case class Pileup(referenceName: String, locus: Long, referenceBase: Byte, elements: Seq[PileupElement]) {
   /** The first element in the pileup. */
   lazy val head = {
     assume(elements.nonEmpty, "Empty pileup")
     elements.head
   }
 
-  /** The contig name for all elements in this pileup. */
-  lazy val referenceName: String = head.read.referenceContig
-
   assume(elements.forall(_.read.referenceContig == referenceName),
-    "Reads in pileup have mismatching reference names")
+    "Pileup reference name '%s' does not match read reference name(s): %s".format(
+      referenceName, elements.map(_.read.referenceContig).filter(_ != referenceName).mkString(",")))
   assume(elements.forall(_.locus == locus), "Reads in pileup have mismatching loci")
 
   lazy val distinctAlleles: Seq[Allele] = elements.map(_.allele).distinct.sorted.toIndexedSeq
@@ -56,7 +55,7 @@ case class Pileup(locus: Long, referenceBase: Byte, elements: Seq[PileupElement]
    */
   lazy val bySample: Map[String, Pileup] = {
     elements.groupBy(element => Option(element.read.sampleName).map(_.toString).getOrElse("default")).map({
-      case (sample, elems) => (sample, Pileup(locus, referenceBase, elems))
+      case (sample, elems) => (sample, Pileup(referenceName, locus, referenceBase, elems))
     })
   }
 
@@ -66,7 +65,7 @@ case class Pileup(locus: Long, referenceBase: Byte, elements: Seq[PileupElement]
    */
   lazy val byToken: Map[Int, Pileup] = {
     elements.groupBy(element => element.read.token).map({
-      case (token, elems) => (token, Pileup(locus, referenceBase, elems))
+      case (token, elems) => (token, Pileup(referenceName, locus, referenceBase, elems))
     })
   }
 
@@ -106,7 +105,7 @@ case class Pileup(locus: Long, referenceBase: Byte, elements: Seq[PileupElement]
     if (elements.isEmpty && newReads.isEmpty) {
       // Optimization for common case.
       // If there are no reads, we won't know what the reference base is
-      Pileup(newLocus, newReferenceBase, Vector.empty[PileupElement])
+      Pileup(referenceName, newLocus, newReferenceBase, Vector.empty[PileupElement])
     } else {
       // This code gets called many times. We are using while loops for performance.
       val builder = Vector.newBuilder[PileupElement]
@@ -127,7 +126,7 @@ case class Pileup(locus: Long, referenceBase: Byte, elements: Seq[PileupElement]
       }
 
       val newPileupElements = builder.result
-      Pileup(newLocus, newReferenceBase, newPileupElements)
+      Pileup(referenceName, newLocus, newReferenceBase, newPileupElements)
     }
   }
 
@@ -172,16 +171,16 @@ object Pileup {
    * @param referenceBase The reference base at [[locus]]
    * @return A [[Pileup]] at the given locus.
    */
-  def apply(reads: Seq[MappedRead], locus: Long, referenceBase: Byte): Pileup = {
+  def apply(reads: Seq[MappedRead], referenceName: String, locus: Long, referenceBase: Byte): Pileup = {
     //TODO: Is this call to overlaps locus necessary?
     val elements = reads.filter(_.overlapsLocus(locus)).map(PileupElement(_, locus, referenceBase))
-    Pileup(locus, referenceBase, elements)
+    Pileup(referenceName, locus, referenceBase, elements)
   }
 
-  def apply(reads: Seq[MappedRead], locus: Long): Pileup = {
+  def apply(reads: Seq[MappedRead], referenceName: String, locus: Long): Pileup = {
     val overlappingReads = reads.filter(_.overlapsLocus(locus))
     val referenceBase = referenceBaseAtLocus(overlappingReads, locus)
     val elements = overlappingReads.map(PileupElement(_, locus, referenceBase))
-    Pileup(locus, referenceBase, elements)
+    Pileup(referenceName, locus, referenceBase, elements)
   }
 }

--- a/src/main/scala/org/hammerlab/guacamole/windowing/SlidingWindow.scala
+++ b/src/main/scala/org/hammerlab/guacamole/windowing/SlidingWindow.scala
@@ -42,7 +42,8 @@ import scala.collection.mutable
  *
  * @param rawSortedRegions Iterator of regions, sorted by the aligned start locus.
  */
-case class SlidingWindow[Region <: HasReferenceRegion](halfWindowSize: Long,
+case class SlidingWindow[Region <: HasReferenceRegion](referenceName: String,
+                                                       halfWindowSize: Long,
                                                        rawSortedRegions: Iterator[Region]) extends Logging {
   /** The locus currently under consideration. */
   var currentLocus = -1L
@@ -50,11 +51,9 @@ case class SlidingWindow[Region <: HasReferenceRegion](halfWindowSize: Long,
   /** The new regions that were added to currentRegions as a result of the most recent call to setCurrentLocus. */
   var newRegions: Seq[Region] = Seq.empty
 
-  private var referenceName: Option[String] = None
   private var mostRecentRegionStart: Long = 0
   private val sortedRegions: BufferedIterator[Region] = rawSortedRegions.map(region => {
-    if (referenceName.isEmpty) referenceName = Some(region.referenceContig)
-    require(region.referenceContig == referenceName.get, "Regions must have the same reference name")
+    require(region.referenceContig == referenceName, "Regions must have the same reference name")
     require(region.start >= mostRecentRegionStart, "Regions must be sorted by start locus")
     mostRecentRegionStart = region.start
 

--- a/src/test/scala/org/hammerlab/guacamole/commands/GermlineThresholdCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/GermlineThresholdCallerSuite.scala
@@ -32,7 +32,7 @@ class GermlineThresholdCallerSuite extends GuacFunSuite with Matchers {
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1),
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1),
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1))
-    val pileup = Pileup(reads, 1)
+    val pileup = Pileup(reads, "chr1", 1)
     val genotypes = GermlineThreshold.Caller.callVariantsAtLocus(pileup, 0)
     genotypes.foreach(gt => assert(gt.getAlleles.toList === List(GenotypeAllele.Ref, GenotypeAllele.Ref)))
   }
@@ -42,7 +42,7 @@ class GermlineThresholdCallerSuite extends GuacFunSuite with Matchers {
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1),
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1),
       TestUtil.makeRead("GCGATCGA", "8M", "0T7", 1))
-    val pileup = Pileup(reads, 1)
+    val pileup = Pileup(reads, "chr1", 1)
     val genotypes = GermlineThreshold.Caller.callVariantsAtLocus(pileup, 0)
     genotypes.foreach(gt => assert(gt.getAlleles.toList === List(GenotypeAllele.Ref, GenotypeAllele.Alt)))
 
@@ -53,7 +53,7 @@ class GermlineThresholdCallerSuite extends GuacFunSuite with Matchers {
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1),
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1),
       TestUtil.makeRead("GCGATCGA", "8M", "0T7", 1))
-    val pileup = Pileup(reads, 1)
+    val pileup = Pileup(reads, "chr1", 1)
     val genotypes = GermlineThreshold.Caller.callVariantsAtLocus(pileup, 30)
     genotypes.foreach(gt => assert(gt.getAlleles.toList === List(GenotypeAllele.Ref, GenotypeAllele.Alt)))
 
@@ -64,7 +64,7 @@ class GermlineThresholdCallerSuite extends GuacFunSuite with Matchers {
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1),
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1),
       TestUtil.makeRead("GCGATCGA", "8M", "0T7", 1))
-    val pileup = Pileup(reads, 1)
+    val pileup = Pileup(reads, "chr1", 1)
     val genotypes = GermlineThreshold.Caller.callVariantsAtLocus(pileup, 50)
     genotypes.foreach(gt => assert(gt.getAlleles.toList === List(GenotypeAllele.Ref, GenotypeAllele.Ref)))
   }
@@ -74,7 +74,7 @@ class GermlineThresholdCallerSuite extends GuacFunSuite with Matchers {
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1),
       TestUtil.makeRead("GCGATCGA", "8M", "0T7", 1),
       TestUtil.makeRead("GCGATCGA", "8M", "0T7", 1))
-    val pileup = Pileup(reads, 1)
+    val pileup = Pileup(reads, "chr1", 1)
     val genotypes = GermlineThreshold.Caller.callVariantsAtLocus(pileup, 50, emitRef = false)
     genotypes.foreach(gt => assert(gt.getAlleles.toList === List(GenotypeAllele.Alt, GenotypeAllele.Alt)))
 
@@ -89,7 +89,7 @@ class GermlineThresholdCallerSuite extends GuacFunSuite with Matchers {
       TestUtil.makeRead("TGGATCGA", "8M", "1C6", 1),
       TestUtil.makeRead("TGGATCGA", "8M", "1C6", 1),
       TestUtil.makeRead("TGGATCGA", "8M", "1C6", 1))
-    val pileup = Pileup(reads, 2)
+    val pileup = Pileup(reads, "chr1", 2)
     val genotypes = GermlineThreshold.Caller.callVariantsAtLocus(pileup, 50, emitRef = false)
 
     genotypes.length should be(1)
@@ -104,7 +104,7 @@ class GermlineThresholdCallerSuite extends GuacFunSuite with Matchers {
   sparkTest("heterozygous deletion") {
     val filters = Read.InputFilters(mapped = true, nonDuplicate = true, passedVendorQualityChecks = true)
     val reads = TestUtil.loadReads(sc, "synthetic.challenge.set1.normal.v2.withMDTags.chr2.syn1fp.sam", filters = filters).mappedReads.collect()
-    val pileup = Pileup(reads, 16050070)
+    val pileup = Pileup(reads, "2", 16050070)
 
     val genotypes = GermlineThreshold.Caller.callVariantsAtLocus(pileup, 8 /* 8% variant allele fraction */ , emitRef = false)
 

--- a/src/test/scala/org/hammerlab/guacamole/commands/SomaticStandardCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/SomaticStandardCallerSuite.scala
@@ -28,10 +28,10 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 
 class SomaticStandardCallerSuite extends GuacFunSuite with Matchers with TableDrivenPropertyChecks {
 
-  def loadPileup(filename: String, locus: Long = 0): Pileup = {
+  def loadPileup(filename: String, referenceName: String, locus: Long = 0): Pileup = {
     val records = TestUtil.loadReads(sc, filename).mappedReads
     val localReads = records.collect
-    Pileup(localReads, locus)
+    Pileup(localReads, referenceName, locus)
   }
 
   /**
@@ -120,14 +120,14 @@ class SomaticStandardCallerSuite extends GuacFunSuite with Matchers with TableDr
       TestUtil.makeRead("TCGATCGA", "8M", "8", 0),
       TestUtil.makeRead("TCGATCGA", "8M", "8", 0)
     )
-    val normalPileup = Pileup(normalReads, 2)
+    val normalPileup = Pileup(normalReads, "chr1", 2)
 
     val tumorReads = Seq(
       TestUtil.makeRead("TCGGTCGA", "8M", "3G4", 0),
       TestUtil.makeRead("TCGGTCGA", "8M", "3G4", 0),
       TestUtil.makeRead("TCGGTCGA", "8M", "3G4", 0)
     )
-    val tumorPileup = Pileup(tumorReads, 2)
+    val tumorPileup = Pileup(tumorReads, "chr1", 2)
 
     SomaticStandard.Caller.findPotentialVariantAtLocus(tumorPileup, normalPileup, oddsThreshold = 2).size should be(0)
   }
@@ -137,13 +137,13 @@ class SomaticStandardCallerSuite extends GuacFunSuite with Matchers with TableDr
       TestUtil.makeRead("TCGATCGA", "8M", "8", 0),
       TestUtil.makeRead("TCGATCGA", "8M", "8", 0),
       TestUtil.makeRead("TCGATCGA", "8M", "8", 0))
-    val normalPileup = Pileup(normalReads, 2)
+    val normalPileup = Pileup(normalReads, "chr1", 2)
 
     val tumorReads = Seq(
       TestUtil.makeRead("TCGTCGA", "3M1D4M", "3^A4", 0),
       TestUtil.makeRead("TCGTCGA", "3M1D4M", "3^A4", 0),
       TestUtil.makeRead("TCGTCGA", "3M1D4M", "3^A4", 0))
-    val tumorPileup = Pileup(tumorReads, 2)
+    val tumorPileup = Pileup(tumorReads, "chr1", 2)
 
     val alleles = SomaticStandard.Caller.findPotentialVariantAtLocus(tumorPileup, normalPileup, oddsThreshold = 2)
     alleles.size should be(1)
@@ -159,14 +159,14 @@ class SomaticStandardCallerSuite extends GuacFunSuite with Matchers with TableDr
       TestUtil.makeRead("TCGAAGCTTCGAAGCT", "16M", "16", 0),
       TestUtil.makeRead("TCGAAGCTTCGAAGCT", "16M", "16", 0)
     )
-    val normalPileup = Pileup(normalReads, 4)
+    val normalPileup = Pileup(normalReads, "chr1", 4)
 
     val tumorReads = Seq(
       TestUtil.makeRead("TCGAAAAGCT", "5M6D5M", "5^GCTTCG5", 0),
       TestUtil.makeRead("TCGAAAAGCT", "5M6D5M", "5^GCTTCG5", 0),
       TestUtil.makeRead("TCGAAAAGCT", "5M6D5M", "5^GCTTCG5", 0)
     )
-    val tumorPileup = Pileup(tumorReads, 4)
+    val tumorPileup = Pileup(tumorReads, "chr1", 4)
 
     val alleles = SomaticStandard.Caller.findPotentialVariantAtLocus(tumorPileup, normalPileup, oddsThreshold = 2)
     alleles.size should be(1)
@@ -182,14 +182,14 @@ class SomaticStandardCallerSuite extends GuacFunSuite with Matchers with TableDr
       TestUtil.makeRead("TCGATCGA", "8M", "8", 0),
       TestUtil.makeRead("TCGATCGA", "8M", "8", 0)
     )
-    val normalPileup = Pileup(normalReads, 2)
+    val normalPileup = Pileup(normalReads, "chr1", 2)
 
     val tumorReads = Seq(
       TestUtil.makeRead("TCGAGTCGA", "4M1I4M", "8", 0),
       TestUtil.makeRead("TCGAGTCGA", "4M1I4M", "8", 0),
       TestUtil.makeRead("TCGAGTCGA", "4M1I4M", "8", 0)
     )
-    val tumorPileup = Pileup(tumorReads, 3)
+    val tumorPileup = Pileup(tumorReads, "chr1", 3)
 
     val alleles = SomaticStandard.Caller.findPotentialVariantAtLocus(tumorPileup, normalPileup, oddsThreshold = 2)
     alleles.size should be(1)
@@ -213,7 +213,7 @@ class SomaticStandardCallerSuite extends GuacFunSuite with Matchers with TableDr
     )
 
     val alleles = SomaticStandard.Caller.findPotentialVariantAtLocus(
-      Pileup(tumorReads, 3), Pileup(normalReads, 3), oddsThreshold = 2
+      Pileup(tumorReads, "chr1", 3), Pileup(normalReads, "chr1", 3), oddsThreshold = 2
     )
     alleles.size should be(1)
 
@@ -241,12 +241,12 @@ class SomaticStandardCallerSuite extends GuacFunSuite with Matchers with TableDr
       TestUtil.makeRead("TCATCTCAAAAGAGATCGA", "2M2D1M2I2M4I2M2D6M", "2^GA5^TC6", 10)
     )
 
-    def testLocus(locus: Int, refBases: String, altBases: String) = {
-      val tumorPileup = Pileup(tumorReads, locus)
-      val normalPileup = Pileup(normalReads, locus)
+    def testLocus(referenceName: String, locus: Int, refBases: String, altBases: String) = {
+      val tumorPileup = Pileup(tumorReads, referenceName, locus)
+      val normalPileup = Pileup(normalReads, referenceName, locus)
 
       val alleles = SomaticStandard.Caller.findPotentialVariantAtLocus(
-        Pileup(tumorReads, locus), Pileup(normalReads, locus), oddsThreshold = 2
+        Pileup(tumorReads, referenceName, locus), Pileup(normalReads, referenceName, locus), oddsThreshold = 2
       )
       alleles.size should be(1)
 
@@ -255,10 +255,10 @@ class SomaticStandardCallerSuite extends GuacFunSuite with Matchers with TableDr
       Bases.basesToString(allele.altBases) should be(altBases)
     }
 
-    testLocus(11, "CGA", "C")
-    testLocus(14, "A", "ATC")
-    testLocus(16, "C", "CAAAA")
-    testLocus(18, "ATC", "A")
+    testLocus("chr1", 11, "CGA", "C")
+    testLocus("chr1", 14, "A", "ATC")
+    testLocus("chr1", 16, "C", "CAAAA")
+    testLocus("chr1", 18, "ATC", "A")
   }
 
 }

--- a/src/test/scala/org/hammerlab/guacamole/commands/VariantSupportSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/VariantSupportSuite.scala
@@ -21,7 +21,7 @@ class VariantSupportSuite extends GuacFunSuite with Matchers with TableDrivenPro
       (contig: String, locus: Long, alleleCountMap) =>
         {
           window.setCurrentLocus(locus)
-          val pileup = Pileup(window.currentRegions(), locus, Bases.N)
+          val pileup = Pileup(window.currentRegions(), contig, locus, Bases.N)
           assertAlleleCounts(pileup, alleleCountMap)
         }
     }
@@ -51,19 +51,19 @@ class VariantSupportSuite extends GuacFunSuite with Matchers with TableDrivenPro
 
   sparkTest("read evidence for simple snvs") {
 
-    val pileup = Pileup(gatk_reads, 10008951)
+    val pileup = Pileup(gatk_reads, "20", 10008951)
     assertAlleleCounts(pileup, Map(("A", 1), ("C", 4)))
   }
 
   sparkTest("read evidence for mid-deletion") {
 
-    val pileup = Pileup(gatk_reads, 10006822)
+    val pileup = Pileup(gatk_reads, "20", 10006822)
     assertAlleleCounts(pileup, Map(("", 5), ("C", 1)))
   }
 
   sparkTest("read evidence for simple snvs 2") {
 
-    val pileup = Pileup(gatk_reads, 10009053)
+    val pileup = Pileup(gatk_reads, "20", 10009053)
     assertAlleleCounts(pileup, Map(("AT", 3)))
   }
 
@@ -74,7 +74,7 @@ class VariantSupportSuite extends GuacFunSuite with Matchers with TableDrivenPro
       ("20", 10009053L, Map(("AT", 3)))
     )
 
-    val window = SlidingWindow[MappedRead](0L, gatk_reads.toIterator)
+    val window = SlidingWindow[MappedRead]("20", 0L, gatk_reads.toIterator)
     testAlleleCounts(window, loci: _*)
   }
 
@@ -86,7 +86,7 @@ class VariantSupportSuite extends GuacFunSuite with Matchers with TableDrivenPro
       ("20", 10260442L, Map(("T", 7)))
     )
 
-    val window = SlidingWindow[MappedRead](0L, gatk_reads.toIterator)
+    val window = SlidingWindow[MappedRead]("20", 0L, gatk_reads.toIterator)
     testAlleleCounts(window, loci: _*)
 
   }
@@ -99,7 +99,7 @@ class VariantSupportSuite extends GuacFunSuite with Matchers with TableDrivenPro
       ("20", 10009053L, Map(("AT", 3)))
     )
 
-    val window = SlidingWindow[MappedRead](0L, non_duplicate_gatk_reads.toIterator)
+    val window = SlidingWindow[MappedRead]("20", 0L, non_duplicate_gatk_reads.toIterator)
     testAlleleCounts(window, loci: _*)
 
   }

--- a/src/test/scala/org/hammerlab/guacamole/likelihood/LikelihoodSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/likelihood/LikelihoodSuite.scala
@@ -43,7 +43,7 @@ class LikelihoodSuite extends GuacFunSuite with TableDrivenPropertyChecks with M
   }
 
   def testGenotypeLikelihoods(reads: Seq[MappedRead], genotypesMap: ((Char, Char), Double)*): Unit = {
-    val pileup = Pileup(reads, 1)
+    val pileup = Pileup(reads, reads(0).referenceContig, 1)
     forAll(Table("genotype", genotypesMap: _*)) { pair =>
       TestUtil.assertAlmostEqual(
         Likelihood.likelihoodOfGenotype(
@@ -110,7 +110,7 @@ class LikelihoodSuite extends GuacFunSuite with TableDrivenPropertyChecks with M
       refRead(30)
     )
 
-    val pileup = Pileup(reads, 1)
+    val pileup = Pileup(reads, "chr1", 1)
 
     testLikelihoods(
       Likelihood.likelihoodsOfAllPossibleGenotypesFromPileup(pileup, Likelihood.probabilityCorrectIgnoringAlignment),
@@ -125,7 +125,7 @@ class LikelihoodSuite extends GuacFunSuite with TableDrivenPropertyChecks with M
       altRead(30)
     )
 
-    val pileup = Pileup(reads, 1)
+    val pileup = Pileup(reads, "chr1", 1)
 
     testLikelihoods(
       Likelihood.likelihoodsOfAllPossibleGenotypesFromPileup(pileup, Likelihood.probabilityCorrectIgnoringAlignment),
@@ -143,7 +143,7 @@ class LikelihoodSuite extends GuacFunSuite with TableDrivenPropertyChecks with M
       altRead(30)
     )
 
-    val pileup = Pileup(reads, 1)
+    val pileup = Pileup(reads, "chr1", 1)
 
     testLikelihoods(
       Likelihood.likelihoodsOfAllPossibleGenotypesFromPileup(pileup, Likelihood.probabilityCorrectIgnoringAlignment),
@@ -159,7 +159,7 @@ class LikelihoodSuite extends GuacFunSuite with TableDrivenPropertyChecks with M
       refRead(30)
     )
 
-    val pileup = Pileup(reads, 1)
+    val pileup = Pileup(reads, "chr1", 1)
 
     testLikelihoods(
       Likelihood.likelihoodsOfAllPossibleGenotypesFromPileup(
@@ -177,7 +177,7 @@ class LikelihoodSuite extends GuacFunSuite with TableDrivenPropertyChecks with M
       altRead(30)
     )
 
-    val pileup = Pileup(reads, 1)
+    val pileup = Pileup(reads, "chr1", 1)
 
     testLikelihoods(
       Likelihood.likelihoodsOfAllPossibleGenotypesFromPileup(
@@ -198,7 +198,7 @@ class LikelihoodSuite extends GuacFunSuite with TableDrivenPropertyChecks with M
       altRead(30)
     )
 
-    val pileup = Pileup(reads, 1)
+    val pileup = Pileup(reads, "chr1", 1)
 
     testLikelihoods(
       Likelihood.likelihoodsOfAllPossibleGenotypesFromPileup(

--- a/src/test/scala/org/hammerlab/guacamole/pileup/PileupSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/pileup/PileupSuite.scala
@@ -44,7 +44,7 @@ class PileupSuite extends GuacFunSuite with Matchers with TableDrivenPropertyChe
   def loadPileup(filename: String, locus: Long = 0): Pileup = {
     val records = TestUtil.loadReads(sc, filename).mappedReads
     val localReads = records.collect
-    Pileup(localReads, locus)
+    Pileup(localReads, localReads(0).referenceContig, locus)
   }
 
   sparkTest("create pileup from long insert reads") {
@@ -53,14 +53,14 @@ class PileupSuite extends GuacFunSuite with Matchers with TableDrivenPropertyChe
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1),
       TestUtil.makeRead("TCGACCCTCGA", "4M3I4M", "8", 1))
 
-    val noPileup = Pileup(reads, 0).elements
+    val noPileup = Pileup(reads, "chr1", 0).elements
     assert(noPileup.size === 0)
 
-    val firstPileup = Pileup(reads, 1)
+    val firstPileup = Pileup(reads, "chr1", 1)
     firstPileup.elements.forall(_.isMatch) should be(true)
     firstPileup.elements.forall(_.qualityScore == 31) should be(true)
 
-    val insertPileup = Pileup(reads, 4)
+    val insertPileup = Pileup(reads, "chr1", 4)
     insertPileup.elements.exists(_.isInsertion) should be(true)
     insertPileup.elements.forall(_.qualityScore == 31) should be(true)
 
@@ -75,7 +75,7 @@ class PileupSuite extends GuacFunSuite with Matchers with TableDrivenPropertyChe
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1, "chr1", Some(Seq(10, 15, 20, 25, 10, 15, 20, 25))),
       TestUtil.makeRead("TCGACCCTCGA", "4M3I4M", "8", 1, "chr1", Some(Seq(10, 15, 20, 25, 5, 5, 5, 10, 15, 20, 25))))
 
-    val insertPileup = Pileup(reads, 4)
+    val insertPileup = Pileup(reads, "chr1", 4)
     insertPileup.elements.exists(_.isInsertion) should be(true)
     insertPileup.elements.exists(_.qualityScore == 5) should be(true)
 
@@ -94,10 +94,10 @@ class PileupSuite extends GuacFunSuite with Matchers with TableDrivenPropertyChe
       TestUtil.makeRead("TCGACCCTCGA", "4M3I4M", "8", 1, "chr1", Some(Seq(10, 15, 20, 25, 5, 5, 5, 10, 15, 20, 25)))
     )
 
-    val noPileup = Pileup(reads, 0).elements
+    val noPileup = Pileup(reads, "chr1", 0).elements
     noPileup.size should be(0)
 
-    val pastInsertPileup = Pileup(reads, 5)
+    val pastInsertPileup = Pileup(reads, "chr1", 5)
     pastInsertPileup.elements.foreach(_.isMatch should be(true))
 
     pastInsertPileup.elements.foreach(_.qualityScore should be(10))
@@ -109,7 +109,7 @@ class PileupSuite extends GuacFunSuite with Matchers with TableDrivenPropertyChe
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1),
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1),
       TestUtil.makeRead("TCGACCCTCGA", "4M3I4M", "8", 1))
-    val lastPileup = Pileup(reads, 7)
+    val lastPileup = Pileup(reads, "chr1", 7)
     lastPileup.elements.foreach(e => assertBases(e.sequencedBases, "G"))
     lastPileup.elements.forall(_.isMatch) should be(true)
   }
@@ -121,7 +121,7 @@ class PileupSuite extends GuacFunSuite with Matchers with TableDrivenPropertyChe
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1, "chr1", Some(Seq(10, 15, 20, 25, 10, 15, 20, 25))),
       TestUtil.makeRead("TCGACCCTCGA", "4M3I4M", "8", 1, "chr1", Some(Seq(10, 15, 20, 25, 5, 5, 5, 10, 15, 20, 25))))
 
-    val lastPileup = Pileup(reads, 8)
+    val lastPileup = Pileup(reads, "chr1", 8)
     lastPileup.elements.foreach(e => assertBases(e.sequencedBases, "A"))
     lastPileup.elements.forall(_.sequencedBases.headOption.exists(_ == Bases.A)) should be(true)
 

--- a/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
@@ -166,7 +166,9 @@ object TestUtil extends Matchers {
   def loadTumorNormalPileup(tumorReads: Seq[MappedRead],
                             normalReads: Seq[MappedRead],
                             locus: Long): (Pileup, Pileup) = {
-    (Pileup(tumorReads, locus), Pileup(normalReads, locus))
+    val contig = tumorReads(0).referenceContig
+    assume(normalReads(0).referenceContig == contig)
+    (Pileup(tumorReads, contig, locus), Pileup(normalReads, contig, locus))
   }
 
   def assertAlmostEqual(a: Double, b: Double, epsilon: Double = 1e-12) {

--- a/src/test/scala/org/hammerlab/guacamole/windowing/SlidingWindowSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/windowing/SlidingWindowSuite.scala
@@ -30,7 +30,7 @@ class SlidingWindowSuite extends FunSuite with Matchers {
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1),
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1),
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1))
-    val window = SlidingWindow(2, reads.iterator)
+    val window = SlidingWindow("chr1", 2, reads.iterator)
     window.setCurrentLocus(0)
     assert(window.currentRegions.size === 3)
 
@@ -42,7 +42,7 @@ class SlidingWindowSuite extends FunSuite with Matchers {
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1, "chr1"),
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1, "chr2"),
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1, "chr3"))
-    val window = SlidingWindow(2, reads.iterator)
+    val window = SlidingWindow("chr1", 2, reads.iterator)
     val caught = the[IllegalArgumentException] thrownBy { window.setCurrentLocus(0) }
     caught.getMessage should include("must have the same reference name")
 
@@ -54,7 +54,7 @@ class SlidingWindowSuite extends FunSuite with Matchers {
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1),
       TestUtil.makeRead("TCGATCGA", "8M", "8", 4),
       TestUtil.makeRead("TCGATCGA", "8M", "8", 8))
-    val window = SlidingWindow(2, reads.iterator)
+    val window = SlidingWindow("chr1", 2, reads.iterator)
 
     window.setCurrentLocus(0)
     assert(window.currentRegions.size === 1)
@@ -70,7 +70,7 @@ class SlidingWindowSuite extends FunSuite with Matchers {
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1),
       TestUtil.makeRead("TCGATCGA", "8M", "8", 8),
       TestUtil.makeRead("TCGATCGA", "8M", "8", 4))
-    val window = SlidingWindow(8, reads.iterator)
+    val window = SlidingWindow("chr1", 8, reads.iterator)
     val caught = the[IllegalArgumentException] thrownBy { window.setCurrentLocus(0) }
     caught.getMessage should include("Regions must be sorted by start locus")
 
@@ -86,7 +86,7 @@ class SlidingWindowSuite extends FunSuite with Matchers {
       TestUtil.makeRead("TCGATCGA", "8M", "8", 1),
       TestUtil.makeRead("CGATCGAT", "8M", "8", 2),
       TestUtil.makeRead("TCG", "3M", "3", 5))
-    val window = SlidingWindow(0, reads.iterator)
+    val window = SlidingWindow("chr1", 0, reads.iterator)
 
     window.setCurrentLocus(0)
     assert(window.currentRegions.size === 0)
@@ -132,7 +132,7 @@ class SlidingWindowSuite extends FunSuite with Matchers {
       TestUtil.makeRead("TCGATCGA", "8M", "8", 2),
       TestUtil.makeRead("CGATCGAT", "8M", "8", 3),
       TestUtil.makeRead("TCG", "3M", "3", 6))
-    val window = SlidingWindow(1, reads.iterator)
+    val window = SlidingWindow("chr1", 1, reads.iterator)
 
     window.setCurrentLocus(0)
     assert(window.currentRegions.size === 0)
@@ -179,13 +179,13 @@ class SlidingWindowSuite extends FunSuite with Matchers {
       TestUtil.makeRead("TCGATCGA", "8M", "8", 2),
       TestUtil.makeRead("CGATCGAT", "8M", "8", 3),
       TestUtil.makeRead("TCG", "3M", "3", 6))
-    val window1 = SlidingWindow(0, reads1.iterator)
+    val window1 = SlidingWindow("chr1", 0, reads1.iterator)
 
     val reads2 = Seq(
       TestUtil.makeRead("TCGATCGA", "8M", "8", 2),
       TestUtil.makeRead("CGATCGAT", "8M", "8", 3),
       TestUtil.makeRead("TCG", "3M", "3", 6))
-    val window2 = SlidingWindow(0, reads2.iterator)
+    val window2 = SlidingWindow("chr1", 0, reads2.iterator)
 
     val loci = LociSet.parse("chr1:0-3,chr1:20-30").onContig("chr1").iterator
     val windows = Seq(window1, window2)
@@ -205,13 +205,13 @@ class SlidingWindowSuite extends FunSuite with Matchers {
       TestUtil.makeRead("TCGATCGA", "8M", "8", 0),
       TestUtil.makeRead("CGATCGAT", "8M", "8", 3),
       TestUtil.makeRead("TCG", "3M", "3", 6))
-    val window1 = SlidingWindow(1, reads1.iterator)
+    val window1 = SlidingWindow("chr1", 1, reads1.iterator)
 
     val reads2 = Seq(
       TestUtil.makeRead("TCGATCGA", "8M", "8", 2),
       TestUtil.makeRead("CGATCGAT", "8M", "8", 3),
       TestUtil.makeRead("TCG", "3M", "3", 6))
-    val window2 = SlidingWindow(0, reads2.iterator)
+    val window2 = SlidingWindow("chr1", 0, reads2.iterator)
 
     val loci = LociSet.parse("chr1:0-3,chr1:20-30").onContig("chr1").iterator
     val windows = Seq(window1, window2)
@@ -234,13 +234,13 @@ class SlidingWindowSuite extends FunSuite with Matchers {
       TestUtil.makeRead("TCGATCGA", "8M", "8", 2),
       TestUtil.makeRead("CGATCGAT", "8M", "8", 3),
       TestUtil.makeRead("TCG", "3M", "3", 6))
-    val window1 = SlidingWindow(0, reads1.iterator)
+    val window1 = SlidingWindow("chr1", 0, reads1.iterator)
 
     val reads2 = Seq(
       TestUtil.makeRead("TCGATCGA", "8M", "8", 5),
       TestUtil.makeRead("CGATCGAT", "8M", "8", 80),
       TestUtil.makeRead("TCG", "3M", "3", 100))
-    val window2 = SlidingWindow(0, reads2.iterator)
+    val window2 = SlidingWindow("chr1", 0, reads2.iterator)
 
     val loci = LociSet.parse("chr1:0-3,chr1:60-101").onContig("chr1").iterator
     val windows = Seq(window1, window2)


### PR DESCRIPTION
* Add referenceName to Pileup as an attribute. This makes it possible to access this field even when the Pileup is empty. Closes #335.
* Fix a compile warning  in `ReadSet`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/336)
<!-- Reviewable:end -->
