### PR TITLE
Find cliques within the SV Graph and output them

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/commands/StructuralVariantCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/StructuralVariantCaller.scala
@@ -171,6 +171,7 @@ object StructuralVariant {
           } else {
             if (areReadsCompatible(read, nextRead, maxNormalInsertSize)) {
               // TODO: this is from DELLY but seems imprecise. It only considers the insert size, not position.
+              // If two reads are of similar length, but don't overlap much, they'll get a spuriously low weight.
               val weight = Math.abs((nextGapEnd - nextStart) - (gapEnd - start))
               graph += (read ~ nextRead) % weight
             }

--- a/src/main/scala/org/hammerlab/guacamole/commands/StructuralVariantCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/StructuralVariantCaller.scala
@@ -184,7 +184,7 @@ object StructuralVariant {
       graph
     }
 
-    case class SVClique(readPairs: mutable.Set[PairedMappedRead],
+    case class SVClique(readPairs: Set[PairedMappedRead],
                         wiggle: Long,
                         svStart: Long,
                         svEnd: Long,
@@ -235,7 +235,7 @@ object StructuralVariant {
         // this is the "wiggle room": by how much can the SV shrink and still be compatible with all reads in the clique?
         // It starts negative and then increases towards zero (at which point there's no wiggle room left).
         val wiggle = maxNormalInsertSize - ((pair.insertSize - (svEnd - svStart)))
-        SVClique(mutable.Set(pair), wiggle, svStart, svEnd, maxNormalInsertSize)
+        SVClique(Set(pair), wiggle, svStart, svEnd, maxNormalInsertSize)
       }
     }
 

--- a/src/main/scala/org/hammerlab/guacamole/reads/PairedMappedRead.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/PairedMappedRead.scala
@@ -8,6 +8,7 @@ case class PairedMappedRead(read: MappedRead,
                             isFirstInPair: Boolean,
                             inferredInsertSize: Int,
                             mate: MateAlignmentProperties) {
+  // The length of the primary read's sequence
   def readLength: Long = {
     this.read.sequence.length
   }
@@ -28,7 +29,7 @@ case class PairedMappedRead(read: MappedRead,
 
   // Size of the gap between mated reads (only makes sense for same contig pairs)
   def gapLength: Long = {
-    Math.abs(this.read.start - this.mate.start) + this.readLength
+    Math.abs(this.read.start - this.mate.start) - this.readLength
   }
 
   // Should be the same as inferredInsertSize

--- a/src/main/scala/org/hammerlab/guacamole/reads/PairedMappedRead.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/PairedMappedRead.scala
@@ -31,6 +31,11 @@ case class PairedMappedRead(read: MappedRead,
     Math.abs(this.read.start - this.mate.start) + this.readLength
   }
 
+  // Should be the same as inferredInsertSize
+  def insertSize: Long = {
+    this.maxPos - this.minPos
+  }
+
   // Returns the four alignment points, i.e. the start/stop of each read in the pair.
   // The output is guaranteed to be sorted.
   def startsAndStops: (Long, Long, Long, Long) = {

--- a/src/main/scala/org/hammerlab/guacamole/variants/ReferenceVariant.scala
+++ b/src/main/scala/org/hammerlab/guacamole/variants/ReferenceVariant.scala
@@ -18,8 +18,8 @@
 
 package org.hammerlab.guacamole.variants
 
-import org.bdgenomics.formats.avro.{DatabaseVariantAnnotation, Contig, Variant}
-import org.hammerlab.guacamole.{Bases, HasReferenceRegion}
+import org.bdgenomics.formats.avro.{ DatabaseVariantAnnotation, Contig, Variant }
+import org.hammerlab.guacamole.{ Bases, HasReferenceRegion }
 
 /**
  * Base properties of a genomic change in a sequence sample from a reference genome

--- a/src/test/scala/org/hammerlab/guacamole/commands/StructuralVariantCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/StructuralVariantCallerSuite.scala
@@ -12,6 +12,12 @@ class StructuralVariantCallerSuite extends GuacFunSuite with Matchers {
   // aliases
   val MedianStats = StructuralVariant.MedianStats
   val medianStats = StructuralVariant.Caller.medianStats[Int] _
+  val GenomeRange = StructuralVariant.GenomeRange
+
+  def makePair(start: Long, end: Long, mateStart: Long, mateEnd: Long) = {
+    assert(mateEnd - mateStart == end - start)
+    TestUtil.makePairedMappedRead(start = start, mateStart = mateStart, sequence = "A" * (end - start).toInt)
+  }
 
   test("median stats") {
     // This example comes from Wikipedia: https://en.wikipedia.org/wiki/Median_absolute_deviation
@@ -30,12 +36,8 @@ class StructuralVariantCallerSuite extends GuacFunSuite with Matchers {
   test("read compatibility") {
     // Shorthand for this test
     val areCompat = StructuralVariant.Caller.areReadsCompatible(_, _, _)
-    def makePair(start: Long, end: Long, mateStart: Long, mateEnd: Long) = {
-      assert(mateEnd - mateStart == end - start)
-      TestUtil.makePairedMappedRead(start = start, mateStart = mateStart, sequence = "A" * (end - start).toInt)
-    }
 
-    // Assertions which are commented out _should_ pass but do not because of inaccuracies in the DELLY checks.
+    // Assertions which are marked should be inverted but are not because of inaccuracies in the DELLY checks.
 
     // Scenario 1:
     // 0 10       90 100
@@ -43,7 +45,7 @@ class StructuralVariantCallerSuite extends GuacFunSuite with Matchers {
     //   <--- .... --->
     // The largest deletion compatible with this is of (20, 90). It would produce insert sizes of 30 and 20.
     assert(areCompat(makePair(0, 10, 90, 100), makePair(10, 20, 90, 100), 10) == false)
-    assert(areCompat(makePair(0, 10, 90, 100), makePair(10, 20, 90, 100), 29) == true)  // Wrong!
+    assert(areCompat(makePair(0, 10, 90, 100), makePair(10, 20, 90, 100), 29) == true) // Wrong!
     assert(areCompat(makePair(0, 10, 90, 100), makePair(10, 20, 90, 100), 30) == true)
     assert(areCompat(makePair(0, 10, 90, 100), makePair(10, 20, 90, 100), 40) == true)
 
@@ -53,8 +55,8 @@ class StructuralVariantCallerSuite extends GuacFunSuite with Matchers {
     //   <--- ... --->
     // The largest deletion compatible with this is of (20, 90). It produces inserts of 40 and 20.
     assert(areCompat(makePair(0, 10, 100, 110), makePair(10, 20, 90, 100), 10) == false)
-    assert(areCompat(makePair(0, 10, 100, 110), makePair(10, 20, 90, 100), 20) == true)  // Wrong!
-    assert(areCompat(makePair(0, 10, 100, 110), makePair(10, 20, 90, 100), 39) == true)  // Wrong!
+    assert(areCompat(makePair(0, 10, 100, 110), makePair(10, 20, 90, 100), 20) == true) // Wrong!
+    assert(areCompat(makePair(0, 10, 100, 110), makePair(10, 20, 90, 100), 39) == true) // Wrong!
     assert(areCompat(makePair(0, 10, 100, 110), makePair(10, 20, 90, 100), 40) == true)
     assert(areCompat(makePair(0, 10, 100, 110), makePair(10, 20, 90, 100), 50) == true)
 
@@ -64,8 +66,8 @@ class StructuralVariantCallerSuite extends GuacFunSuite with Matchers {
     //   <--- ...... --->
     // The largest deletion with this is (20, 90). It produces inserts of 30 and 30.
     // TODO: a less symmetric test
-    assert(areCompat(makePair(0, 10, 90, 100), makePair(10, 20, 100, 110), 20) == true)  // Wrong!
-    assert(areCompat(makePair(0, 10, 90, 100), makePair(10, 20, 100, 110), 29) == true)  // Wrong!
+    assert(areCompat(makePair(0, 10, 90, 100), makePair(10, 20, 100, 110), 20) == true) // Wrong!
+    assert(areCompat(makePair(0, 10, 90, 100), makePair(10, 20, 100, 110), 29) == true) // Wrong!
     assert(areCompat(makePair(0, 10, 90, 100), makePair(10, 20, 100, 110), 30) == true)
     assert(areCompat(makePair(0, 10, 90, 100), makePair(10, 20, 100, 110), 40) == true)
 
@@ -120,6 +122,65 @@ class StructuralVariantCallerSuite extends GuacFunSuite with Matchers {
 
     // TODO: test overlapping but incompatible pairs
     // TODO: test reads with mateStart < start
+  }
+
+  test("clique detection") {
+    // These reads are all compatible. We'll use them to create some graphs.
+    val (a, b, c, d) = (
+      TestUtil.makePairedMappedRead(start = 1000, mateStart = 1287),
+      TestUtil.makePairedMappedRead(start = 1000, mateStart = 1288),
+      TestUtil.makePairedMappedRead(start = 1001, mateStart = 1289),
+      TestUtil.makePairedMappedRead(start = 1002, mateStart = 1290)
+    )
+    val findCliques = StructuralVariant.Caller.findCliques(_, _)
+
+    // Simple case: two reads which are compatible
+    var g = Graph(a ~ b % 1)
+    assert(findCliques(g, 100).map(_.reads) === Seq(Set(a, b)))
+
+    // two reads are compatible, but the third one won't form a clique. The lower-weight edge becomes the clique.
+    g = Graph(a ~ b % 1, b ~ c % 2)
+    assert(findCliques(g, 100).map(_.reads) === Seq(Set(a, b)))
+
+    // a fully-connected three-read clique
+    g = Graph(a ~ b % 1, b ~ c % 2, a ~ c % 3)
+    assert(findCliques(g, 100).map(_.reads) === Seq(Set(a, b, c)))
+
+    // Read c is not part of the clique, but a lower-weight read, d, is.
+    g = Graph(a ~ b % 1, b ~ c % 2, c ~ d % 3, a ~ d % 4, d ~ b % 5)
+    assert(findCliques(g, 100).map(_.reads) === Seq(Set(a, b, d)))
+
+    // {a, c, d} is the maximal clique but we miss it because a~b has stronger agreement
+    g = Graph(a ~ b % 1, a ~ c % 2, a ~ d % 3, c ~ d % 4)
+    assert(findCliques(g, 100).map(_.reads) === Seq(Set(a, b)))
+
+    // disjoint components -- the ordering of the components is arbitrary
+    g = Graph(a ~ b % 1, c ~ d % 2)
+    assert(findCliques(g, 100).map(_.reads).toSet === Set(Set(a, b), Set(c, d)))
+  }
+
+  // The clique detection tests are entirely for graph operations. This checks cases where there is a clique,
+  // but some paired reads are incompatible with the intersection of gaps between other reads in the clique.
+  test("clique detection with alignment limitations") {
+    // In this situation, all three reads are compatible with each other pairwise, but there is no deletion which
+    // would make all three normal reads. Hence they can't all form a clique representing a single SV.
+    //    <-- ...... -->
+    //      <-- ...... -->
+    // <-- ................ -->
+    //          xxxx
+    // (The xs mark the largest deletion possible with all three reads. It's incompatible with the third read.)
+    val (a, b, c) = (
+      makePair(100, 120, 380, 400),
+      makePair(200, 220, 480, 500),
+      makePair(0, 20, 580, 600)
+    )
+    val findCliques = StructuralVariant.Caller.findCliques(_, _)
+
+    val g = Graph(a ~ b % 1, b ~ c % 2, a ~ c % 3)
+    val Seq(sv) = findCliques(g, 400)
+    assert(sv.reads === Set(a, b))
+    assert(sv.span === GenomeRange("chr1", 220, 380))
+    assert(sv.wiggle == 260)  // the deletion could be made 260bp smaller & the reads would still be OK
   }
 
 }

--- a/src/test/scala/org/hammerlab/guacamole/commands/StructuralVariantCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/StructuralVariantCallerSuite.scala
@@ -180,7 +180,7 @@ class StructuralVariantCallerSuite extends GuacFunSuite with Matchers {
     val Seq(sv) = findCliques(g, 400)
     assert(sv.reads === Set(a, b))
     assert(sv.span === GenomeRange("chr1", 220, 380))
-    assert(sv.wiggle == 260)  // the deletion could be made 260bp smaller & the reads would still be OK
+    assert(sv.wiggle == 260) // the deletion could be made 260bp smaller & the reads would still be OK
   }
 
 }

--- a/src/test/scala/org/hammerlab/guacamole/commands/StructuralVariantCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/StructuralVariantCallerSuite.scala
@@ -118,7 +118,9 @@ class StructuralVariantCallerSuite extends GuacFunSuite with Matchers {
     )
 
     val graph = StructuralVariant.Caller.buildVariantGraph(reads, 100)
-    assert(graph === Graph(reads(1) ~ reads(2) % 1))
+    assert(graph === Graph(reads(1) ~ reads(2) % 0))
+    // See https://github.com/scala-graph/scala-graph/issues/46
+    assert(graph.totalWeight == 0)
 
     // TODO: test overlapping but incompatible pairs
     // TODO: test reads with mateStart < start


### PR DESCRIPTION
DELLY's heuristic for finding a maximal clique is:

```
For each connected component:
  Collect all the edges within the component
  Sort the edges by weight (increasing)
  Seed the clique with the vertex that is the source of the lowest-weight edge.
      (Because of the way that the graph is constructed, this will have an earlier start position.)

  Repeat:
    Find the lowest-weight edge which connects a new node to the current clique.
    Add it to the clique if it's fully-connected and the resulting SV would still place all insert sizes in range.
```

Now that I have some tests in place, I'd like to refactor the clique-growing logic to be a bit cleaner.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/343)
<!-- Reviewable:end -->
