### PR TITLE
faster unmasking (i.e. lowercasing) of reference sequence in Bases.scala

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/Bases.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Bases.scala
@@ -109,20 +109,18 @@ object Bases {
    * Convert a mixed sequence of bases (lower and upper-case) to upper case
    * Lower-case bases typically represent masked bases
    *
+   * Works in place.
+   *
    * @param bases Byte array of bases
    * @return Unmasked (upper-case) byte array of bases
    */
-  def unmaskBases(bases: Array[Byte]): Array[Byte] = {
-    bases.map(base =>
-      base match {
-        case (Bases.A | Bases.a) => Bases.A
-        case (Bases.G | Bases.g) => Bases.G
-        case (Bases.T | Bases.t) => Bases.T
-        case (Bases.C | Bases.c) => Bases.C
-        case (Bases.N | Bases.n) => Bases.N
-        case (other: Byte)       => other.toChar.toUpper.toByte
-      }
-    )
+  def unmaskBases(bases: Array[Byte]): Unit = {
+    // We modify the array in place.
+    var i = 0
+    while (i < bases.length) {
+      bases(i) = java.lang.Character.toUpperCase(bases(i)).toByte
+      i += 1
+    }
   }
 
 }

--- a/src/main/scala/org/hammerlab/guacamole/reference/ReferenceBroadcast.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reference/ReferenceBroadcast.scala
@@ -43,7 +43,8 @@ object ReferenceBroadcast {
     val broadcastedSequences = Map.newBuilder[String, Broadcast[Array[Byte]]]
     while (nextSequence != null) {
       val sequenceName = nextSequence.getName
-      val sequence = Bases.unmaskBases(nextSequence.getBases)
+      val sequence = nextSequence.getBases
+      Bases.unmaskBases(sequence)
       val broadcastedSequence = sc.broadcast(sequence)
 
       broadcastedSequences += ((sequenceName, broadcastedSequence))


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/373)
<!-- Reviewable:end -->
