### PR TITLE
Updating germline assembly to determine anchor from reads

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/assembly/DeBruijnGraph.scala
+++ b/src/main/scala/org/hammerlab/guacamole/assembly/DeBruijnGraph.scala
@@ -140,12 +140,12 @@ class DeBruijnGraph(val kmerSize: Int,
     // Kmer next in the path
     def nextNodes(currentNode: Kmer) =
       if (avoidLoops)
-        nextFunc(current).filterNot(visited.contains)
+        nextFunc(currentNode).filterNot(visited.contains)
       else
-        nextFunc(current)
+        nextFunc(currentNode)
 
     var next = nextNodes(current)
-    var mergeable = List(kmer)
+    var mergeable = List(current)
 
     // While in/out-degree == 1
     while (next.size == 1 && prevFunc(next.head).size == 1) {

--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
@@ -59,6 +59,57 @@ object GermlineAssemblyCaller {
     override val description = "call germline variants by assembling the surrounding region of reads"
 
     /**
+     * Extract a subsequence from a read sequence
+     *
+     * NOTE: This assumes that the read entirely covers the reference region and does not check for insertions
+     * or deletion
+     *
+     * @param read Read to extract subsequence from
+     * @param startLocus Start (inclusive) locus on the reference
+     * @param endLocus End (exclusive) locus on the reference
+     * @return Subsequence overlapping [startLocus, endLocus)
+     */
+    def getSequenceFromRead(read: MappedRead, startLocus: Int, endLocus: Int) = {
+      read.sequence.slice(startLocus - read.unclippedStart.toInt, endLocus - read.unclippedStart.toInt)
+    }
+
+    /**
+     * For a given set of reads identify all kmers that appear in the specified reference region
+     *
+     * @param reads  Set of reads to extract sequence from
+     * @param startLocus Start (inclusive) locus on the reference
+     * @param endLocus End (exclusive) locus on the reference
+     * @param kmerSize Length of the subsequence
+     * @param minOccurrence Mininum number of times a subsequence needs to appear to be included
+     * @return List of subsequences overlapping [startLocus, endLocus) that appear at least `minOccurrence` time
+     */
+    def getConsensusKmer(reads: Seq[MappedRead],
+                         startLocus: Int,
+                         endLocus: Int,
+                         kmerSize: Int,
+                         minOccurrence: Int) = {
+
+      // Filter to reads that entirely cover the region
+      // Exclude reads that have any non-M Cigars (these don't have a 1 to 1 base mapping to the region)
+      val overlapping = reads
+        .filter(r => r.cigarElements.count(el => el.getOperator != CigarOperator.M) == 0)
+        .filter(r => r.overlapsLocus(startLocus) && r.overlapsLocus(endLocus - 1))
+
+      // Extract the sequences from each region
+      val sequences = overlapping
+        .map(r => (r, getSequenceFromRead(r, startLocus, endLocus)))
+
+      // Filter to sequences that appear at least `minOccurrence` times
+      sequences
+        .map(_._2)
+        .filter(_.size == kmerSize)
+        .groupBy(identity)
+        .map(kv => (kv._1, kv._2.length))
+        .filter(_._2 >= minOccurrence)
+        .map(_._1.toArray).toList
+    }
+
+    /**
      *
      * @param graph An existing DeBruijn graph of the reads
      * @param currentWindow Window of reads that overlaps the current loci
@@ -76,7 +127,7 @@ object GermlineAssemblyCaller {
                            reference: ReferenceGenome,
                            minOccurrence: Int = 3,
                            expectedPloidy: Int = 2,
-                           maxPathsToScore: Int = 6,
+                           maxPathsToScore: Int = 16,
                            debugPrint: Boolean = false): (Option[DeBruijnGraph], Iterator[CalledAllele]) = {
 
       val locus = currentWindow.currentLocus
@@ -84,15 +135,6 @@ object GermlineAssemblyCaller {
 
       val sampleName = reads.head.sampleName
       val referenceContig = reads.head.referenceContig
-
-      // TODO: Should update graph instead of rebuilding it
-      // Need to keep track of reads removed from last update and reads added
-      val currentGraph: DeBruijnGraph = DeBruijnGraph(
-        reads.map(_.sequence),
-        kmerSize,
-        minOccurrence,
-        mergeNodes = true
-      )
 
       val referenceStart = (locus - currentWindow.halfWindowSize).toInt
       val referenceEnd = (locus + currentWindow.halfWindowSize).toInt
@@ -103,46 +145,33 @@ object GermlineAssemblyCaller {
         referenceEnd
       )
 
-      val referenceKmerSource = currentReference.take(kmerSize)
-      val referenceKmerSink = currentReference.takeRight(kmerSize)
-
-      // If the current window size doesn't cover the kmer size we won't be able to find the reference start/end
-      if (currentReference.size < kmerSize || referenceKmerSource == referenceKmerSink) {
-        log.warn(s"In window ${referenceContig}:${referenceStart}-$referenceEnd " +
-          s"the start and end source kmers were invalid. " +
-          s"Start: ${Bases.basesToString(referenceKmerSource)} End: ${Bases.basesToString(referenceKmerSink)}")
-        return (graph, Iterator.empty)
-      }
-
-      if (debugPrint) {
-        println(s"Source: ${Bases.basesToString(referenceKmerSource)}")
-        println(s"Sink: ${Bases.basesToString(referenceKmerSink)}")
-      }
-
-      val paths = currentGraph.depthFirstSearch(
-        referenceKmerSource,
-        referenceKmerSink,
-        debugPrint = debugPrint
-      )
+      val paths = discoverPathsFromReads(
+        reads,
+        referenceStart,
+        referenceEnd,
+        currentReference,
+        kmerSize = kmerSize,
+        minOccurrence = minOccurrence,
+        maxPaths = maxPathsToScore + 1,
+        debugPrint)
 
       // Score up to the maximum number of paths, by aligning them against the reference
       // Take the best aligning `expectedPloidy` paths
       val pathAndAlignments =
-        if (paths.length <= maxPathsToScore) {
+        if (paths.size <= maxPathsToScore) {
           paths.map(path => {
             val mergedPath = DeBruijnGraph.mergeOverlappingSequences(path, kmerSize)
             (mergedPath, AffineGapPenaltyAlignment.align(mergedPath, currentReference))
-          })
+          }).toSeq
             .sortBy(_._2.alignmentScore)
             .take(expectedPloidy)
         } else {
           log.warn(s"In window ${referenceContig}:${referenceStart}-$referenceEnd " +
-            s"there were ${paths.length} paths found, all variants skipped")
+            s"there were ${paths.size} paths found, all variants skipped")
           List.empty
         }
 
-      // Build a variant using the current offset and
-      // read evidence
+      // Build a variant using the current offset and read evidence
       def buildVariant(referenceOffset: Int,
                        referenceBases: Array[Byte],
                        alternateBases: Array[Byte]) = {
@@ -196,7 +225,7 @@ object GermlineAssemblyCaller {
                 val referenceAllele = currentReference.slice(referenceIndex, referenceIndex + referenceLength)
                 val alternateAllele = path.slice(pathIndex, pathIndex + pathLength)
                 Some(buildVariant(referenceIndex, referenceAllele, alternateAllele.toArray))
-              case (CigarOperator.I | CigarOperator.D) =>
+              case (CigarOperator.I | CigarOperator.D) if referenceIndex != 0 =>
                 // For insertions and deletions, report the variant with the last reference base attached
                 val referenceAllele = currentReference.slice(referenceIndex - 1, referenceIndex + referenceLength)
                 val alternateAllele = path.slice(pathIndex - 1, pathIndex + pathLength)
@@ -221,7 +250,7 @@ object GermlineAssemblyCaller {
       val readSet = Common.loadReadsFromArguments(
         args,
         sc,
-        Read.InputFilters(mapped = true, nonDuplicate = true))
+        Read.InputFilters(overlapsLoci = Some(loci), mapped = true, nonDuplicate = true))
 
       val minAlignmentQuality = args.minAlignmentQuality
       val qualityReads = readSet
@@ -230,24 +259,21 @@ object GermlineAssemblyCaller {
 
       val reference = ReferenceBroadcast(args.referenceFastaPath, sc)
 
-      val minAreaVaf = args.minAreaVaf
       val lociPartitions = DistributedUtil.partitionLociAccordingToArgs(
         args,
         loci.result(readSet.contigLengths),
         readSet.mappedReads
       )
 
-      val kmerSize = args.kmerSize
-      val minAverageBaseQuality = args.minAverageBaseQuality
       val genotypes: RDD[CalledAllele] = discoverGenotypes(
         qualityReads,
-        kmerSize,
+        kmerSize = args.kmerSize,
         snvWindowRange = args.snvWindowRange,
         minOccurrence = args.minOccurrence,
         minAreaVaf = args.minAreaVaf / 100.0f,
         reference,
-        lociPartitions,
-        parallelism = args.parallelism)
+        lociPartitions)
+
       genotypes.persist()
 
       Common.progress(s"Found ${genotypes.count} variants")
@@ -265,8 +291,7 @@ object GermlineAssemblyCaller {
                           minOccurrence: Int,
                           minAreaVaf: Float,
                           reference: ReferenceBroadcast,
-                          lociPartitions: LociMap[Long],
-                          parallelism: Int): RDD[CalledAllele] = {
+                          lociPartitions: LociMap[Long]): RDD[CalledAllele] = {
 
       val genotypes: RDD[CalledAllele] =
         DistributedUtil.windowFlatMapWithState[MappedRead, CalledAllele, Option[DeBruijnGraph]](
@@ -276,30 +301,97 @@ object GermlineAssemblyCaller {
           halfWindowSize = snvWindowRange,
           initialState = None,
           (graph, windows) => {
-            val window = windows(0)
-            val variableReads =
+            val window = windows.head
+
+            // Find the reads the overlap the center locus
+            val centerReads =
               window
                 .currentRegions()
+                .filter(_.overlapsLocus(window.currentLocus))
+            val variableReads =
+              centerReads
                 .count(read => read.cigar.numCigarElements() > 1 || read.mdTagOpt.get.countOfMismatches > 0)
 
-            if ((variableReads.toFloat / window.currentRegions().length) > minAreaVaf) {
+            // Computer the number reads with variant bases from the reads overlapping the center
+            val centerVAF = variableReads.toFloat / centerReads.length
+            if (centerVAF > minAreaVaf) {
               val result = discoverHaplotypes(
-                graph,
-                windows(0),
+                None,
+                window,
                 kmerSize,
                 reference,
                 minOccurrence
               )
+
               // Jump to the next region
               window.setCurrentLocus(window.currentLocus + snvWindowRange)
-
-              result
+              (graph, result._2)
             } else {
               (graph, Iterator.empty)
             }
           }
         )
       genotypes
+    }
+
+    /**
+     * Find paths through the reads given that represent the sequence covering referenceStart and referenceEnd
+     * @param reads Reads to use to build the graph
+     * @param referenceStart Start of the reference region corresponding to the reads
+     * @param referenceEnd End of the reference region corresponding to the reads
+     * @param referenceSequence Reference sequence overlapping [referenceStart, referenceEnd)
+     * @param kmerSize Length of kmers to use to traverse the paths
+     * @param minOccurrence Minimum number of occurrences of the each kmer
+     * @param maxPaths Maximum number of paths to find
+     * @param debugPrint Print debug statements (default: false)
+     * @return List of paths that traverse the region
+     */
+    def discoverPathsFromReads(reads: Seq[MappedRead],
+                               referenceStart: Int,
+                               referenceEnd: Int,
+                               referenceSequence: Array[Byte],
+                               kmerSize: Int,
+                               minOccurrence: Int,
+                               maxPaths: Int,
+                               debugPrint: Boolean = false) = {
+      val referenceKmerSource = referenceSequence.take(kmerSize)
+      val referenceKmerSink = referenceSequence.takeRight(kmerSize)
+
+      val sources: Set[Array[Byte]] = (referenceKmerSource :: getConsensusKmer(
+        reads,
+        referenceStart,
+        referenceStart + kmerSize,
+        kmerSize = kmerSize,
+        minOccurrence = minOccurrence
+      )).toSet
+
+      val sinks: Set[Array[Byte]] = (referenceKmerSink :: getConsensusKmer(
+        reads,
+        referenceEnd - kmerSize,
+        referenceEnd,
+        kmerSize = kmerSize,
+        minOccurrence = minOccurrence
+      )).toSet
+
+      val currentGraph: DeBruijnGraph = DeBruijnGraph(
+        reads.map(_.sequence),
+        kmerSize,
+        minOccurrence,
+        mergeNodes = true
+      )
+
+      for {
+        source <- sources;
+        sink <- sinks;
+        path <- currentGraph.depthFirstSearch(
+          source,
+          sink,
+          maxPaths = maxPaths,
+          debugPrint = debugPrint
+        )
+      } yield {
+        path
+      }
     }
   }
 }

--- a/src/test/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCallerSuite.scala
@@ -1,12 +1,12 @@
 package org.hammerlab.guacamole.commands
 
 import org.apache.spark.SparkContext
+import org.hammerlab.guacamole._
 import org.hammerlab.guacamole.commands.GermlineAssemblyCaller.Arguments
 import org.hammerlab.guacamole.reads.Read
 import org.hammerlab.guacamole.reference.ReferenceBroadcast
 import org.hammerlab.guacamole.util.TestUtil
 import org.hammerlab.guacamole.variants.CalledAllele
-import org.hammerlab.guacamole._
 import org.scalatest.{ BeforeAndAfter, FunSuite, Matchers }
 
 class GermlineAssemblyCallerSuite extends FunSuite with Matchers with BeforeAndAfter {
@@ -15,7 +15,6 @@ class GermlineAssemblyCallerSuite extends FunSuite with Matchers with BeforeAndA
 
   val input = "illumina-platinum-na12878/NA12878.10k_variants.plus_chr1_3M-3.1M.bam"
   args.reads = TestUtil.testDataPath(input)
-  args.loci = "chr1:772754-772755"
   args.parallelism = 2
 
   var sc: SparkContext = _
@@ -39,20 +38,25 @@ class GermlineAssemblyCallerSuite extends FunSuite with Matchers with BeforeAndA
   val referenceFastaPath = TestUtil.testDataPath("illumina-platinum-na12878/chr1.prefix.fa")
   val loci = Common.lociFromArguments(args)
 
-  def discoverGenotypesAtLoci(loci: String): Seq[CalledAllele] = {
+  def discoverGenotypesAtLoci(loci: String,
+                              readSetIn: ReadSet = readSet,
+                              referenceInput: ReferenceBroadcast = reference,
+                              kmerSize: Int = 31,
+                              snvWindowRange: Int = 55,
+                              minOccurrence: Int = 5,
+                              minVaf: Float = 0.1f): Seq[CalledAllele] = {
     val lociPartitions = DistributedUtil.partitionLociUniformly(
       tasks = args.parallelism,
-      loci = LociSet.parse(loci).result(readSet.contigLengths)
+      loci = LociSet.parse(loci).result(readSetIn.contigLengths)
     )
     GermlineAssemblyCaller.Caller.discoverGenotypes(
-      readSet.mappedReads,
-      kmerSize = 45,
-      snvWindowRange = 75,
-      minOccurrence = 3,
-      minAreaVaf = .1f,
-      reference = reference,
-      lociPartitions = lociPartitions,
-      parallelism = args.parallelism
+      readSetIn.mappedReads,
+      kmerSize = kmerSize,
+      snvWindowRange = snvWindowRange,
+      minOccurrence = minOccurrence,
+      minAreaVaf = minVaf,
+      reference = referenceInput,
+      lociPartitions = lociPartitions
     ).collect().sortBy(_.start)
   }
 
@@ -200,5 +204,4 @@ class GermlineAssemblyCallerSuite extends FunSuite with Matchers with BeforeAndA
     Bases.basesToString(variant.allele.altBases) should be("C")
 
   }
-
 }


### PR DESCRIPTION
This PR has 3 key updates:
1. Updates the source/sink searching to first determine the possible start/end kmers (instead of just relying on the reference) and then attempting to find all paths between all pairs of those
2. Instead of filtering to regions when any of the reads exceed the variability threshold, this waits for those reads to enter the center. This fixes the issue when only the end kmer contains the variant and we can't find a proper path to the reference kmer at that point.
3. Refactors a few aspects into functions. This is so these can be reused in the somatic version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/393)
<!-- Reviewable:end -->
