### PR TITLE
Fix reference sequence in SomaticStandardCallerSuite. Closes #403

### DIFF
--- a/src/test/scala/org/hammerlab/guacamole/commands/SomaticStandardCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/SomaticStandardCallerSuite.scala
@@ -34,7 +34,8 @@ class SomaticStandardCallerSuite extends GuacFunSuite with Matchers with TableDr
   def simpleReference = TestUtil.makeReference(sc, Seq(
     ("chr1", 0, "TCGATCGACG"),
     ("chr2", 0, "TCGAAGCTTCG"),
-    ("chr3", 10, "TCGAATCGATCGATCGA")))
+    ("chr3", 10, "TCGAATCGATCGATCGA"),
+    ("chr4", 0, "TCGAAGCTTCGAAGCT")))
 
   def loadPileup(filename: String, contig: String, locus: Long = 0): Pileup = {
     val contigReference = grch37Reference.getContig(contig)
@@ -177,18 +178,18 @@ class SomaticStandardCallerSuite extends GuacFunSuite with Matchers with TableDr
 
   sparkTest("multiple-base deletion") {
     val normalReads = Seq(
-      TestUtil.makeRead("TCGAAGCTTCGAAGCT", "16M", 0),
-      TestUtil.makeRead("TCGAAGCTTCGAAGCT", "16M", 0),
-      TestUtil.makeRead("TCGAAGCTTCGAAGCT", "16M", 0)
+      TestUtil.makeRead("TCGAAGCTTCGAAGCT", "16M", 0, chr = "chr4"),
+      TestUtil.makeRead("TCGAAGCTTCGAAGCT", "16M", 0, chr = "chr4"),
+      TestUtil.makeRead("TCGAAGCTTCGAAGCT", "16M", 0, chr = "chr4")
     )
-    val normalPileup = Pileup(normalReads, "chr1", 4, referenceContigSequence = simpleReference.getContig("chr2"))
+    val normalPileup = Pileup(normalReads, "chr4", 4, referenceContigSequence = simpleReference.getContig("chr4"))
 
     val tumorReads = Seq(
-      TestUtil.makeRead("TCGAAAAGCT", "5M6D5M", 0), // md tag: "5^GCTTCG5"
-      TestUtil.makeRead("TCGAAAAGCT", "5M6D5M", 0),
-      TestUtil.makeRead("TCGAAAAGCT", "5M6D5M", 0)
+      TestUtil.makeRead("TCGAAAAGCT", "5M6D5M", 0, chr = "chr4"), // md tag: "5^GCTTCG5"
+      TestUtil.makeRead("TCGAAAAGCT", "5M6D5M", 0, chr = "chr4"),
+      TestUtil.makeRead("TCGAAAAGCT", "5M6D5M", 0, chr = "chr4")
     )
-    val tumorPileup = Pileup(tumorReads, "chr1", 4, referenceContigSequence = simpleReference.getContig("chr2"))
+    val tumorPileup = Pileup(tumorReads, "chr4", 4, referenceContigSequence = simpleReference.getContig("chr4"))
 
     val alleles = SomaticStandard.Caller.findPotentialVariantAtLocus(tumorPileup, normalPileup, oddsThreshold = 2)
     alleles.size should be(1)


### PR DESCRIPTION
Tentative trivial fix for #403 

By adding intentional mistakes into `SomaticStandardCaller` I was able to get the `testing complex region negative variants on syn1` negative test to fail, so I have reasonable confidence that these tests are in fact testing something. Most of the tests involve both positive and negative assertions too, which also inspires some confidence.

Minor note: I wasn't able to get the `"difficult negative variants"` test to fail by changing the`SomaticStandardCaller.findVariantsAtLocus` since the tumor VAF appears to be 0, causing the`SomaticGenotypeFilter` filtering to remove it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/405)
<!-- Reviewable:end -->
