### PR TITLE
use contigLengths instead of readset as param

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/Common.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Common.scala
@@ -229,10 +229,10 @@ object Common extends Logging {
    * @param filePath path to file containing loci. If it ends in '.vcf' then it is read as a VCF and the variant sites
    *                 are the loci. If it ends in '.loci' or '.txt' then it should be a file containing loci as
    *                 "chrX:5-10,chr12-10-20", etc. Whitespace is ignored.
-   * @param readSet readset to use for contig names
+   * @param contigLengths contig lengths, by name
    * @return a LociSet
    */
-  def lociFromFile(filePath: String, readSet: ReadSet): LociSet = {
+  def lociFromFile(filePath: String, contigLengths: Map[String, Long]): LociSet = {
     if (filePath.endsWith(".vcf")) {
       val builder = LociSet.newBuilder
       val reader = new VCFFileReader(new File(filePath), false)
@@ -246,7 +246,8 @@ object Common extends Logging {
       val filesystem = FileSystem.get(new Configuration())
       val path = new Path(filePath)
       LociSet.parse(
-        IOUtils.toString(new InputStreamReader(filesystem.open(path)))).result(readSet.contigLengths)
+        IOUtils.toString(new InputStreamReader(filesystem.open(path)))
+      ).result(contigLengths)
     } else {
       throw new IllegalArgumentException(
         "Couldn't guess format for file: %s. Expected file extensions: '.loci' or '.txt' for loci string format; '.vcf' for VCFs.".format(filePath))
@@ -260,20 +261,20 @@ object Common extends Logging {
    *
    * @param loci loci to load as a string
    * @param lociFromFilePath path to file containing loci to load
-   * @param readSet readset to use for contig names
+   * @param contigLengths contig lengths, by name
    * @return a LociSet
    */
-  def loci(loci: String, lociFromFilePath: String, readSet: ReadSet): LociSet = {
+  def loci(loci: String, lociFromFilePath: String, contigLengths: Map[String, Long]): LociSet = {
     if (loci.nonEmpty && lociFromFilePath.nonEmpty) {
       throw new IllegalArgumentException("Specify at most one of the 'loci' and 'loci-from-file' arguments")
     }
     if (loci.nonEmpty) {
-      LociSet.parse(loci).result(Some(readSet.contigLengths))
+      LociSet.parse(loci).result(Some(contigLengths))
     } else if (lociFromFilePath.nonEmpty) {
-      lociFromFile(lociFromFilePath, readSet)
+      lociFromFile(lociFromFilePath, contigLengths)
     } else {
       // Default is "all"
-      LociSet.parse("all").result(Some(readSet.contigLengths))
+      LociSet.parse("all").result(Some(contigLengths))
     }
   }
 

--- a/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCaller.scala
@@ -76,7 +76,7 @@ object SomaticJoint {
           .format(readSets.map(_.sequenceDictionary.toString).mkString("\n")))
 
       val forceCallLoci = if (args.forceCallLoci.nonEmpty || args.forceCallLociFromFile.nonEmpty) {
-        Common.loci(args.forceCallLoci, args.forceCallLociFromFile, readSets(0))
+        Common.loci(args.forceCallLoci, args.forceCallLociFromFile, readSets(0).contigLengths)
       } else {
         LociSet.empty
       }


### PR DESCRIPTION
feels weird to have to pass a whole `ReadSet` to parse some loci, and we were only using it for the contig lengths

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/421)
<!-- Reviewable:end -->
