### PR TITLE
Make Structural Variant caller work for adam.

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
@@ -524,9 +524,9 @@ object Read extends Logging {
     if (alignmentRecord.getReadPaired) {
       val mateAlignment = if (alignmentRecord.getMateMapped) Some(
         MateAlignmentProperties(
-          referenceContig = alignmentRecord.getMateContig.getContigName.intern,
+          referenceContig = alignmentRecord.getMateContig.getContigName.intern(),
           start = alignmentRecord.getMateAlignmentStart,
-          inferredInsertSize = None,
+          inferredInsertSize = if (alignmentRecord.getInferredInsertSize != 0 && alignmentRecord.getInferredInsertSize != null) Some(alignmentRecord.getInferredInsertSize.toInt) else None,
           isPositiveStrand = !alignmentRecord.getMateNegativeStrand
         )
       )

--- a/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
@@ -466,37 +466,7 @@ object Read extends Logging {
 
     val adamContext = new ADAMContext(sc)
 
-    // Build a projection that will only load the fields we will need to populate a Read
-    val ADAMSpecificProjection = Projection(
-      AlignmentRecordField.recordGroupSample,
-
-      AlignmentRecordField.sequence,
-      AlignmentRecordField.qual,
-
-      // Alignment properties
-      AlignmentRecordField.readMapped,
-      AlignmentRecordField.contig,
-      AlignmentRecordField.start,
-      AlignmentRecordField.readNegativeStrand,
-      AlignmentRecordField.cigar,
-      AlignmentRecordField.mapq,
-      AlignmentRecordField.mismatchingPositions,
-
-      // Filter flags
-      AlignmentRecordField.duplicateRead,
-      AlignmentRecordField.failedVendorQualityChecks,
-
-      // Mate fields
-      AlignmentRecordField.readPaired,
-      AlignmentRecordField.mateMapped,
-      AlignmentRecordField.firstOfPair,
-      AlignmentRecordField.mateContig,
-      AlignmentRecordField.mateAlignmentStart,
-      AlignmentRecordField.mateNegativeStrand,
-      AlignmentRecordField.recordGroupPredictedMedianInsertSize
-    )
-
-    val adamRecords: RDD[AlignmentRecord] = adamContext.loadParquet(filename, projection = Some(ADAMSpecificProjection))
+    val adamRecords: RDD[AlignmentRecord] = adamContext.loadAlignments(filename, projection = None, stringency = ValidationStringency.LENIENT)
     val sequenceDictionary = new ADAMSpecificRecordSequenceDictionaryRDDAggregator(adamRecords).adamGetSequenceDictionary()
 
     val allReads: RDD[Read] = adamRecords.map(fromADAMRecord(_, token, referenceGenome))
@@ -554,7 +524,7 @@ object Read extends Logging {
     if (alignmentRecord.getReadPaired) {
       val mateAlignment = if (alignmentRecord.getMateMapped) Some(
         MateAlignmentProperties(
-          referenceContig = alignmentRecord.getMateContig.toString,
+          referenceContig = alignmentRecord.getMateContig.getContigName.intern,
           start = alignmentRecord.getMateAlignmentStart,
           inferredInsertSize = None,
           isPositiveStrand = !alignmentRecord.getMateNegativeStrand


### PR DESCRIPTION
The boolean in line 106 of StructuralVariantCaller.scala is always false, because of the different types of line 519 and 557 in Read.scala. So I changed that. To work with Delly you need to know the insert size, that is not loaded in 470 Read.scala (see https://github.com/bigdatagenomics/bdg-formats/issues/37 and https://github.com/bigdatagenomics/adam/issues/729). The “inferredInsertSize” is not always None for Dally 559 in Read.scala. So I changed that to make it Null when it is None or zero (43 MateAlignmentProperties.scala).

This makes the boolean on line 106 of StructuralVariantCaller.scala true and ensures “getExceptionalReads” has an insert size to work with. So that Structural Variant caller, no more empty files returns.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/378)
<!-- Reviewable:end -->
