### PR TITLE
Two Spark API optimizations

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/ReadSet.scala
+++ b/src/main/scala/org/hammerlab/guacamole/ReadSet.scala
@@ -72,10 +72,11 @@ case class ReadSet(
       sequenceDictionary.get.records.foreach(record => builder += ((record.name.toString, record.length)))
       builder.result
     } else {
-      mappedReads.map(read => Map(read.referenceContig -> read.end)).reduce((map1, map2) => {
-        val keys = map1.keySet.union(map2.keySet).toSeq
-        keys.map(key => key -> math.max(map1.getOrElse(key, 0L), map2.getOrElse(key, 0L))).toMap
-      }).toMap
+      mappedReads
+        .map(read => read.referenceContig → read.end)
+        .reduceByKey(math.max)
+        .collectAsMap()
+        .toMap
     }
   }
 }

--- a/src/main/scala/org/hammerlab/guacamole/commands/VAFHistogram.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/VAFHistogram.scala
@@ -199,7 +199,11 @@ object VAFHistogram {
       val variantPercent = (variantAlleleFrequency * 100).toInt
       variantPercent - (variantPercent % (100 / bins))
     }
-    variantAlleleFrequencies.map(vaf => roundToBin(vaf.variantAlleleFrequency)).countByValue().toMap
+    variantAlleleFrequencies
+      .map(vaf ⇒ roundToBin(vaf.variantAlleleFrequency) → 1L)
+      .reduceByKey(_ + _)
+      .collectAsMap
+      .toMap
   }
 
   /**

--- a/src/main/scala/org/hammerlab/guacamole/commands/VAFHistogram.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/VAFHistogram.scala
@@ -199,7 +199,7 @@ object VAFHistogram {
       val variantPercent = (variantAlleleFrequency * 100).toInt
       variantPercent - (variantPercent % (100 / bins))
     }
-    variantAlleleFrequencies.keyBy(vaf => roundToBin(vaf.variantAlleleFrequency)).countByKey().toMap
+    variantAlleleFrequencies.map(vaf => roundToBin(vaf.variantAlleleFrequency)).countByValue().toMap
   }
 
   /**

--- a/src/test/scala/org/hammerlab/guacamole/commands/jointcaller/ReadSubsequenceSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/jointcaller/ReadSubsequenceSuite.scala
@@ -1,10 +1,8 @@
 package org.hammerlab.guacamole.commands.jointcaller
 
-import org.hammerlab.guacamole.Bases
 import org.hammerlab.guacamole.pileup.Pileup
 import org.hammerlab.guacamole.reference.ReferenceBroadcast
-import org.hammerlab.guacamole.reference.ReferenceBroadcast.ArrayBackedReferenceSequence
-import org.hammerlab.guacamole.util.{ TestUtil, GuacFunSuite }
+import org.hammerlab.guacamole.util.{ GuacFunSuite, TestUtil }
 import org.scalatest.Matchers
 
 class ReadSubsequenceSuite extends GuacFunSuite with Matchers {
@@ -19,7 +17,6 @@ class ReadSubsequenceSuite extends GuacFunSuite with Matchers {
   }
 
   sparkTest("ofFixedReferenceLength") {
-    val ref = ArrayBackedReferenceSequence(sc, "NTCGATCGA")
     val reads = Seq(
       TestUtil.makeRead("TCGATCGA", "8M", 1), // no variant
       TestUtil.makeRead("TCGACCCTCGA", "4M3I4M", 1), // insertion
@@ -35,7 +32,6 @@ class ReadSubsequenceSuite extends GuacFunSuite with Matchers {
   }
 
   sparkTest("ofNextAltAllele") {
-    val ref = ArrayBackedReferenceSequence(sc, "NTCGATCGA")
     val reads = Seq(
       TestUtil.makeRead("TCGATCGA", "8M", 1), // no variant
       TestUtil.makeRead("TCGAGCGA", "8M", 1), // snv
@@ -70,7 +66,6 @@ class ReadSubsequenceSuite extends GuacFunSuite with Matchers {
     val pileups = cancerWGS1Bams.map(
       path => TestUtil.loadPileup(sc, path, contig = Some(contigLocus._1), locus = contigLocus._2, reference = partialReference))
 
-    val reference = partialReference
     val subsequences = ReadSubsequence.nextAlts(pileups(1).elements)
     assert(subsequences.nonEmpty)
 


### PR DESCRIPTION
Two Spark API nits:
- changed a `reduce` over `Map`s in ReadSet to be a `reduceByKey` over `Long`s; I've observed merging `Map`s in a reduce* to be super slow in Pageant, in the past. It also feels cleaner to use the simpler combiner.
- switched a `keyBy(…).countByKey` to a `map(…).reduceByKey(_+_)`, which should produce fewer intermediate objects

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/411)
<!-- Reviewable:end -->
