### PR TITLE
Updates to simple alignment to single-pass and matrix pruning

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/alignment/AffineGapPenaltyAlignment.scala
+++ b/src/main/scala/org/hammerlab/guacamole/alignment/AffineGapPenaltyAlignment.scala
@@ -37,7 +37,7 @@ object AffineGapPenaltyAlignment {
         closeGapProbability
       )
 
-    val (path, score) = alignments(sequence.length, reference.length)
+    val (path, score) = (for (i <- 0 to reference.length) yield { alignments(sequence.length, i) }).minBy(_._2)
     ReadAlignment(path, score.toInt)
   }
 
@@ -112,7 +112,7 @@ object AffineGapPenaltyAlignment {
           val (prevPath, prevScore) = alignments(prevSeqPos, prevRefPos)
           val prevStateOpt = prevPath.lastOption
 
-          val isEndState = (sequenceIdx == sequenceLength && referenceIdx == referenceLength)
+          val isEndState = sequenceIdx == sequenceLength
 
           val transitionCost = transitionPenalty(nextState, prevStateOpt, isEndState = isEndState)
           (prevPath :+ nextState, prevScore + transitionCost)

--- a/src/main/scala/org/hammerlab/guacamole/alignment/AffineGapPenaltyAlignment.scala
+++ b/src/main/scala/org/hammerlab/guacamole/alignment/AffineGapPenaltyAlignment.scala
@@ -5,7 +5,7 @@ import org.hammerlab.guacamole.alignment.AlignmentState.{AlignmentState, isGapAl
 
 object AffineGapPenaltyAlignment {
 
-  type Path = (Int, Seq[AlignmentState], Double)
+  type Path = (Int, Vector[AlignmentState], Double)
 
   /**
    * Produces an alignment of an input sequence against a reference sequence
@@ -66,7 +66,7 @@ object AffineGapPenaltyAlignment {
     for {
       refIdx <- 0 to referenceLength
     } {
-      lastSequenceAlignment(refIdx) = (refIdx, Nil, 0)
+      lastSequenceAlignment(refIdx) = (refIdx, Vector.empty, 0)
     }
     var currentSequenceAlignment = new DenseVector[Path](referenceLength + 1)
 

--- a/src/main/scala/org/hammerlab/guacamole/alignment/AffineGapPenaltyAlignment.scala
+++ b/src/main/scala/org/hammerlab/guacamole/alignment/AffineGapPenaltyAlignment.scala
@@ -37,8 +37,8 @@ object AffineGapPenaltyAlignment {
         closeGapProbability
       )
 
-    val (refStartIdx, path, score) = (for (i <- 0 to reference.length) yield { alignments(sequence.length, i) }).minBy(_._3)
-    ReadAlignment(path, score.toInt)
+    val ((refStartIdx, path, score), refEndIdx) = (for (i <- 0 to reference.length) yield { (alignments(sequence.length, i), i) }).minBy(_._1._3)
+    ReadAlignment(path, reference.slice(refStartIdx, refEndIdx), score.toInt)
   }
 
   def scoreAlignmentPaths(sequence: Seq[Byte],

--- a/src/main/scala/org/hammerlab/guacamole/alignment/ReadAlignment.scala
+++ b/src/main/scala/org/hammerlab/guacamole/alignment/ReadAlignment.scala
@@ -17,6 +17,7 @@ object AlignmentState extends Enumeration {
  * @param alignmentScore Score of the alignment
  */
 case class ReadAlignment(alignments: Seq[AlignmentState],
+                         refBases: Seq[Byte],
                          alignmentScore: Int) {
 
   /**

--- a/src/test/scala/org/hammerlab/guacamole/alignment/AffineGapPenaltyAlignmentSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/alignment/AffineGapPenaltyAlignmentSuite.scala
@@ -13,7 +13,7 @@ class AffineGapPenaltyAlignmentSuite extends FunSuite with Matchers {
       openGapProbability = 1e-3,
       closeGapProbability = 1e-2
     )
-    alignments(4, 4)._2.toInt should be(0)
+    alignments(4, 4)._3.toInt should be(0)
   }
 
   test("score alignment: single mismatch") {
@@ -24,7 +24,7 @@ class AffineGapPenaltyAlignmentSuite extends FunSuite with Matchers {
       openGapProbability = 1e-3,
       closeGapProbability = 1e-2
     )
-    math.round(alignments(4, 4)._2) should be(5)
+    math.round(alignments(4, 4)._3) should be(5)
   }
 
   test("align exact match") {

--- a/src/test/scala/org/hammerlab/guacamole/alignment/AffineGapPenaltyAlignmentSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/alignment/AffineGapPenaltyAlignmentSuite.scala
@@ -13,7 +13,7 @@ class AffineGapPenaltyAlignmentSuite extends FunSuite with Matchers {
       openGapProbability = 1e-3,
       closeGapProbability = 1e-2
     )
-    alignments(4, 4)._3.toInt should be(0)
+    alignments(4)._3.toInt should be(0)
   }
 
   test("score alignment: single mismatch") {
@@ -24,7 +24,7 @@ class AffineGapPenaltyAlignmentSuite extends FunSuite with Matchers {
       openGapProbability = 1e-3,
       closeGapProbability = 1e-2
     )
-    math.round(alignments(4, 4)._3) should be(5)
+    math.round(alignments(4)._3) should be(5)
   }
 
   test("align exact match") {

--- a/src/test/scala/org/hammerlab/guacamole/alignment/AffineGapPenaltyAlignmentSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/alignment/AffineGapPenaltyAlignmentSuite.scala
@@ -6,25 +6,25 @@ import org.hammerlab.guacamole.util.TestUtil.Implicits._
 class AffineGapPenaltyAlignmentSuite extends FunSuite with Matchers {
 
   test("score alignment: exact match") {
-    val (alignmentStates, alignmentScores) = AffineGapPenaltyAlignment.scoreAlignmentPaths(
+    val alignments = AffineGapPenaltyAlignment.scoreAlignmentPaths(
       "TCGA",
       "TCGA",
       mismatchProbability = 1e-2,
       openGapProbability = 1e-3,
       closeGapProbability = 1e-2
     )
-    alignmentScores(4, 4).toInt should be(0)
+    alignments(4, 4)._2.toInt should be(0)
   }
 
   test("score alignment: single mismatch") {
-    val (alignmentStates, alignmentScores) = AffineGapPenaltyAlignment.scoreAlignmentPaths(
+    val alignments = AffineGapPenaltyAlignment.scoreAlignmentPaths(
       "TCGA",
       "TCCA",
       mismatchProbability = 1e-2,
       openGapProbability = 1e-3,
       closeGapProbability = 1e-2
     )
-    math.round(alignmentScores(4, 4)) should be(5)
+    math.round(alignments(4, 4)._2) should be(5)
   }
 
   test("align exact match") {

--- a/src/test/scala/org/hammerlab/guacamole/alignment/ReadAlignmentSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/alignment/ReadAlignmentSuite.scala
@@ -12,7 +12,11 @@ class ReadAlignmentSuite extends FunSuite with Matchers {
         AlignmentState.Match,
         AlignmentState.Match,
         AlignmentState.Match,
-        AlignmentState.Match), 60)
+        AlignmentState.Match
+      ),
+      Nil,
+      60
+    )
 
     alignment.toCigar should be("6=")
   }
@@ -25,7 +29,11 @@ class ReadAlignmentSuite extends FunSuite with Matchers {
         AlignmentState.Match,
         AlignmentState.Insertion,
         AlignmentState.Insertion,
-        AlignmentState.Match), 60)
+        AlignmentState.Match
+      ),
+      Nil,
+      60
+    )
 
     alignment.toCigar should be("3=2I1=")
   }
@@ -38,7 +46,11 @@ class ReadAlignmentSuite extends FunSuite with Matchers {
         AlignmentState.Insertion,
         AlignmentState.Insertion,
         AlignmentState.Insertion,
-        AlignmentState.Match), 60)
+        AlignmentState.Match
+      ),
+      Nil,
+      60
+    )
 
     alignment.toCigar should be("1=4I1=")
   }
@@ -51,7 +63,11 @@ class ReadAlignmentSuite extends FunSuite with Matchers {
         AlignmentState.Mismatch,
         AlignmentState.Match,
         AlignmentState.Match,
-        AlignmentState.Match), 60)
+        AlignmentState.Match
+      ),
+      Nil,
+      60
+    )
 
     alignment.toCigar should be("1=2X3=")
   }


### PR DESCRIPTION
@ryan-williams I couldn't figure out the git surgery to split the first commit out so ended up just implementing it with only saving see 2 rows of the matrix.  There is only one new commit here compared to #353, aa6a356

This is a PR against `simple-alignment` but then we can merge all of these in.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/358)
<!-- Reviewable:end -->
