### PR TITLE
Default to spark parallelism setting

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/DistributedUtil.scala
+++ b/src/main/scala/org/hammerlab/guacamole/DistributedUtil.scala
@@ -55,7 +55,8 @@ object DistributedUtil extends Logging {
   def partitionLociAccordingToArgs[M <: HasReferenceRegion: ClassTag](args: Arguments,
                                                                       loci: LociSet,
                                                                       regionRDDs: RDD[M]*): LociMap[Long] = {
-    val tasks = if (args.parallelism > 0) args.parallelism else regionRDDs(0).partitions.length
+    val sc = regionRDDs.head.sparkContext
+    val tasks = if (args.parallelism > 0) args.parallelism else sc.defaultParallelism
     if (args.partitioningAccuracy == 0) {
       partitionLociUniformly(tasks, loci)
     } else {


### PR DESCRIPTION
Closes #344

This sets the spark setting as the default.  Though it may be confusing to have both though, so I'd be ok with removing this option as well?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/364)
<!-- Reviewable:end -->
