### PR TITLE
Fix 0 length ref or alt allele, Fixes #379

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/variants/Allele.scala
+++ b/src/main/scala/org/hammerlab/guacamole/variants/Allele.scala
@@ -24,6 +24,8 @@ import org.hammerlab.guacamole.Bases
 import org.hammerlab.guacamole.Bases.BasesOrdering
 
 case class Allele(refBases: Seq[Byte], altBases: Seq[Byte]) extends Ordered[Allele] {
+  assume(refBases.length > 0)
+  assume(altBases.length > 0)
   lazy val isVariant = refBases != altBases
 
   override def toString: String = "Allele(%s,%s)".format(Bases.basesToString(refBases), Bases.basesToString(altBases))


### PR DESCRIPTION
There appear to be some cases where 0 length reference/alternate alleles are created. These cause variant writing to crash due to a "Null Allele" as stated in  https://github.com/hammerlab/guacamole/issues/379. To start this PR has an assertion in Allele building that you have non-zero ref/alt alleles, which should help track down errors in testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/406)
<!-- Reviewable:end -->
