### PR TITLE
Change Seq to Vector and other small fixes

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/Bases.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Bases.scala
@@ -84,7 +84,7 @@ object Bases {
   }
 
   /** Convert a string (e.g. "AAAGGC") to a byte array. */
-  def stringToBases(string: String): Seq[Byte] = {
+  def stringToBases(string: String): IndexedSeq[Byte] = {
     string.toUpperCase.getBytes
   }
 

--- a/src/main/scala/org/hammerlab/guacamole/DistributedUtil.scala
+++ b/src/main/scala/org/hammerlab/guacamole/DistributedUtil.scala
@@ -47,7 +47,7 @@ object DistributedUtil extends Logging {
     var partitioningAccuracy: Int = 250
   }
 
-  type PerSample[A] = Seq[A]
+  type PerSample[A] = IndexedSeq[A]
 
   /**
    * Partition a LociSet among tasks according to the strategy specified in args.
@@ -285,7 +285,7 @@ object DistributedUtil extends Logging {
     function: Pileup => Iterator[T],
     reference: ReferenceGenome): RDD[T] = {
     windowFlatMapWithState(
-      Seq(reads),
+      Vector(reads),
       lociPartitions,
       skipEmpty,
       0,
@@ -313,7 +313,7 @@ object DistributedUtil extends Logging {
     function: (Pileup, Pileup) => Iterator[T],
     reference: ReferenceGenome): RDD[T] = {
     windowFlatMapWithState(
-      Seq(reads1, reads2),
+      Vector(reads1, reads2),
       lociPartitions,
       skipEmpty,
       halfWindowSize = 0L,
@@ -333,10 +333,10 @@ object DistributedUtil extends Logging {
    * @see the windowTaskFlatMapMultipleRDDs function for other argument descriptions.
    */
   def pileupFlatMapMultipleRDDs[T: ClassTag](
-    readsRDDs: Seq[RDD[MappedRead]],
+    readsRDDs: PerSample[RDD[MappedRead]],
     lociPartitions: LociMap[Long],
     skipEmpty: Boolean,
-    function: Seq[Pileup] => Iterator[T],
+    function: PerSample[Pileup] => Iterator[T],
     reference: ReferenceGenome): RDD[T] = {
     windowFlatMapWithState(
       readsRDDs,
@@ -344,7 +344,7 @@ object DistributedUtil extends Logging {
       skipEmpty,
       halfWindowSize = 0L,
       initialState = None,
-      function = (maybePileups: Option[Seq[Pileup]], windows: PerSample[SlidingWindow[MappedRead]]) => {
+      function = (maybePileups: Option[PerSample[Pileup]], windows: PerSample[SlidingWindow[MappedRead]]) => {
         val advancedPileups = maybePileups match {
           case Some(existingPileups) => {
             existingPileups.zip(windows).map(

--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
@@ -292,7 +292,7 @@ object GermlineAssemblyCaller {
 
       val genotypes: RDD[CalledAllele] =
         DistributedUtil.windowFlatMapWithState[MappedRead, CalledAllele, Option[DeBruijnGraph]](
-          Seq(reads),
+          Vector(reads),
           lociPartitions,
           skipEmpty = true,
           halfWindowSize = snvWindowRange,

--- a/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/InputCollection.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/InputCollection.scala
@@ -1,5 +1,6 @@
 package org.hammerlab.guacamole.commands.jointcaller
 
+import org.hammerlab.guacamole.DistributedUtil.PerSample
 import org.hammerlab.guacamole.commands.jointcaller.Input.{ Analyte, TissueType }
 import org.kohsuke.args4j.spi.StringArrayOptionHandler
 import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
@@ -7,7 +8,7 @@ import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
 /**
  * Convenience container for zero or more Input instances.
  */
-case class InputCollection(items: Seq[Input]) {
+case class InputCollection(items: PerSample[Input]) {
   val normalDNA = items.filter(_.normalDNA)
   val normalRNA = items.filter(_.normalRNA)
   val tumorDNA = items.filter(_.tumorDNA)
@@ -37,7 +38,11 @@ object InputCollection {
    * Create an InputCollection from parsed commandline arguments.
    */
   def apply(args: Arguments): InputCollection = {
-    apply(paths = args.paths, sampleNames = args.sampleNames, tissueTypes = args.tissueTypes, analytes = args.analytes)
+    apply(
+      paths = args.paths.toVector,
+      sampleNames = args.sampleNames.toVector,
+      tissueTypes = args.tissueTypes.toVector,
+      analytes = args.analytes.toVector)
   }
 
   /**
@@ -53,10 +58,10 @@ object InputCollection {
    * @param analytes "dna" or "rna" for each input
    * @return resulting InputCollection
    */
-  def apply(paths: Seq[String],
-            sampleNames: Seq[String] = Seq.empty,
-            tissueTypes: Seq[String] = Seq.empty,
-            analytes: Seq[String] = Seq.empty): InputCollection = {
+  def apply(paths: PerSample[String],
+            sampleNames: PerSample[String] = Vector.empty,
+            tissueTypes: PerSample[String] = Vector.empty,
+            analytes: PerSample[String] = Vector.empty): InputCollection = {
 
     def checkLength(name: String, items: Seq[String]) = {
       if (items.length != paths.length) {

--- a/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCaller.scala
@@ -4,6 +4,7 @@ import htsjdk.samtools.SAMSequenceDictionary
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.hammerlab.guacamole.Common.Arguments.NoSequenceDictionary
+import org.hammerlab.guacamole.DistributedUtil.PerSample
 import org.hammerlab.guacamole._
 import org.hammerlab.guacamole.reads._
 import org.hammerlab.guacamole.reference.ReferenceBroadcast
@@ -41,7 +42,7 @@ object SomaticJoint {
                        inputs: InputCollection,
                        loci: LociSet.Builder,
                        reference: ReferenceBroadcast,
-                       contigLengthsFromDictionary: Boolean = true): Seq[ReadSet] = {
+                       contigLengthsFromDictionary: Boolean = true): PerSample[ReadSet] = {
     inputs.items.zipWithIndex.map({
       case (input, index) => ReadSet(
         sc,
@@ -136,7 +137,7 @@ object SomaticJoint {
 
   def makeCalls(sc: SparkContext,
                 inputs: InputCollection,
-                readSets: Seq[ReadSet],
+                readSets: PerSample[ReadSet],
                 parameters: Parameters,
                 reference: ReferenceBroadcast,
                 loci: LociSet,
@@ -210,7 +211,7 @@ object SomaticJoint {
 
     def writeSome(out: String,
                   filteredCalls: Seq[MultipleAllelesEvidenceAcrossSamples],
-                  filteredInputs: Seq[Input],
+                  filteredInputs: PerSample[Input],
                   includePooledNormal: Option[Boolean] = None,
                   includePooledTumor: Option[Boolean] = None): Unit = {
 
@@ -268,14 +269,14 @@ object SomaticJoint {
           path("all.%s.%s.%s".format(
             input.sampleName, input.tissueType.toString, input.analyte.toString)),
           calls,
-          Seq(input))
+          Vector(input))
         writeSome(
           path("somatic.%s.%s.%s".format(
             input.sampleName, input.tissueType.toString, input.analyte.toString)),
           somaticCallsOrForced,
-          Seq(input))
+          Vector(input))
       })
-      writeSome(path("all.tumor_pooled_dna"), somaticCallsOrForced, Seq.empty, includePooledTumor = Some(true))
+      writeSome(path("all.tumor_pooled_dna"), somaticCallsOrForced, Vector.empty, includePooledTumor = Some(true))
     }
   }
 }

--- a/src/main/scala/org/hammerlab/guacamole/filters/FishersExactTest.scala
+++ b/src/main/scala/org/hammerlab/guacamole/filters/FishersExactTest.scala
@@ -29,7 +29,7 @@ object FishersExactTest {
       ArithmeticUtils.binomialCoefficientLog(totalA + totalB, conditionA + conditionB))
   }
 
-  /** Fisher's exact test, returned as log base 10 probability. */
+  /** Fisher's exact test, returned as -1 * log base 10 probability (i.e. a positive number). */
   def asLog10(totalA: Int, totalB: Int, conditionA: Int, conditionB: Int): Double = {
     (ArithmeticUtils.binomialCoefficientLog(totalA, conditionA) +
       ArithmeticUtils.binomialCoefficientLog(totalB, conditionB) -

--- a/src/main/scala/org/hammerlab/guacamole/pileup/Pileup.scala
+++ b/src/main/scala/org/hammerlab/guacamole/pileup/Pileup.scala
@@ -48,7 +48,7 @@ case class Pileup(referenceName: String, locus: Long, referenceContigSequence: C
       referenceName, elements.map(_.read.referenceContig).filter(_ != referenceName).mkString(",")))
   assume(elements.forall(_.locus == locus), "Reads in pileup have mismatching loci")
 
-  lazy val distinctAlleles: Seq[Allele] = elements.map(_.allele).distinct.sorted.toIndexedSeq
+  lazy val distinctAlleles: Seq[Allele] = elements.map(_.allele).distinct.sorted.toVector
 
   lazy val sampleName = elements.head.read.sampleName
 

--- a/src/main/scala/org/hammerlab/guacamole/pileup/PileupElement.scala
+++ b/src/main/scala/org/hammerlab/guacamole/pileup/PileupElement.scala
@@ -138,6 +138,7 @@ case class PileupElement(
    */
   def isInsertion = alignment match { case Insertion(_, _) => true; case _ => false }
   def isDeletion = alignment match { case Deletion(_, _) => true; case _ => false }
+  def isClipped = alignment match { case Clipped => true; case _ => false }
   def isMidDeletion = alignment match { case MidDeletion(_) => true; case _ => false }
   def isMismatch = alignment match { case Mismatch(_, _, _) => true; case _ => false }
   def isMatch = alignment match { case Match(_, _) => true; case _ => false }

--- a/src/main/scala/org/hammerlab/guacamole/reads/MappedRead.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/MappedRead.scala
@@ -37,8 +37,8 @@ import scala.collection.JavaConversions
 case class MappedRead(
     token: Int,
     name: String,
-    sequence: Seq[Byte],
-    baseQualities: Seq[Byte],
+    sequence: IndexedSeq[Byte],
+    baseQualities: IndexedSeq[Byte],
     isDuplicate: Boolean,
     sampleName: String,
     referenceContig: String,

--- a/src/main/scala/org/hammerlab/guacamole/reads/MappedReadSerializer.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/MappedReadSerializer.scala
@@ -48,8 +48,8 @@ class MappedReadSerializer extends Serializer[MappedRead] {
     val token = input.readInt()
     val name = input.readString()
     val count: Int = input.readInt(true)
-    val sequenceArray: Seq[Byte] = input.readBytes(count)
-    val qualityScoresArray: Seq[Byte] = input.readBytes(count)
+    val sequenceArray: IndexedSeq[Byte] = input.readBytes(count).toVector
+    val qualityScoresArray: IndexedSeq[Byte] = input.readBytes(count).toVector
     val isDuplicate = input.readBoolean()
     val sampleName = input.readString().intern()
     val referenceContig = input.readString().intern()

--- a/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
@@ -451,8 +451,8 @@ object Read extends Logging {
    */
   def fromADAMRecord(alignmentRecord: AlignmentRecord, token: Int, reference: ReferenceGenome): Read = {
 
-    val sequence = Bases.stringToBases(alignmentRecord.getSequence.toString)
-    val baseQualities = baseQualityStringToArray(alignmentRecord.getQual.toString, sequence.length)
+    val sequence = Bases.stringToBases(alignmentRecord.getSequence)
+    val baseQualities = baseQualityStringToArray(alignmentRecord.getQual, sequence.length)
 
     val referenceContig = alignmentRecord.getContig.getContigName.intern
     val cigar = TextCigarCodec.decode(alignmentRecord.getCigar)

--- a/src/main/scala/org/hammerlab/guacamole/reads/UnmappedRead.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/UnmappedRead.scala
@@ -25,8 +25,8 @@ package org.hammerlab.guacamole.reads
 case class UnmappedRead(
     token: Int,
     name: String,
-    sequence: Seq[Byte],
-    baseQualities: Seq[Byte],
+    sequence: IndexedSeq[Byte],
+    baseQualities: IndexedSeq[Byte],
     isDuplicate: Boolean,
     sampleName: String,
     failedVendorQualityChecks: Boolean,

--- a/src/main/scala/org/hammerlab/guacamole/reads/UnmappedReadSerializer.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/UnmappedReadSerializer.scala
@@ -41,8 +41,8 @@ class UnmappedReadSerializer extends Serializer[UnmappedRead] {
     val token = input.readInt()
     val name: String = input.readString()
     val count: Int = input.readInt(true)
-    val sequenceArray: Seq[Byte] = input.readBytes(count)
-    val qualityScoresArray = input.readBytes(count)
+    val sequenceArray: Vector[Byte] = input.readBytes(count).toVector
+    val qualityScoresArray = input.readBytes(count).toVector
     val isDuplicate = input.readBoolean()
     val sampleName = input.readString().intern()
     val failedVendorQualityChecks = input.readBoolean()

--- a/src/main/scala/org/hammerlab/guacamole/variants/Allele.scala
+++ b/src/main/scala/org/hammerlab/guacamole/variants/Allele.scala
@@ -24,7 +24,7 @@ import org.hammerlab.guacamole.Bases
 import org.hammerlab.guacamole.Bases.BasesOrdering
 
 case class Allele(refBases: Seq[Byte], altBases: Seq[Byte]) extends Ordered[Allele] {
-  lazy val isVariant = refBases != altBases
+  val isVariant = refBases != altBases
 
   override def toString: String = "Allele(%s,%s)".format(Bases.basesToString(refBases), Bases.basesToString(altBases))
 
@@ -52,9 +52,9 @@ class AlleleSerializer extends Serializer[Allele] {
 
   def read(kryo: Kryo, input: Input, klass: Class[Allele]): Allele = {
     val referenceBasesLength = input.readInt(true)
-    val referenceBases: Seq[Byte] = input.readBytes(referenceBasesLength)
+    val referenceBases: IndexedSeq[Byte] = input.readBytes(referenceBasesLength)
     val alternateLength = input.readInt(true)
-    val alternateBases: Seq[Byte] = input.readBytes(alternateLength)
+    val alternateBases: IndexedSeq[Byte] = input.readBytes(alternateLength)
     Allele(referenceBases, alternateBases)
   }
 }

--- a/src/main/scala/org/hammerlab/guacamole/windowing/SlidingWindow.scala
+++ b/src/main/scala/org/hammerlab/guacamole/windowing/SlidingWindow.scala
@@ -68,8 +68,8 @@ case class SlidingWindow[Region <: HasReferenceRegion](referenceName: String,
   }
 
   /** The regions that overlap the window surrounding [[currentLocus]]. */
-  def currentRegions(): Seq[Region] = {
-    currentRegionsPriorityQueue.toSeq
+  def currentRegions(): Vector[Region] = {
+    currentRegionsPriorityQueue.toVector
   }
 
   /**
@@ -80,7 +80,7 @@ case class SlidingWindow[Region <: HasReferenceRegion](referenceName: String,
    * @return The *new regions* that were added as a result of this call. Note that this is not the full set of regions
    *         in the window: you must examine [[currentRegions]] for that.
    */
-  def setCurrentLocus(locus: Long): Seq[Region] = {
+  def setCurrentLocus(locus: Long): Vector[Region] = {
     assume(locus >= currentLocus, "Pileup window can only move forward in locus")
     currentLocus = locus
 
@@ -106,7 +106,7 @@ case class SlidingWindow[Region <: HasReferenceRegion](referenceName: String,
       newRegionsBuilder.result
     }
     currentRegionsPriorityQueue.enqueue(newRegions: _*)
-    newRegions // We return the newly added regions.
+    newRegions.toVector // We return the newly added regions.
   }
 
   /**

--- a/src/main/scala/org/hammerlab/guacamole/windowing/SplitIterator.scala
+++ b/src/main/scala/org/hammerlab/guacamole/windowing/SplitIterator.scala
@@ -13,9 +13,9 @@ object SplitIterator {
    * @tparam V
    * @return a buffered iterator for each key in 0 .. num.
    */
-  def split[V](num: Int, iterator: Iterator[(Int, V)]): Seq[BufferedIterator[V]] = {
+  def split[V](num: Int, iterator: Iterator[(Int, V)]): Vector[BufferedIterator[V]] = {
     val buffers = (0 until num).map(_ => new collection.mutable.Queue[V])
-    (0 until num).map(index => new SplitIterator[V](index, buffers, iterator))
+    (0 until num).toVector.map(index => new SplitIterator[V](index, buffers, iterator))
   }
 }
 

--- a/src/test/scala/org/hammerlab/guacamole/DistributedUtilSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/DistributedUtilSuite.scala
@@ -203,21 +203,21 @@ class DistributedUtilSuite extends GuacFunSuite with Matchers {
       TestUtil.makeRead("XZX", "3M", 99)))
 
     val resultPlain = DistributedUtil.pileupFlatMapMultipleRDDs[Seq[Seq[String]]](
-      Seq(reads1, reads2, reads3),
+      Vector(reads1, reads2, reads3),
       DistributedUtil.partitionLociUniformly(1, LociSet.parse("chr1:1-500,chr2:10-20").result),
       true, // skip empty pileups
       pileups => Iterator(pileups.map(_.elements.map(p => Bases.basesToString(p.sequencedBases)))),
       reference = TestUtil.makeReference(sc, Seq(("chr1", 0, "ATCGATCGA")))).collect.map(_.toList)
 
     val resultParallelized = DistributedUtil.pileupFlatMapMultipleRDDs[Seq[Seq[String]]](
-      Seq(reads1, reads2, reads3),
+      Vector(reads1, reads2, reads3),
       DistributedUtil.partitionLociUniformly(800, LociSet.parse("chr0:0-100,chr1:1-500,chr2:10-20").result),
       true, // skip empty pileups
       pileups => Iterator(pileups.map(_.elements.map(p => Bases.basesToString(p.sequencedBases)))),
       reference = TestUtil.makeReference(sc, Seq(("chr1", 0, "ATCGATCGA")))).collect.map(_.toList)
 
     val resultWithEmpty = DistributedUtil.pileupFlatMapMultipleRDDs[Seq[Seq[String]]](
-      Seq(reads1, reads2, reads3),
+      Vector(reads1, reads2, reads3),
       DistributedUtil.partitionLociUniformly(5, LociSet.parse("chr1:1-500,chr2:10-20").result),
       false, // don't skip empty pileups
       pileups => Iterator(pileups.map(_.elements.map(p => Bases.basesToString(p.sequencedBases)))),
@@ -406,7 +406,7 @@ class DistributedUtilSuite extends GuacFunSuite with Matchers {
       TestUtil.makeRead("GGGGGGG", "7M", 9)))
 
     val counts = DistributedUtil.windowFoldLoci(
-      Seq(reads),
+      Vector(reads),
       // Split loci in 5 partitions - we will compute an aggregate value per partition
       DistributedUtil.partitionLociUniformly(5, LociSet.parse("chr1:0-20").result),
       skipEmpty = false,

--- a/src/test/scala/org/hammerlab/guacamole/commands/jointcaller/ReadSubsequenceSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/jointcaller/ReadSubsequenceSuite.scala
@@ -8,7 +8,7 @@ import org.hammerlab.guacamole.util.{ TestUtil, GuacFunSuite }
 import org.scalatest.Matchers
 
 class ReadSubsequenceSuite extends GuacFunSuite with Matchers {
-  val cancerWGS1Bams = Seq("normal.bam", "primary.bam", "recurrence.bam").map(
+  val cancerWGS1Bams = Vector("normal.bam", "primary.bam", "recurrence.bam").map(
     name => TestUtil.testDataPath("cancer-wgs1/" + name))
 
   def simpleReference = TestUtil.makeReference(sc, Seq(("chr1", 0, "NTCGATCGACG")))

--- a/src/test/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCallerSuite.scala
@@ -7,7 +7,7 @@ import org.hammerlab.guacamole.util.{ GuacFunSuite, TestUtil }
 import org.scalatest.Matchers
 
 class SomaticJointCallerSuite extends GuacFunSuite with Matchers {
-  val cancerWGS1Bams = Seq("normal.bam", "primary.bam", "recurrence.bam").map(
+  val cancerWGS1Bams = Vector("normal.bam", "primary.bam", "recurrence.bam").map(
     name => TestUtil.testDataPath("cancer-wgs1/" + name))
 
   val partialFasta = TestUtil.testDataPath("hg19.partial.fasta")
@@ -41,7 +41,7 @@ class SomaticJointCallerSuite extends GuacFunSuite with Matchers {
   }
 
   sparkTest("call germline variants") {
-    val inputs = InputCollection(cancerWGS1Bams, tissueTypes = Seq("normal", "normal", "normal"))
+    val inputs = InputCollection(cancerWGS1Bams, tissueTypes = Vector("normal", "normal", "normal"))
     val loci = LociSet.parse("chr1,chr2,chr3")
     val readSets = SomaticJoint.inputsToReadSets(sc, inputs, loci, partialReference)
     val calls = SomaticJoint.makeCalls(

--- a/src/test/scala/org/hammerlab/guacamole/windowing/SlidingWindowSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/windowing/SlidingWindowSuite.scala
@@ -188,7 +188,7 @@ class SlidingWindowSuite extends FunSuite with Matchers {
     val window2 = SlidingWindow("chr1", 0, reads2.iterator)
 
     val loci = LociSet.parse("chr1:0-3,chr1:20-30").result.onContig("chr1").iterator
-    val windows = Seq(window1, window2)
+    val windows = Vector(window1, window2)
 
     SlidingWindow.advanceMultipleWindows(windows, loci, skipEmpty = false) should be(Some(0))
     windows.map(_.currentLocus) should equal(Seq(0, 0))
@@ -214,7 +214,7 @@ class SlidingWindowSuite extends FunSuite with Matchers {
     val window2 = SlidingWindow("chr1", 0, reads2.iterator)
 
     val loci = LociSet.parse("chr1:0-3,chr1:20-30").result.onContig("chr1").iterator
-    val windows = Seq(window1, window2)
+    val windows = Vector(window1, window2)
 
     SlidingWindow.advanceMultipleWindows(windows, loci, skipEmpty = true) should be(Some(0))
     windows.map(_.currentLocus) should equal(Seq(0, 0))
@@ -243,7 +243,7 @@ class SlidingWindowSuite extends FunSuite with Matchers {
     val window2 = SlidingWindow("chr1", 0, reads2.iterator)
 
     val loci = LociSet.parse("chr1:0-3,chr1:60-101").result.onContig("chr1").iterator
-    val windows = Seq(window1, window2)
+    val windows = Vector(window1, window2)
 
     SlidingWindow.advanceMultipleWindows(windows, loci, skipEmpty = false) should be(Some(0))
     windows.map(_.currentLocus) should equal(Seq(0, 0))


### PR DESCRIPTION
 * Change Seq to Vector in a number of places. For vast majority of cases, Vector performs better. Where possible, we use Vector for concreteness but in some places, especially deserialization, it's desirable to be able to pass Arrays around without copying them to a Vector. In these places, we use IndexedSeq.
 * Also change per-sample Seq's to be of type PerSample in a few places
 * Add isClipped method to Alignment
 * Small comment updates

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/407)
<!-- Reviewable:end -->
