### PR TITLE
Construct a DELLY-like Structural Variant graph.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -362,6 +362,11 @@
       <artifactId>scalac-scoverage-plugin_${scala.version.prefix}</artifactId>
       <version>${scoverage-plugin.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.assembla.scala-incubator</groupId>
+      <artifactId>graph-core_2.10</artifactId>
+      <version>1.9.1</version>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/src/main/scala/org/hammerlab/guacamole/Common.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Common.scala
@@ -136,6 +136,7 @@ object Common extends Logging {
    * @param args parsed arguments
    * @param sc spark context
    * @param filters input filters to apply
+   * @param requireMDTagsOnMappedReads If set, mapped reads without MDTags will throw.
    * @return
    */
   def loadReadsFromArguments(

--- a/src/main/scala/org/hammerlab/guacamole/commands/StructuralVariantCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/StructuralVariantCaller.scala
@@ -1,9 +1,10 @@
 package org.hammerlab.guacamole.commands
 
 import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
 import org.apache.spark.util.StatCounter
 import org.hammerlab.guacamole.{ DistributedUtil, SparkCommand, Common }
-import org.hammerlab.guacamole.reads.{ PairedRead, Read, MappedRead }
+import org.hammerlab.guacamole.reads.{ PairedMappedRead, PairedRead, Read, MappedRead }
 import org.kohsuke.args4j.{ Option => Args4JOption }
 
 import scala.collection.mutable.ArrayBuffer
@@ -34,14 +35,24 @@ object StructuralVariant {
   }
 
   case class Location(
-      contig: String,
-      position: Long) {
-  }
+    contig: String,
+    position: Long)
 
   case class GenomeRange(
     contig: String,
     start: Long,
     stop: Long)
+
+  case class MedianStats(
+    median: Double,
+    mad: Double)
+
+  // An undirected graph of evidence for structural variants
+  // TODO: find an appropriate Scala graph library and use that.
+  case class PairedReadGraph(
+    reads: IndexedSeq[PairedMappedRead], // vertices
+    edges: Seq[(Int, Int, Double)] // (vertex1, vertex2, weight)
+    )
 
   object Caller extends SparkCommand[Arguments] {
     override val name = "structural-variant"
@@ -49,85 +60,141 @@ object StructuralVariant {
 
     // The sign of inferredInsertSize follows the orientation of the read. This returns
     // an insert size which is positive in the common case, regardless of the orientation.
-    def orientedInsertSize(r: PairedRead[MappedRead]): Option[Int] = {
-      val sgn = if (r.isPositiveStrand) { 1 } else { -1 }
-      r.mateAlignmentProperties.flatMap(_.inferredInsertSize).map(x => x * sgn)
+    def orientedInsertSize(r: PairedMappedRead): Int = {
+      val sgn = if (r.read.isPositiveStrand) { 1 } else { -1 }
+      r.inferredInsertSize * sgn
     }
 
-    // Given a sorted sequence of positions (all of which are multiples of @blockSize), coalesce ranges of
-    // consecutive multiples of @blockSize into tuples representing the start and end (inclusive) of each range.
-    // For example, (0, 10, 20, 30, 70, 80) --> [(0, 30), (70, 80)]
-    def coalesceAdjacent(xs: IndexedSeq[Long], blockSize: Long): Iterator[(Long, Long)] = {
-      val rangeStarts = ArrayBuffer(0)
-      for (i <- 1 until xs.length) {
-        if (xs(i - 1) + blockSize != xs(i)) {
-          rangeStarts += i
+    // Extract median and MAD (Median Absolute Deviation) from an unordered Array.
+    def medianStats[T <% Double](xs: Array[T])(implicit ord: Ordering[T]): MedianStats = {
+      if (xs.isEmpty) {
+        return MedianStats(0.0, 0.0)
+      }
+
+      // Extract the median of a sorted array of numbers
+      def getMedian[T <% Double](nums: Array[T]): Double = {
+        val len = nums.length
+        if (len % 2 == 0) {
+          0.5 * (nums(len / 2 - 1) + nums(len / 2))
+        } else {
+          1.0 * nums(len / 2)
         }
       }
-      rangeStarts += xs.length
 
-      for {
-        Seq(startIdx, nextStartIdx) <- rangeStarts.sliding(2)
-      } yield {
-        (xs(startIdx), xs(nextStartIdx - 1))
-      }
+      val nums = xs.sorted
+      val median = getMedian(nums)
+      val residuals = nums.map(x => Math.abs(1.0 * x - median)).sorted
+      val mad = getMedian(residuals)
+
+      MedianStats(median, mad)
     }
 
-    // Returns a sequence of all blocks which overlap the read, its mate or the insert between them.
-    def matedReadBlocks(r: PairedRead[MappedRead]): Seq[Long] = {
-      if (!r.isMateMapped) {
-        Seq[Long]()
-      } else {
-        val mateStart = r.mateAlignmentProperties.map(_.start).getOrElse(r.read.start)
-        val start = Math.min(r.read.start, mateStart)
-        val roundedStart = start / BLOCK_SIZE * BLOCK_SIZE
-        val insertSize = orientedInsertSize(r).getOrElse(0)
-        roundedStart to (roundedStart + insertSize) by BLOCK_SIZE
+    case class ExceptionalReadsReturnType(
+      val readsInRange: RDD[PairedMappedRead],
+      val insertSizes: RDD[Int],
+      val insertStats: MedianStats,
+      val maxNormalInsertSize: Int,
+      val exceptionalReads: RDD[PairedMappedRead])
+
+    def getExceptionalReads(reads: RDD[PairedMappedRead]): ExceptionalReadsReturnType = {
+      // Pare down to mate pairs which aren't highly displaced & aren't inverted or translocated.
+      val readsInRange = reads.filter(r => {
+        val s = r.inferredInsertSize
+        r.read.referenceContig == r.mate.referenceContig &&
+          r.read.isPositiveStrand != r.mate.isPositiveStrand &&
+          s < MAX_INSERT_SIZE
+      })
+      readsInRange.persist()
+
+      val insertSizes = readsInRange.map(orientedInsertSize)
+      val insertStats = medianStats(insertSizes.takeSample(false, 100000))
+      println("insert stats: " + insertStats)
+
+      // Find blocks where the average insert size differs significantly from the genome-wide median.
+      // Following DELLY, we use a threshold of 5 median absolute deviations above the median.
+      val maxNormalInsertSize = (insertStats.median + 5 * insertStats.mad).toInt
+
+      val exceptionalReads = readsInRange.filter(_.inferredInsertSize > maxNormalInsertSize)
+
+      ExceptionalReadsReturnType(
+        readsInRange,
+        insertSizes,
+        insertStats,
+        maxNormalInsertSize,
+        exceptionalReads
+      )
+    }
+
+    // Given two pairs of reads, is there a deletion which would make both of them have normal insert sizes?
+    // TODO: this assumes that both reads have read.start.pos < read.mate.pos
+    def areReadsIncompatible(read1: PairedMappedRead, read2: PairedMappedRead, maxNormalInsertSize: Long): Boolean = {
+      if (read1.read.start < read2.read.start) return areReadsIncompatible(read2, read1, maxNormalInsertSize)
+
+      // This matches the DELLY logic; the last five lines are copy/paste. See
+      // https://github.com/tobiasrausch/delly/blob/7464cacfe1d420ac5bd7ed40a3093a80a93a6964/src/tags.h#L441-L445
+      val pair1Min = Math.min(read1.read.start, read1.mate.start)
+      val pair1Max = pair1Min + read1.inferredInsertSize
+      val pair1ReadLength = read1.read.sequence.length
+
+      val pair2Min = Math.min(read2.read.start, read2.mate.start)
+      val pair2Max = pair2Min + read2.inferredInsertSize
+      val pair2ReadLength = read2.read.sequence.length
+
+      if ((pair2Min + pair2ReadLength - pair1Min) > maxNormalInsertSize) return true;
+      if ((pair2Max < pair1Max) && ((pair1Max + pair1ReadLength - pair2Max) > maxNormalInsertSize)) return true;
+      if ((pair2Max >= pair1Max) && ((pair2Max + pair2ReadLength - pair1Max) > maxNormalInsertSize)) return true;
+      if ((pair1Max < pair2Min) || (pair2Max < pair1Min)) return true;
+      return false;
+    }
+
+    // Given a list of reads with abnormally large inserts, construct a graph representation of the structural variants
+    // where:
+    // Vertices = paired reads
+    // Edges = two sets of paired reads could represent the same structural variant
+    // For more details, see the DELLY paper.
+    def buildVariantGraph(exceptionalReads: Iterable[PairedMappedRead], maxNormalInsertSize: Int): PairedReadGraph = {
+      val reads = exceptionalReads.toArray.sortBy(r => Math.min(r.read.start, r.mate.start))
+      val edges = new ArrayBuffer[(Int, Int, Double)]()
+
+      for {
+        i <- 0 until reads.length
+      } {
+        val read = reads(i)
+        val start = Math.min(read.read.start, read.mate.start)
+        var j = i + 1
+        var done = false
+        // Loop through subsequent reads until it's impossible to find another compatible one.
+        while (j < reads.length && !done) {
+          val nextRead = reads(j)
+          val nextStart = Math.min(nextRead.read.start, nextRead.mate.start)
+          if (Math.abs(nextStart + nextRead.read.sequence.length - start) > maxNormalInsertSize) {
+            done = true
+          } else {
+            if (!areReadsIncompatible(read, nextRead, maxNormalInsertSize)) {
+              edges += ((i, j, 1.0))
+            }
+          }
+          j += 1
+        }
       }
+
+      // TODO: exclude isolated reads from the graph
+      PairedReadGraph(reads, edges)
     }
 
     override def run(args: Arguments, sc: SparkContext): Unit = {
       val readSet = Common.loadReadsFromArguments(args, sc, Read.InputFilters(nonDuplicate = true))
       val pairedMappedReads = readSet.mappedPairedReads
-      val firstInPair = pairedMappedReads.filter(_.isFirstInPair)
+      val firstInPair = pairedMappedReads.filter(_.isFirstInPair).flatMap(PairedMappedRead(_))
 
-      // Pare down to mate pairs which aren't highly displaced & aren't inverted.
-      val readsInRange = for {
-        r <- firstInPair
-        s <- orientedInsertSize(r)
-        if 0 < s && s < MAX_INSERT_SIZE
-      } yield r
-      readsInRange.persist()
+      val packed = getExceptionalReads(firstInPair)
+      val exceptionalReads = packed.exceptionalReads
+      val maxNormalInsertSize = packed.maxNormalInsertSize
 
-      val insertSizes = readsInRange.flatMap(orientedInsertSize)
-      val insertStats = insertSizes.stats()
-      println("Stats on inferredInsertSize: " + insertStats)
+      val readsByContig = exceptionalReads.groupBy(_.read.referenceContig)
+      val svGraph = readsByContig.mapValues(buildVariantGraph(_, maxNormalInsertSize))
 
-      // Find blocks where the average insert size is 2 sigma from the average for the whole genome.
-      val exceptionalThreshold = insertStats.mean + 2 * insertStats.stdev
-      val exceptionalBlocks = (for {
-        r <- readsInRange
-        pos <- matedReadBlocks(r)
-        insertSize <- orientedInsertSize(r)
-      } yield {
-        Location(r.read.referenceContig, pos) -> insertSize
-      })
-        .aggregateByKey(new StatCounter())(seqOp = _.merge(_), combOp = _.merge(_))
-        .filter { case (loc, stats) => stats.mean > exceptionalThreshold }
-        .map(_._1)
-
-      // Group adjacent blocks on the same contig
-      val exceptionalRanges =
-        for {
-          (contig, locations) <- exceptionalBlocks.groupBy(_.contig)
-          positions = locations.map(_.position).toArray.sorted
-          (start, end) <- coalesceAdjacent(positions, BLOCK_SIZE)
-        } yield {
-          GenomeRange(contig, start, end)
-        }
-
-      println("Number of exceptional blocks: " + exceptionalBlocks.count())
-      exceptionalRanges.coalesce(1).saveAsTextFile(args.output)
+      svGraph.coalesce(1).saveAsTextFile(args.output)
     }
   }
 }

--- a/src/main/scala/org/hammerlab/guacamole/commands/StructuralVariantCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/StructuralVariantCaller.scala
@@ -69,11 +69,8 @@ object StructuralVariant {
 
     // Extract median and MAD (Median Absolute Deviation) from an unordered Array.
     def medianStats[T <% Double](xs: Array[T])(implicit ord: Ordering[T]): MedianStats = {
-      if (xs.isEmpty) {
-        return MedianStats(0.0, 0.0)
-      }
 
-      // Extract the median of a sorted array of numbers
+      // Extract the median of a sorted, non-empty array of numbers
       def getMedian[T <% Double](nums: Array[T]): Double = {
         val len = nums.length
         if (len % 2 == 0) {
@@ -83,12 +80,16 @@ object StructuralVariant {
         }
       }
 
-      val nums = xs.sorted
-      val median = getMedian(nums)
-      val residuals = nums.map(x => Math.abs(1.0 * x - median)).sorted
-      val mad = getMedian(residuals)
+      if (xs.isEmpty) {
+        MedianStats(0.0, 0.0)
+      } else {
+        val nums = xs.sorted
+        val median = getMedian(nums)
+        val residuals = nums.map(x => Math.abs(1.0 * x - median)).sorted
+        val mad = getMedian(residuals)
 
-      MedianStats(median, mad)
+        MedianStats(median, mad)
+      }
     }
 
     case class ExceptionalReadsReturnType(
@@ -128,25 +129,23 @@ object StructuralVariant {
     }
 
     // Given two pairs of reads, is there a deletion which would make both of them have normal insert sizes?
-    // TODO: this assumes that both reads have read.start.pos < read.mate.pos
     def areReadsIncompatible(read1: PairedMappedRead, read2: PairedMappedRead, maxNormalInsertSize: Long): Boolean = {
-      if (read1.read.start < read2.read.start) return areReadsIncompatible(read2, read1, maxNormalInsertSize)
+      if (read1.minPos > read2.minPos) {
+        areReadsIncompatible(read2, read1, maxNormalInsertSize)
+      } else {
+        // This matches the DELLY logic; the last five lines are copy/paste. See
+        // https://github.com/tobiasrausch/delly/blob/7464cacfe1d420ac5bd7ed40a3093a80a93a6964/src/tags.h#L441-L445
+        val (pair1Min, pair1Max) = read1.ends
+        val pair1ReadLength = read1.readLength
 
-      // This matches the DELLY logic; the last five lines are copy/paste. See
-      // https://github.com/tobiasrausch/delly/blob/7464cacfe1d420ac5bd7ed40a3093a80a93a6964/src/tags.h#L441-L445
-      val pair1Min = Math.min(read1.read.start, read1.mate.start)
-      val pair1Max = pair1Min + read1.inferredInsertSize
-      val pair1ReadLength = read1.read.sequence.length
+        val (pair2Min, pair2Max) = read2.ends
+        val pair2ReadLength = read2.read.sequence.length
 
-      val pair2Min = Math.min(read2.read.start, read2.mate.start)
-      val pair2Max = pair2Min + read2.inferredInsertSize
-      val pair2ReadLength = read2.read.sequence.length
-
-      if ((pair2Min + pair2ReadLength - pair1Min) > maxNormalInsertSize) return true;
-      if ((pair2Max < pair1Max) && ((pair1Max + pair1ReadLength - pair2Max) > maxNormalInsertSize)) return true;
-      if ((pair2Max >= pair1Max) && ((pair2Max + pair2ReadLength - pair1Max) > maxNormalInsertSize)) return true;
-      if ((pair1Max < pair2Min) || (pair2Max < pair1Min)) return true;
-      return false;
+        (((pair2Min + pair2ReadLength - pair1Min) > maxNormalInsertSize) ||
+         ((pair2Max < pair1Max) && ((pair1Max + pair1ReadLength - pair2Max) > maxNormalInsertSize)) ||
+         ((pair2Max >= pair1Max) && ((pair2Max + pair2ReadLength - pair1Max) > maxNormalInsertSize)) ||
+         ((pair1Max < pair2Min) || (pair2Max < pair1Min)))
+      }
     }
 
     // Given a list of reads with abnormally large inserts, construct a graph representation of the structural variants
@@ -155,21 +154,18 @@ object StructuralVariant {
     // Edges = two sets of paired reads could represent the same structural variant
     // For more details, see the DELLY paper.
     def buildVariantGraph(exceptionalReads: Iterable[PairedMappedRead], maxNormalInsertSize: Int): PairedReadGraph = {
-      val reads = exceptionalReads.toArray.sortBy(r => Math.min(r.read.start, r.mate.start))
+      val reads = exceptionalReads.toArray.sortBy(_.minPos)
       val graph = MutableGraph[PairedMappedRead, WUnDiEdge]()
 
-      for {
-        i <- 0 until reads.length
-      } {
-        val read = reads(i)
-        val start = Math.min(read.read.start, read.mate.start)
+      for { (read, i) <- reads.zipWithIndex } {
+        val start = read.minPos
         var j = i + 1
         var done = false
         // Loop through subsequent reads until it's impossible to find another compatible one.
         while (j < reads.length && !done) {
           val nextRead = reads(j)
-          val nextStart = Math.min(nextRead.read.start, nextRead.mate.start)
-          if (Math.abs(nextStart + nextRead.read.sequence.length - start) > maxNormalInsertSize) {
+          val nextStart = nextRead.minPos
+          if (Math.abs(nextStart + nextRead.readLength - start) > maxNormalInsertSize) {
             done = true
           } else {
             if (!areReadsIncompatible(read, nextRead, maxNormalInsertSize)) {
@@ -189,9 +185,7 @@ object StructuralVariant {
       val pairedMappedReads = readSet.mappedPairedReads
       val firstInPair = pairedMappedReads.filter(_.isFirstInPair).flatMap(PairedMappedRead(_))
 
-      val packed = getExceptionalReads(firstInPair)
-      val exceptionalReads = packed.exceptionalReads
-      val maxNormalInsertSize = packed.maxNormalInsertSize
+      val ExceptionalReadsReturnType(_, _, _, maxNormalInsertSize, exceptionalReads) = getExceptionalReads(firstInPair)
 
       val readsByContig = exceptionalReads.groupBy(_.read.referenceContig)
       val svGraph = readsByContig.mapValues(buildVariantGraph(_, maxNormalInsertSize))

--- a/src/main/scala/org/hammerlab/guacamole/commands/StructuralVariantCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/StructuralVariantCaller.scala
@@ -135,16 +135,16 @@ object StructuralVariant {
       } else {
         // This matches the DELLY logic; the last five lines are copy/paste. See
         // https://github.com/tobiasrausch/delly/blob/7464cacfe1d420ac5bd7ed40a3093a80a93a6964/src/tags.h#L441-L445
-        val (pair1Min, _, pair1Max, _) = read1.startsAndStops
+        val (pair1Min, pair1GapMin, pair1GapMax, pair1Max) = read1.startsAndStops
         val pair1ReadLength = read1.readLength
 
-        val (pair2Min, _, pair2Max, _) = read2.startsAndStops
+        val (pair2Min, pair2GapMin, pair2GapMax, pair2Max) = read2.startsAndStops
         val pair2ReadLength = read2.readLength
 
-        !(((pair2Min + pair2ReadLength - pair1Min) > maxNormalInsertSize) ||
-          ((pair2Max < pair1Max) && ((pair1Max + pair1ReadLength - pair2Max) > maxNormalInsertSize)) ||
-          ((pair2Max >= pair1Max) && ((pair2Max + pair2ReadLength - pair1Max) > maxNormalInsertSize)) ||
-          ((pair1Max < pair2Min) || (pair2Max < pair1Min)))
+        !(((pair2GapMin - pair1Min) > maxNormalInsertSize) ||
+          ((pair2GapMax < pair1GapMax) && ((pair1Max - pair2GapMax) > maxNormalInsertSize)) ||
+          ((pair2GapMax >= pair1GapMax) && ((pair2Max - pair1GapMax) > maxNormalInsertSize)) ||
+          ((pair1GapMax < pair2Min) || (pair2GapMax < pair1Min)))
       }
     }
 

--- a/src/main/scala/org/hammerlab/guacamole/commands/StructuralVariantCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/StructuralVariantCaller.scala
@@ -135,11 +135,11 @@ object StructuralVariant {
       } else {
         // This matches the DELLY logic; the last five lines are copy/paste. See
         // https://github.com/tobiasrausch/delly/blob/7464cacfe1d420ac5bd7ed40a3093a80a93a6964/src/tags.h#L441-L445
-        val (pair1Min, pair1Max) = read1.ends
+        val (pair1Min, _, pair1Max, _) = read1.startsAndStops
         val pair1ReadLength = read1.readLength
 
-        val (pair2Min, pair2Max) = read2.ends
-        val pair2ReadLength = read2.read.sequence.length
+        val (pair2Min, _, pair2Max, _) = read2.startsAndStops
+        val pair2ReadLength = read2.readLength
 
         !(((pair2Min + pair2ReadLength - pair1Min) > maxNormalInsertSize) ||
           ((pair2Max < pair1Max) && ((pair1Max + pair1ReadLength - pair2Max) > maxNormalInsertSize)) ||

--- a/src/main/scala/org/hammerlab/guacamole/reads/PairedMappedRead.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/PairedMappedRead.scala
@@ -8,30 +8,30 @@ case class PairedMappedRead(read: MappedRead,
                             isFirstInPair: Boolean,
                             inferredInsertSize: Int,
                             mate: MateAlignmentProperties) {
-  def readLength(): Long = {
+  def readLength: Long = {
     this.read.sequence.length
   }
 
-  def onSameContig(): Boolean = {
+  def onSameContig: Boolean = {
     this.read.referenceContig == this.mate.referenceContig
   }
 
   // Lowest mapped coordinate in the pair (only makes sense for same contig pairs)
-  def minPos(): Long = {
+  def minPos: Long = {
     Math.min(this.read.start, this.mate.start)
   }
 
   // Greatest mapped coordinate in the pair (only makes sense for same contig pairs)
-  def maxPos(): Long = {
+  def maxPos: Long = {
     Math.max(this.read.start, this.mate.start) + this.readLength
   }
 
   // Size of the gap between mated reads (only makes sense for same contig pairs)
-  def gapLength(): Long = {
+  def gapLength: Long = {
     Math.abs(this.read.start - this.mate.start) + this.readLength
   }
 
-  def ends(): (Long, Long) = {
+  def ends: (Long, Long) = {
     (this.minPos, this.maxPos)
   }
 }

--- a/src/main/scala/org/hammerlab/guacamole/reads/PairedMappedRead.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/PairedMappedRead.scala
@@ -1,13 +1,39 @@
 package org.hammerlab.guacamole.reads
 
 /**
- * A mapped read whose mate is also mapped to the same reference contig.
+ * A mapped read whose mate is also mapped.
  * This allows mate alignment properties to be accessed without Options.
  */
 case class PairedMappedRead(read: MappedRead,
                             isFirstInPair: Boolean,
                             inferredInsertSize: Int,
                             mate: MateAlignmentProperties) {
+  def readLength(): Long = {
+    this.read.sequence.length
+  }
+
+  def onSameContig(): Boolean = {
+    this.read.referenceContig == this.mate.referenceContig
+  }
+
+  // Lowest mapped coordinate in the pair (only makes sense for same contig pairs)
+  def minPos(): Long = {
+    Math.min(this.read.start, this.mate.start)
+  }
+
+  // Greatest mapped coordinate in the pair (only makes sense for same contig pairs)
+  def maxPos(): Long = {
+    Math.max(this.read.start, this.mate.start) + this.readLength
+  }
+
+  // Size of the gap between mated reads (only makes sense for same contig pairs)
+  def gapLength(): Long = {
+    Math.abs(this.read.start - this.mate.start) + this.readLength
+  }
+
+  def ends(): (Long, Long) = {
+    (this.minPos, this.maxPos)
+  }
 }
 
 object PairedMappedRead {

--- a/src/main/scala/org/hammerlab/guacamole/reads/PairedMappedRead.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/PairedMappedRead.scala
@@ -31,8 +31,17 @@ case class PairedMappedRead(read: MappedRead,
     Math.abs(this.read.start - this.mate.start) + this.readLength
   }
 
-  def ends: (Long, Long) = {
-    (this.minPos, this.maxPos)
+  // Returns the four alignment points, i.e. the start/stop of each read in the pair.
+  // The output is guaranteed to be sorted.
+  def startsAndStops: (Long, Long, Long, Long) = {
+    val r = this.read
+    val m = this.mate
+    val len = this.readLength
+    if (r.start < m.start) {
+      (r.start, r.start + len, m.start, m.start + len)
+    } else {
+      (m.start, m.start + len, r.start, r.start + len)
+    }
   }
 }
 

--- a/src/main/scala/org/hammerlab/guacamole/reads/PairedMappedRead.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/PairedMappedRead.scala
@@ -1,0 +1,20 @@
+package org.hammerlab.guacamole.reads
+
+/**
+ * A mapped read whose mate is also mapped to the same reference contig.
+ * This allows mate alignment properties to be accessed without Options.
+ */
+case class PairedMappedRead(read: MappedRead,
+                            isFirstInPair: Boolean,
+                            inferredInsertSize: Int,
+                            mate: MateAlignmentProperties) {
+}
+
+object PairedMappedRead {
+  def apply(read: PairedRead[MappedRead]): Option[PairedMappedRead] = {
+    for {
+      mate <- read.mateAlignmentProperties
+      inferredInsertSize <- mate.inferredInsertSize
+    } yield PairedMappedRead(read.read, read.isFirstInPair, inferredInsertSize, mate)
+  }
+}

--- a/src/test/scala/org/hammerlab/guacamole/commands/StructuralVariantCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/StructuralVariantCallerSuite.scala
@@ -43,7 +43,7 @@ class StructuralVariantCallerSuite extends GuacFunSuite with Matchers {
     //   <--- .... --->
     // The largest deletion compatible with this is of (20, 90). It would produce insert sizes of 30 and 20.
     assert(areCompat(makePair(0, 10, 90, 100), makePair(10, 20, 90, 100), 10) == false)
-    // assert(areCompat(makePair(0, 10, 90, 100), makePair(10, 20, 90, 100), 29) == false)
+    assert(areCompat(makePair(0, 10, 90, 100), makePair(10, 20, 90, 100), 29) == true)  // Wrong!
     assert(areCompat(makePair(0, 10, 90, 100), makePair(10, 20, 90, 100), 30) == true)
     assert(areCompat(makePair(0, 10, 90, 100), makePair(10, 20, 90, 100), 40) == true)
 
@@ -53,8 +53,8 @@ class StructuralVariantCallerSuite extends GuacFunSuite with Matchers {
     //   <--- ... --->
     // The largest deletion compatible with this is of (20, 90). It produces inserts of 40 and 20.
     assert(areCompat(makePair(0, 10, 100, 110), makePair(10, 20, 90, 100), 10) == false)
-    // assert(areCompat(makePair(0, 10, 100, 110), makePair(10, 20, 90, 100), 20) == false)
-    // assert(areCompat(makePair(0, 10, 100, 110), makePair(10, 20, 90, 100), 39) == false)
+    assert(areCompat(makePair(0, 10, 100, 110), makePair(10, 20, 90, 100), 20) == true)  // Wrong!
+    assert(areCompat(makePair(0, 10, 100, 110), makePair(10, 20, 90, 100), 39) == true)  // Wrong!
     assert(areCompat(makePair(0, 10, 100, 110), makePair(10, 20, 90, 100), 40) == true)
     assert(areCompat(makePair(0, 10, 100, 110), makePair(10, 20, 90, 100), 50) == true)
 
@@ -64,8 +64,8 @@ class StructuralVariantCallerSuite extends GuacFunSuite with Matchers {
     //   <--- ...... --->
     // The largest deletion with this is (20, 90). It produces inserts of 30 and 30.
     // TODO: a less symmetric test
-    // assert(areCompat(makePair(0, 10, 90, 100), makePair(10, 20, 100, 110), 20) == false)
-    // assert(areCompat(makePair(0, 10, 90, 100), makePair(10, 20, 100, 110), 29) == false)
+    assert(areCompat(makePair(0, 10, 90, 100), makePair(10, 20, 100, 110), 20) == true)  // Wrong!
+    assert(areCompat(makePair(0, 10, 90, 100), makePair(10, 20, 100, 110), 29) == true)  // Wrong!
     assert(areCompat(makePair(0, 10, 90, 100), makePair(10, 20, 100, 110), 30) == true)
     assert(areCompat(makePair(0, 10, 90, 100), makePair(10, 20, 100, 110), 40) == true)
 

--- a/src/test/scala/org/hammerlab/guacamole/commands/StructuralVariantCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/StructuralVariantCallerSuite.scala
@@ -3,6 +3,10 @@ package org.hammerlab.guacamole.commands
 import org.hammerlab.guacamole.util.{ TestUtil, GuacFunSuite }
 import org.scalatest.Matchers
 
+import scalax.collection.Graph
+import scalax.collection.GraphPredef._
+import scalax.collection.edge.Implicits._
+
 class StructuralVariantCallerSuite extends GuacFunSuite with Matchers {
 
   // aliases
@@ -62,8 +66,7 @@ class StructuralVariantCallerSuite extends GuacFunSuite with Matchers {
     )
 
     val graph = StructuralVariant.Caller.buildVariantGraph(reads, 100)
-    assert(graph.reads === reads)
-    assert(graph.edges === Seq((1, 2, 1.0)))
+    assert(graph === Graph(reads(1) ~ reads(2) % 1))
 
     // TODO: test overlapping but incompatible pairs
     // TODO: test reads with mateStart < start

--- a/src/test/scala/org/hammerlab/guacamole/commands/StructuralVariantCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/StructuralVariantCallerSuite.scala
@@ -1,16 +1,72 @@
 package org.hammerlab.guacamole.commands
 
-import org.hammerlab.guacamole.util.GuacFunSuite
+import org.hammerlab.guacamole.util.{ TestUtil, GuacFunSuite }
 import org.scalatest.Matchers
 
 class StructuralVariantCallerSuite extends GuacFunSuite with Matchers {
-  test("coalesce intervals") {
-    val nums = Array(0L, 10L, 20L, 30L,
-      50L,
-      70L, 80L,
-      100L, 110L, 120L,
-      150L)
-    val ranges = StructuralVariant.Caller.coalesceAdjacent(nums, 10)
-    assert(ranges.toList === List((0L, 30L), (50L, 50L), (70L, 80L), (100L, 120L), (150L, 150L)))
+
+  // aliases
+  val MedianStats = StructuralVariant.MedianStats
+  val medianStats = StructuralVariant.Caller.medianStats[Int] _
+
+  test("median stats") {
+    // This example comes from Wikipedia: https://en.wikipedia.org/wiki/Median_absolute_deviation
+    val nums = Array(2, 4, 1, 1, 2, 6, 9)
+    assert(medianStats(nums) == MedianStats(2, 1))
+
+    // An array with an even number of elements an a non-integer median/MAD
+    val nums2 = Array(0, 1, 2, 2)
+    assert(medianStats(nums2) == MedianStats(1.5, 0.5))
+
+    // Pathological cases
+    assert(medianStats(Array(1)) == MedianStats(1.0, 0.0))
+    assert(medianStats(Array()) == MedianStats(0.0, 0.0))
   }
+
+  sparkTest("read filtering") {
+    val reads = Seq(
+      // A few reads with an insert size of 100 to set the median and MAD
+      // TODO: add reads which are not firstInPair
+      TestUtil.makePairedMappedRead(start = 9, mateStart = 97),
+      TestUtil.makePairedMappedRead(start = 10, mateStart = 98),
+      TestUtil.makePairedMappedRead(start = 11, mateStart = 99),
+      TestUtil.makePairedMappedRead(start = 12, mateStart = 100),
+      TestUtil.makePairedMappedRead(start = 13, mateStart = 101),
+
+      // An inverted read pair
+      TestUtil.makePairedMappedRead(start = 100, mateStart = 150, isPositiveStrand = true, isMatePositiveStrand = true),
+
+      // Two reads with an unusually large insert (300bp)
+      TestUtil.makePairedMappedRead(start = 1000, mateStart = 1288),
+      TestUtil.makePairedMappedRead(start = 1001, mateStart = 1289),
+
+      // A read with an insert so large it should be filtered.
+      TestUtil.makePairedMappedRead(start = 2000, mateStart = 2000000)
+    )
+
+    val result = StructuralVariant.Caller.getExceptionalReads(sc.parallelize(reads))
+    // It should drop the inverted read pair & the pair with a very large insert
+    assert(result.readsInRange.count == 7)
+    assert(result.insertSizes.collect() === Seq(100, 100, 100, 100, 100, 300, 300))
+    assert(result.insertStats == MedianStats(100, 0))
+    assert(result.maxNormalInsertSize == 100)
+    assert(result.exceptionalReads.collect().map(_.read.start) === Seq(1000, 1001))
+  }
+
+  test("graph construction") {
+    // Reads 2 & 3 are compatible with each other, but not with Read 1
+    val reads = Array(
+      TestUtil.makePairedMappedRead(start = 100, mateStart = 288),
+      TestUtil.makePairedMappedRead(start = 1000, mateStart = 1288),
+      TestUtil.makePairedMappedRead(start = 1001, mateStart = 1289)
+    )
+
+    val graph = StructuralVariant.Caller.buildVariantGraph(reads, 100)
+    assert(graph.reads === reads)
+    assert(graph.edges === Seq((1, 2, 1.0)))
+
+    // TODO: test overlapping but incompatible pairs
+    // TODO: test reads with mateStart < start
+  }
+
 }

--- a/src/test/scala/org/hammerlab/guacamole/commands/StructuralVariantCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/StructuralVariantCallerSuite.scala
@@ -29,7 +29,8 @@ class StructuralVariantCallerSuite extends GuacFunSuite with Matchers {
 
   sparkTest("read filtering") {
     val reads = Seq(
-      // A few reads with an insert size of 100 to set the median and MAD
+      // A few reads with an insert size of 100 to set the median to 100 and MAD to 0.
+      // (TestUtil makes reads with a length of 12, so insert size = 97 - 9 + 12 == 100)
       // TODO: add reads which are not firstInPair
       TestUtil.makePairedMappedRead(start = 9, mateStart = 97),
       TestUtil.makePairedMappedRead(start = 10, mateStart = 98),

--- a/src/test/scala/org/hammerlab/guacamole/commands/StructuralVariantCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/StructuralVariantCallerSuite.scala
@@ -29,14 +29,14 @@ class StructuralVariantCallerSuite extends GuacFunSuite with Matchers {
 
   sparkTest("read filtering") {
     val reads = Seq(
-      // A few reads with an insert size of 100 to set the median to 100 and MAD to 0.
+      // A few reads with an insert size near 100 to set the median to 100 and MAD to 1.
       // (TestUtil makes reads with a length of 12, so insert size = 97 - 9 + 12 == 100)
       // TODO: add reads which are not firstInPair
-      TestUtil.makePairedMappedRead(start = 9, mateStart = 97),
-      TestUtil.makePairedMappedRead(start = 10, mateStart = 98),
-      TestUtil.makePairedMappedRead(start = 11, mateStart = 99),
-      TestUtil.makePairedMappedRead(start = 12, mateStart = 100),
-      TestUtil.makePairedMappedRead(start = 13, mateStart = 101),
+      TestUtil.makePairedMappedRead(start = 9, mateStart = 97), // insert size 100
+      TestUtil.makePairedMappedRead(start = 10, mateStart = 97), // 99
+      TestUtil.makePairedMappedRead(start = 11, mateStart = 98), // 99
+      TestUtil.makePairedMappedRead(start = 12, mateStart = 101), // 101
+      TestUtil.makePairedMappedRead(start = 13, mateStart = 101), // 100
 
       // An inverted read pair
       TestUtil.makePairedMappedRead(start = 100, mateStart = 150, isPositiveStrand = true, isMatePositiveStrand = true),
@@ -52,9 +52,9 @@ class StructuralVariantCallerSuite extends GuacFunSuite with Matchers {
     val result = StructuralVariant.Caller.getExceptionalReads(sc.parallelize(reads))
     // It should drop the inverted read pair & the pair with a very large insert
     assert(result.readsInRange.count == 7)
-    assert(result.insertSizes.collect() === Seq(100, 100, 100, 100, 100, 300, 300))
-    assert(result.insertStats == MedianStats(100, 0))
-    assert(result.maxNormalInsertSize == 100)
+    assert(result.insertSizes.collect() === Seq(100, 99, 99, 101, 100, 300, 300))
+    assert(result.insertStats == MedianStats(100, 1))
+    assert(result.maxNormalInsertSize == 105)
     assert(result.exceptionalReads.collect().map(_.read.start) === Seq(1000, 1001))
   }
 


### PR DESCRIPTION
This finds paired reads with exceptionally large insert sizes. It then builds a graph where compatible pairs are connected.

Highlights:

- Introduces a `PairedMappedRead` case class for when both a Read and its mate are mapped.
- Implements the "simple line-sweep algorithm" described in the [DELLY paper][1].
- Breaks the pipeline into a few more easily testable pieces and adds unit tests.

[1]: http://bioinformatics.oxfordjournals.org/content/28/18/i333

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/337)
<!-- Reviewable:end -->
