### PR TITLE
Remove unused reference argument in read loading

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/Common.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Common.scala
@@ -29,14 +29,13 @@ import org.apache.hadoop.fs.{ FileSystem, Path }
 import org.apache.hadoop.mapred.FileAlreadyExistsException
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{ Logging, SparkConf, SparkContext }
-import org.bdgenomics.utils.cli.{ Args4jBase, ParquetArgs }
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.formats.avro.Genotype
+import org.bdgenomics.utils.cli.{ Args4jBase, ParquetArgs }
+import org.codehaus.jackson.JsonFactory
 import org.hammerlab.guacamole.Common.Arguments.ReadLoadingConfigArgs
 import org.hammerlab.guacamole.Concordance.ConcordanceArgs
 import org.hammerlab.guacamole.reads.Read
-import org.codehaus.jackson.JsonFactory
-import org.hammerlab.guacamole.reference.ReferenceGenome
 import org.kohsuke.args4j.{ Option => Args4jOption }
 
 /**
@@ -155,8 +154,7 @@ object Common extends Logging {
   def loadReadsFromArguments(
     args: Arguments.Reads,
     sc: SparkContext,
-    filters: Read.InputFilters,
-    reference: ReferenceGenome): ReadSet = {
+    filters: Read.InputFilters): ReadSet = {
 
     ReadSet(
       sc,
@@ -164,7 +162,6 @@ object Common extends Logging {
       filters,
       token = 0,
       contigLengthsFromDictionary = !args.noSequenceDictionary,
-      reference = reference,
       config = ReadLoadingConfigArgs.fromArguments(args))
   }
 
@@ -180,8 +177,7 @@ object Common extends Logging {
   def loadTumorNormalReadsFromArguments(
     args: Arguments.TumorNormalReads,
     sc: SparkContext,
-    filters: Read.InputFilters,
-    reference: ReferenceGenome): (ReadSet, ReadSet) = {
+    filters: Read.InputFilters): (ReadSet, ReadSet) = {
 
     val tumor = ReadSet(
       sc,
@@ -189,7 +185,6 @@ object Common extends Logging {
       filters,
       1,
       !args.noSequenceDictionary,
-      reference,
       ReadLoadingConfigArgs.fromArguments(args))
     val normal = ReadSet(
       sc,
@@ -197,7 +192,6 @@ object Common extends Logging {
       filters,
       2,
       !args.noSequenceDictionary,
-      reference,
       ReadLoadingConfigArgs.fromArguments(args))
     (tumor, normal)
   }

--- a/src/main/scala/org/hammerlab/guacamole/ReadSet.scala
+++ b/src/main/scala/org/hammerlab/guacamole/ReadSet.scala
@@ -21,8 +21,7 @@ package org.hammerlab.guacamole
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models.SequenceDictionary
-import org.hammerlab.guacamole.reads.{ MappedRead, Read, PairedRead }
-import org.hammerlab.guacamole.reference.ReferenceGenome
+import org.hammerlab.guacamole.reads.{ MappedRead, PairedRead, Read }
 
 /**
  * A ReadSet contains an RDD of reads along with some metadata about them.
@@ -97,7 +96,6 @@ object ReadSet {
     filters: Read.InputFilters = Read.InputFilters.empty,
     token: Int = 0,
     contigLengthsFromDictionary: Boolean = true,
-    reference: ReferenceGenome,
     config: Read.ReadLoadingConfig = Read.ReadLoadingConfig.default): ReadSet = {
 
     val (reads, sequenceDictionary) =
@@ -106,7 +104,6 @@ object ReadSet {
         sc,
         token = token,
         filters = filters,
-        reference,
         config
       )
 

--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
@@ -248,8 +248,8 @@ object GermlineAssemblyCaller {
       val readSet = Common.loadReadsFromArguments(
         args,
         sc,
-        Read.InputFilters(overlapsLoci = Some(loci), mapped = true, nonDuplicate = true),
-        reference = reference)
+        Read.InputFilters(overlapsLoci = Some(loci), mapped = true, nonDuplicate = true)
+      )
 
       val minAlignmentQuality = args.minAlignmentQuality
       val qualityReads = readSet

--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineStandardCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineStandardCaller.scala
@@ -58,8 +58,8 @@ object GermlineStandard {
         args, sc, Read.InputFilters(
           overlapsLoci = Some(loci),
           mapped = true,
-          nonDuplicate = true),
-        reference = reference)
+          nonDuplicate = true)
+      )
 
       readSet.mappedReads.persist()
       Common.progress(

--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineThresholdCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineThresholdCaller.scala
@@ -65,8 +65,7 @@ object GermlineThreshold {
       val loci = Common.lociFromArguments(args)
       val readSet = Common.loadReadsFromArguments(
         args, sc, Read.InputFilters(
-          overlapsLoci = Some(loci), nonDuplicate = true),
-        reference = reference
+          overlapsLoci = Some(loci), nonDuplicate = true)
       )
 
       readSet.mappedReads.persist()

--- a/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
@@ -77,8 +77,7 @@ object SomaticStandard {
         Common.loadTumorNormalReadsFromArguments(
           args,
           sc,
-          filters,
-          reference = reference
+          filters
         )
 
       assert(tumorReads.sequenceDictionary == normalReads.sequenceDictionary,

--- a/src/main/scala/org/hammerlab/guacamole/commands/VAFHistogram.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/VAFHistogram.scala
@@ -110,7 +110,6 @@ object VAFHistogram {
             InputFilters.empty,
             token = bamFile._2,
             contigLengthsFromDictionary = true,
-            reference = reference,
             config = Common.Arguments.ReadLoadingConfigArgs.fromArguments(args)
           )
       )

--- a/src/main/scala/org/hammerlab/guacamole/commands/VariantSupport.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/VariantSupport.scala
@@ -79,7 +79,6 @@ object VariantSupport {
             bamFile._1,
             InputFilters.empty,
             token = bamFile._2,
-            reference = reference,
             config = Common.Arguments.ReadLoadingConfigArgs.fromArguments(args)
           ).mappedReads
       )

--- a/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCaller.scala
@@ -48,8 +48,8 @@ object SomaticJoint {
         input.path,
         Read.InputFilters(overlapsLoci = Some(loci)),
         token = index,
-        contigLengthsFromDictionary = contigLengthsFromDictionary,
-        reference = reference)
+        contigLengthsFromDictionary = contigLengthsFromDictionary
+      )
     })
   }
 

--- a/src/main/scala/org/hammerlab/guacamole/other_entrypoints/GeneratePartialFasta.scala
+++ b/src/main/scala/org/hammerlab/guacamole/other_entrypoints/GeneratePartialFasta.scala
@@ -48,7 +48,6 @@ object GeneratePartialFasta extends Logging {
         fileAndIndex._1,
         InputFilters.empty,
         token = fileAndIndex._2,
-        reference = reference,
         config = Common.Arguments.ReadLoadingConfigArgs.fromArguments(args)))
 
     val reads = sc.union(readSets.map(_.mappedReads))

--- a/src/test/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCallerSuite.scala
@@ -27,8 +27,8 @@ class GermlineAssemblyCallerSuite extends FunSuite with Matchers with BeforeAndA
     readSet = Common.loadReadsFromArguments(
       args,
       sc,
-      Read.InputFilters(mapped = true, nonDuplicate = true),
-      reference = reference)
+      Read.InputFilters(mapped = true, nonDuplicate = true)
+    )
     readSet.mappedReads.persist()
   }
 

--- a/src/test/scala/org/hammerlab/guacamole/reads/ReadSetSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/ReadSetSuite.scala
@@ -108,7 +108,7 @@ class ReadSetSuite extends GuacFunSuite with Matchers {
     }
     new AlignmentRecordRDDFunctions(adamRecords.rdd).saveAsParquet(args, adamRecords.sequences, adamRecords.recordGroups)
 
-    val (allReads, _) = Read.loadReadRDDAndSequenceDictionaryFromADAM(adamOut, sc, token = 0, reference = chr22Fasta)
+    val (allReads, _) = Read.loadReadRDDAndSequenceDictionaryFromADAM(adamOut, sc, token = 0)
     allReads.count() should be(8)
     val collectedReads = allReads.collect()
 
@@ -116,8 +116,7 @@ class ReadSetSuite extends GuacFunSuite with Matchers {
       adamOut,
       sc,
       1,
-      Read.InputFilters(mapped = true, nonDuplicate = true),
-      reference = chr22Fasta)
+      Read.InputFilters(mapped = true, nonDuplicate = true))
     filteredReads.count() should be(3)
     filteredReads.collect().forall(_.token == 1) should be(true)
   }

--- a/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
@@ -218,7 +218,7 @@ object TestUtil extends Matchers {
     val path = testDataPath(filename)
     assert(sc != null)
     assert(sc.hadoopConfiguration != null)
-    ReadSet(sc, path, reference = reference, filters = filters, config = config)
+    ReadSet(sc, path, filters = filters, config = config)
   }
 
   def loadTumorNormalPileup(tumorReads: Seq[MappedRead],


### PR DESCRIPTION
After #398 the various `loadRead..` functions still took the reference as an argument but it was unused. I removed that parameter - unless you had other plans for it @timodonnell?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/401)
<!-- Reviewable:end -->
