### PR TITLE
Assorted infra tweaks

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/Bases.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Bases.scala
@@ -48,6 +48,21 @@ object Bases {
     }
   }
 
+  /** Watson-Crick complement of a base. */
+  def complement(base: Byte) = base match {
+    case A => T
+    case T => A
+    case C => G
+    case G => C
+    case _ => N
+  }
+
+  /** Watson-Crick complement of a sequence of bases. */
+  def complement(bases: Seq[Byte]): Seq[Byte] = bases.map(complement _)
+
+  /** Watson-Crick complement of a sequence of bases, with the sequence reversed. */
+  def reverseComplement(bases: Seq[Byte]): Seq[Byte] = complement(bases.reverse)
+
   /** Is the given base one of the 4 canonical DNA bases? */
   def isStandardBase(base: Byte): Boolean = {
     base == Bases.A || base == Bases.C || base == Bases.T || base == Bases.G

--- a/src/main/scala/org/hammerlab/guacamole/Common.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Common.scala
@@ -200,24 +200,7 @@ object Common extends Logging {
       "all"
     }
 
-    val result = {
-      if (lociToParse == "all") {
-        // Call at all loci.
-        val builder = LociSet.newBuilder
-        readSet.contigLengths.foreach(contigNameAndLength => builder.put(contigNameAndLength._1, 0L, contigNameAndLength._2))
-        builder.result
-      } else {
-        // Call at specified loci.
-        val parsed = LociSet.parse(lociToParse)
-
-        // Check that loci given are in the sequence dictionary.
-        parsed.contigs.foreach(contig => {
-          if (!readSet.contigLengths.contains(contig))
-            throw new IllegalArgumentException("No such contig: '%s'.".format(contig))
-        })
-        parsed
-      }
-    }
+    val result = LociSet.parse(lociToParse, Some(readSet.contigLengths))
     progress("Including %,d loci across %,d contig(s): %s".format(
       result.count,
       result.contigs.length,

--- a/src/main/scala/org/hammerlab/guacamole/LociSet.scala
+++ b/src/main/scala/org/hammerlab/guacamole/LociSet.scala
@@ -136,7 +136,10 @@ object LociSet {
    * Return a LociSet parsed from a string representation.
    *
    * @param loci A string of the form "CONTIG:START-END,CONTIG:START-END,..." where CONTIG is a string giving the
-   *             contig name, and START and END are integers. Whitespace is ignored.
+   *             contig name, and START and END are integers. Whitespace is ignored. The :START-END suffix is optional
+   *             if the contigLengths parameter is specified, and defaults to start=0 end=length of contig - 1.
+   * @param contigLengths Optional map: contig name -> length.
+   * @return
    */
   def parse(loci: String, contigLengths: Option[Map[String, Long]] = None): LociSet = {
     def maybeCheckContigIsValid(contig: String): Unit = contigLengths match {

--- a/src/main/scala/org/hammerlab/guacamole/alignment/AffineGapPenaltyAlignment.scala
+++ b/src/main/scala/org/hammerlab/guacamole/alignment/AffineGapPenaltyAlignment.scala
@@ -1,7 +1,7 @@
 package org.hammerlab.guacamole.alignment
 
 import breeze.linalg.DenseVector
-import org.hammerlab.guacamole.alignment.AlignmentState.{AlignmentState, isGapAlignment}
+import org.hammerlab.guacamole.alignment.AlignmentState.{ AlignmentState, isGapAlignment }
 
 object AffineGapPenaltyAlignment {
 
@@ -104,7 +104,7 @@ object AffineGapPenaltyAlignment {
             (sequenceIdx, referenceIdx - 1),
             (sequenceIdx - 1, referenceIdx - 1)
           ).filter {
-              case (sI, rI) => sI >= 0 && rI >= 0  // Filter positions before the start of either sequence
+              case (sI, rI) => sI >= 0 && rI >= 0 // Filter positions before the start of either sequence
             }
 
         // Compute the transition costs based on the gap penalties
@@ -133,7 +133,7 @@ object AffineGapPenaltyAlignment {
       }
       // Save current sequence position alignment position
       lastSequenceAlignment = currentSequenceAlignment
-      
+
       // Clear alignment information before next sequence element
       currentSequenceAlignment = new DenseVector[Path](referenceLength + 1)
     }

--- a/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
@@ -193,12 +193,14 @@ object SomaticStandard {
        * Find the most likely genotype in the tumor sample
        * This is either the reference genotype or an heterozygous genotype with some alternate base
        */
-      val (mostLikelyTumorGenotype, mostLikelyTumorGenotypeLikelihood) =
-        Likelihood.likelihoodsOfAllPossibleGenotypesFromPileup(
-          filteredTumorPileup,
-          Likelihood.probabilityCorrectIncludingAlignment,
-          normalize = true
-        ).maxBy(_._2)
+      val genotypesAndLikelihoods = Likelihood.likelihoodsOfAllPossibleGenotypesFromPileup(
+        filteredTumorPileup,
+        Likelihood.probabilityCorrectIncludingAlignment,
+        normalize = true)
+      if (genotypesAndLikelihoods.isEmpty)
+        return Seq.empty
+
+      val (mostLikelyTumorGenotype, mostLikelyTumorGenotypeLikelihood) = genotypesAndLikelihoods.maxBy(_._2)
 
       // The following lazy vals are only evaluated if mostLikelyTumorGenotype.hasVariantAllele
       lazy val normalLikelihoods =

--- a/src/main/scala/org/hammerlab/guacamole/likelihood/Likelihood.scala
+++ b/src/main/scala/org/hammerlab/guacamole/likelihood/Likelihood.scala
@@ -21,6 +21,7 @@ package org.hammerlab.guacamole.likelihood
 import cern.colt.matrix.impl.DenseDoubleMatrix2D
 import cern.jet.math.Functions
 import org.bdgenomics.adam.util.PhredUtils
+import org.hammerlab.guacamole.Bases
 import org.hammerlab.guacamole.pileup.{ PileupElement, Pileup }
 import org.hammerlab.guacamole.variants.{ Allele, Genotype }
 
@@ -102,7 +103,7 @@ object Likelihood {
     logSpace: Boolean = false,
     normalize: Boolean = false): Seq[(Genotype, Double)] = {
 
-    val alleles = pileup.distinctAlleles
+    val alleles = pileup.distinctAlleles.filter(allele => allele.altBases.forall((Bases.isStandardBase _)))
     val genotypes = for {
       i <- 0 until alleles.size
       j <- i until alleles.size

--- a/src/test/scala/org/hammerlab/guacamole/BasesSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/BasesSuite.scala
@@ -1,0 +1,29 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hammerlab.guacamole
+
+import org.scalatest.{ FunSuite, Matchers }
+
+class BasesSuite extends FunSuite with Matchers {
+
+  test("string conversions, reverse complement") {
+    Bases.basesToString(Bases.reverseComplement(Bases.stringToBases("AGGTCA"))) should equal("TGACCT")
+  }
+
+}

--- a/src/test/scala/org/hammerlab/guacamole/LociSetSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/LociSetSuite.scala
@@ -18,8 +18,6 @@
 
 package org.hammerlab.guacamole
 
-import org.apache.commons.io.FileUtils
-import org.apache.hadoop.fs.FileUtil
 import org.apache.spark.rdd.RDD
 import org.hammerlab.guacamole.util.{ TestUtil, GuacFunSuite }
 import org.hammerlab.guacamole.reads.Read
@@ -80,7 +78,7 @@ class LociSetSuite extends GuacFunSuite with Matchers {
       "with_dots.and_underscores..2:100-200",
       "21:300-400",
       "X:5-17,X:19-22,Y:50-60",
-      "chr21:100-200,chr20:0-10,chr20:8-15,chr20:100-120").map(LociSet.parse)
+      "chr21:100-200,chr20:0-10,chr20:8-15,chr20:100-120").map(LociSet.parse(_))
 
     def check_invariants(set: LociSet): Unit = {
       set should not be (null)
@@ -133,7 +131,7 @@ class LociSetSuite extends GuacFunSuite with Matchers {
       "21:300-400",
       "with_dots._and_..underscores11:900-1000",
       "X:5-17,X:19-22,Y:50-60",
-      "chr21:100-200,chr20:0-10,chr20:8-15,chr20:100-120").map(LociSet.parse)
+      "chr21:100-200,chr20:0-10,chr20:8-15,chr20:100-120").map(LociSet.parse(_))
     val rdd = sc.parallelize(sets)
     val result = rdd.map(_.toString).collect.toSeq
     result should equal(sets.map(_.toString).toSeq)
@@ -146,7 +144,7 @@ class LociSetSuite extends GuacFunSuite with Matchers {
       "20:100-200",
       "21:300-400",
       "X:5-17,X:19-22,Y:50-60",
-      "chr21:100-200,chr20:0-10,chr20:8-15,chr20:100-120").map(LociSet.parse)
+      "chr21:100-200,chr20:0-10,chr20:8-15,chr20:100-120").map(LociSet.parse(_))
     val rdd = sc.parallelize(sets)
     val result = rdd.map(set => {
       set.onContig("21").contains(5) // no op
@@ -160,6 +158,13 @@ class LociSetSuite extends GuacFunSuite with Matchers {
     val set1 = LociSet.parse("chr1:40-43")
     val set2 = LociSet.parse("chr1:40-42")
     set1.union(set2).toString should equal("chr1:40-43")
+  }
+
+  sparkTest("loci set parsing with contig lengths") {
+    LociSet.parse(
+      "chr1,chr2,17,chr2:3-5,chr20:10-20",
+      Some(Map("chr1" -> 10, "chr2" -> 20, "17" -> 12, "chr20" -> 5000))).toString should equal(
+        "17:0-12,chr1:0-10,chr2:0-20,chr20:10-20")
   }
 
   sparkTest("loci set single contig iterator basic") {


### PR DESCRIPTION
Some small tweaks I have accumulated in another branch and wanted to get into master:

* Don't emit alt=N variants in somatic standard
* Base complementing in `Bases`
* `LociSet.parse` accepts strings like `chr1,chr2` instead of requiring start and ends
* Slightly better progress message in Distributed loci partitioning
