### PR TITLE
PoC: one-pass affine alignment; other CR nits

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/alignment/AffineGapPenaltyAlignment.scala
+++ b/src/main/scala/org/hammerlab/guacamole/alignment/AffineGapPenaltyAlignment.scala
@@ -37,7 +37,7 @@ object AffineGapPenaltyAlignment {
         closeGapProbability
       )
 
-    val (path, score) = alignments(sequence.length, reference.length)
+    val (path, score) = (for (i <- 0 to reference.length) yield { alignments(sequence.length, i) }).minBy(_._2)
     ReadAlignment(path, score.toInt)
   }
 
@@ -112,7 +112,7 @@ object AffineGapPenaltyAlignment {
           val (prevPath, prevScore) = alignments(prevSeqPos, prevRefPos)
           val prevStateOpt = prevPath.lastOption
 
-          val isEndState = (sequenceIdx == sequenceLength && referenceIdx == referenceLength)
+          val isEndState = sequenceIdx == sequenceLength
 
           val transitionCost = transitionPenalty(nextState, prevStateOpt, isEndState = isEndState)
           (prevPath :+ nextState, prevScore + transitionCost)

--- a/src/main/scala/org/hammerlab/guacamole/alignment/AffineGapPenaltyAlignment.scala
+++ b/src/main/scala/org/hammerlab/guacamole/alignment/AffineGapPenaltyAlignment.scala
@@ -37,8 +37,8 @@ object AffineGapPenaltyAlignment {
         closeGapProbability
       )
 
-    val (refStartIdx, path, score) = (for (i <- 0 to reference.length) yield { alignments(sequence.length, i) }).minBy(_._3)
-    ReadAlignment(path, score.toInt)
+    val ((refStartIdx, path, score), refEndIdx) = (for (i <- 0 to reference.length) yield { (alignments(sequence.length, i), i) }).minBy(_._1._3)
+    ReadAlignment(path, reference.slice(refStartIdx, refEndIdx), score.toInt)
   }
 
   def scoreAlignmentPaths(sequence: Seq[Byte],

--- a/src/main/scala/org/hammerlab/guacamole/alignment/ReadAlignment.scala
+++ b/src/main/scala/org/hammerlab/guacamole/alignment/ReadAlignment.scala
@@ -17,6 +17,7 @@ object AlignmentState extends Enumeration {
  * @param alignmentScore Score of the alignment
  */
 case class ReadAlignment(alignments: Seq[AlignmentState],
+                         refBases: Seq[Byte],
                          alignmentScore: Int) {
 
   /**

--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineStandardCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineStandardCaller.scala
@@ -50,7 +50,7 @@ object GermlineStandard {
     override def run(args: Arguments, sc: SparkContext): Unit = {
       Common.validateArguments(args)
       val readSet = Common.loadReadsFromArguments(
-          args, sc, Read.InputFilters(mapped = true, nonDuplicate = true, hasMdTag = true))
+        args, sc, Read.InputFilters(mapped = true, nonDuplicate = true, hasMdTag = true))
       readSet.mappedReads.persist()
       Common.progress(
         "Loaded %,d mapped non-duplicate reads into %,d partitions.".format(readSet.mappedReads.count, readSet.mappedReads.partitions.length))

--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineThresholdCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineThresholdCaller.scala
@@ -58,7 +58,7 @@ object GermlineThreshold {
     override def run(args: Arguments, sc: SparkContext): Unit = {
       Common.validateArguments(args)
       val readSet = Common.loadReadsFromArguments(
-          args, sc, Read.InputFilters(mapped = true, nonDuplicate = true, hasMdTag = true))
+        args, sc, Read.InputFilters(mapped = true, nonDuplicate = true, hasMdTag = true))
 
       readSet.mappedReads.persist()
       Common.progress("Loaded %,d mapped non-duplicate MdTag-containing reads into %,d partitions.".format(

--- a/src/main/scala/org/hammerlab/guacamole/reads/MappedRead.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/MappedRead.scala
@@ -124,12 +124,11 @@ object MappedRead {
     failedVendorQualityChecks: Boolean,
     isPositiveStrand: Boolean,
     isPaired: Boolean)(implicit d: DummyImplicit): MappedRead = MappedRead(
-      token, sequence, baseQualities, isDuplicate, sampleName, referenceContig,
-      alignmentQuality, start, cigar,
-      mdTagString.map(MdTag(_, start)),
-      failedVendorQualityChecks, isPositiveStrand, isPaired)
+    token, sequence, baseQualities, isDuplicate, sampleName, referenceContig,
+    alignmentQuality, start, cigar,
+    mdTagString.map(MdTag(_, start)),
+    failedVendorQualityChecks, isPositiveStrand, isPaired)
 }
-
 
 case class MissingMDTagException(record: SAMRecord)
   extends Exception(s"Missing MDTag in SAMRecord: $record")

--- a/src/test/scala/org/hammerlab/guacamole/alignment/AffineGapPenaltyAlignmentSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/alignment/AffineGapPenaltyAlignmentSuite.scala
@@ -13,7 +13,7 @@ class AffineGapPenaltyAlignmentSuite extends FunSuite with Matchers {
       openGapProbability = 1e-3,
       closeGapProbability = 1e-2
     )
-    alignments(4, 4)._2.toInt should be(0)
+    alignments(4, 4)._3.toInt should be(0)
   }
 
   test("score alignment: single mismatch") {
@@ -24,7 +24,7 @@ class AffineGapPenaltyAlignmentSuite extends FunSuite with Matchers {
       openGapProbability = 1e-3,
       closeGapProbability = 1e-2
     )
-    math.round(alignments(4, 4)._2) should be(5)
+    math.round(alignments(4, 4)._3) should be(5)
   }
 
   test("align exact match") {

--- a/src/test/scala/org/hammerlab/guacamole/alignment/AffineGapPenaltyAlignmentSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/alignment/AffineGapPenaltyAlignmentSuite.scala
@@ -6,25 +6,25 @@ import org.hammerlab.guacamole.util.TestUtil.Implicits._
 class AffineGapPenaltyAlignmentSuite extends FunSuite with Matchers {
 
   test("score alignment: exact match") {
-    val (alignmentStates, alignmentScores) = AffineGapPenaltyAlignment.scoreAlignmentPaths(
+    val alignments = AffineGapPenaltyAlignment.scoreAlignmentPaths(
       "TCGA",
       "TCGA",
       mismatchProbability = 1e-2,
       openGapProbability = 1e-3,
       closeGapProbability = 1e-2
     )
-    alignmentScores(4, 4).toInt should be(0)
+    alignments(4, 4)._2.toInt should be(0)
   }
 
   test("score alignment: single mismatch") {
-    val (alignmentStates, alignmentScores) = AffineGapPenaltyAlignment.scoreAlignmentPaths(
+    val alignments = AffineGapPenaltyAlignment.scoreAlignmentPaths(
       "TCGA",
       "TCCA",
       mismatchProbability = 1e-2,
       openGapProbability = 1e-3,
       closeGapProbability = 1e-2
     )
-    math.round(alignmentScores(4, 4)) should be(5)
+    math.round(alignments(4, 4)._2) should be(5)
   }
 
   test("align exact match") {

--- a/src/test/scala/org/hammerlab/guacamole/alignment/ReadAlignmentSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/alignment/ReadAlignmentSuite.scala
@@ -12,7 +12,11 @@ class ReadAlignmentSuite extends FunSuite with Matchers {
         AlignmentState.Match,
         AlignmentState.Match,
         AlignmentState.Match,
-        AlignmentState.Match), 60)
+        AlignmentState.Match
+      ),
+      Nil,
+      60
+    )
 
     alignment.toCigar should be("6=")
   }
@@ -25,7 +29,11 @@ class ReadAlignmentSuite extends FunSuite with Matchers {
         AlignmentState.Match,
         AlignmentState.Insertion,
         AlignmentState.Insertion,
-        AlignmentState.Match), 60)
+        AlignmentState.Match
+      ),
+      Nil,
+      60
+    )
 
     alignment.toCigar should be("3=2I1=")
   }
@@ -38,7 +46,11 @@ class ReadAlignmentSuite extends FunSuite with Matchers {
         AlignmentState.Insertion,
         AlignmentState.Insertion,
         AlignmentState.Insertion,
-        AlignmentState.Match), 60)
+        AlignmentState.Match
+      ),
+      Nil,
+      60
+    )
 
     alignment.toCigar should be("1=4I1=")
   }
@@ -51,7 +63,11 @@ class ReadAlignmentSuite extends FunSuite with Matchers {
         AlignmentState.Mismatch,
         AlignmentState.Match,
         AlignmentState.Match,
-        AlignmentState.Match), 60)
+        AlignmentState.Match
+      ),
+      Nil,
+      60
+    )
 
     alignment.toCigar should be("1=2X3=")
   }


### PR DESCRIPTION
* combine the two matrices into one
* store full paths instead of just last alignments
* treat 0th row and col correctly
* explicitly `Option` "previous state"
* allow alignment to start and end inside the provided reference bases

don't feel that strongly about most of this, but interested to hear thoughts @arahuja

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/353)
<!-- Reviewable:end -->
