### PR TITLE
Moving files/classes to their own packages/files or out of root guacamole package

### DIFF
--- a/scripts/guacamole-spark-defaults.conf
+++ b/scripts/guacamole-spark-defaults.conf
@@ -1,4 +1,4 @@
 spark.serializer               org.apache.spark.serializer.KryoSerializer
-spark.kryo.registrator         org.hammerlab.guacamole.GuacamoleKryoRegistrator
+spark.kryo.registrator         org.hammerlab.guacamole.kryo.GuacamoleKryoRegistrator
 spark.kryoserializer.buffer.mb 4
 spark.kryo.referenceTracking   true

--- a/src/main/scala/org/hammerlab/guacamole/CigarUtils.scala
+++ b/src/main/scala/org/hammerlab/guacamole/CigarUtils.scala
@@ -18,7 +18,7 @@
 
 package org.hammerlab.guacamole
 
-import htsjdk.samtools.CigarElement
+import htsjdk.samtools.{CigarElement, CigarOperator}
 
 object CigarUtils {
   /**
@@ -39,5 +39,10 @@ object CigarUtils {
    */
   def getReferenceLength(element: CigarElement): Int = {
     if (element.getOperator.consumesReferenceBases) element.getLength else 0
+  }
+
+  /** Is the given samtools CigarElement a (hard/soft) clip? */
+  def isClipped(element: CigarElement): Boolean = {
+    element.getOperator == CigarOperator.SOFT_CLIP || element.getOperator == CigarOperator.HARD_CLIP
   }
 }

--- a/src/main/scala/org/hammerlab/guacamole/Common.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Common.scala
@@ -37,6 +37,7 @@ import org.hammerlab.guacamole.Common.Arguments.ReadLoadingConfigArgs
 import org.hammerlab.guacamole.Concordance.ConcordanceArgs
 import org.hammerlab.guacamole.distributed.LociPartitionUtils
 import org.hammerlab.guacamole.loci.LociSet
+import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.reads.Read
 import org.kohsuke.args4j.{Option => Args4jOption}
 
@@ -396,25 +397,6 @@ object Common extends Logging {
     }
 
     new SparkContext(config)
-  }
-
-  /** Time in milliseconds of last progress message. */
-  var lastProgressTime: Long = 0
-
-  /**
-   * Print or log a progress message. For now, we just print to standard out, since ADAM's logging setup makes it
-   * difficult to see log messages at the INFO level without flooding ourselves with parquet messages.
-   * @param message String to print or log.
-   */
-  def progress(message: String): Unit = {
-    val current = System.currentTimeMillis
-    val time = if (lastProgressTime == 0)
-      java.util.Calendar.getInstance.getTime.toString
-    else
-      "%.2f sec. later".format((current - lastProgressTime) / 1000.0)
-    println("--> [%15s]: %s".format(time, message))
-    System.out.flush()
-    lastProgressTime = current
   }
 
   /**

--- a/src/main/scala/org/hammerlab/guacamole/Common.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Common.scala
@@ -386,7 +386,7 @@ object Common extends Logging {
     }
 
     if (config.getOption("spark.kryo.registrator").isEmpty) {
-      config.set("spark.kryo.registrator", "org.hammerlab.guacamole.GuacamoleKryoRegistrator")
+      config.set("spark.kryo.registrator", "org.hammerlab.guacamole.kryo.GuacamoleKryoRegistrator")
     }
 
     if (config.getOption("spark.kryoserializer.buffer").isEmpty) {

--- a/src/main/scala/org/hammerlab/guacamole/Common.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Common.scala
@@ -38,7 +38,8 @@ import org.hammerlab.guacamole.Concordance.ConcordanceArgs
 import org.hammerlab.guacamole.distributed.LociPartitionUtils
 import org.hammerlab.guacamole.loci.LociSet
 import org.hammerlab.guacamole.logging.LoggingUtils.progress
-import org.hammerlab.guacamole.reads.Read
+import org.hammerlab.guacamole.reads.BamReaderAPI.BamReaderAPI
+import org.hammerlab.guacamole.reads.{BamReaderAPI, Read, ReadLoadingConfig}
 import org.kohsuke.args4j.{Option => Args4jOption}
 
 /**
@@ -71,7 +72,7 @@ object Common extends Logging {
       var noSequenceDictionary: Boolean = false
     }
 
-    /** Argument for configuring read loading with a Read.ReadLoadingConfig object. */
+    /** Argument for configuring read loading with a ReadLoadingConfig object. */
     trait ReadLoadingConfigArgs extends Base {
       @Args4jOption(name = "--bam-reader-api",
         usage = "API to use for reading BAMs, one of: best (use samtools if file local), samtools, hadoopbam")
@@ -79,9 +80,8 @@ object Common extends Logging {
     }
     object ReadLoadingConfigArgs {
       /** Given commandline arguments, return a ReadLoadingConfig. */
-      def fromArguments(args: ReadLoadingConfigArgs): Read.ReadLoadingConfig = {
-        Read.ReadLoadingConfig(
-          bamReaderAPI = Read.ReadLoadingConfig.BamReaderAPI.withNameCaseInsensitive(args.bamReaderAPI))
+      def fromArguments(args: ReadLoadingConfigArgs): ReadLoadingConfig = {
+        ReadLoadingConfig(BamReaderAPI.withNameCaseInsensitive(args.bamReaderAPI))
       }
     }
 

--- a/src/main/scala/org/hammerlab/guacamole/Common.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Common.scala
@@ -18,27 +18,20 @@
 
 package org.hammerlab.guacamole
 
-import java.io.{File, InputStreamReader, OutputStream}
+import java.io.{File, InputStreamReader}
 
 import htsjdk.variant.vcf.VCFFileReader
-import org.apache.avro.generic.GenericDatumWriter
-import org.apache.avro.io.EncoderFactory
 import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.mapred.FileAlreadyExistsException
-import org.apache.spark.rdd.RDD
 import org.apache.spark.{Logging, SparkConf, SparkContext}
-import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.formats.avro.Genotype
-import org.bdgenomics.utils.cli.{Args4jBase, ParquetArgs}
-import org.codehaus.jackson.JsonFactory
-import org.hammerlab.guacamole.Common.Arguments.ReadLoadingConfigArgs
-import org.hammerlab.guacamole.Concordance.ConcordanceArgs
 import org.hammerlab.guacamole.distributed.LociPartitionUtils
-import org.hammerlab.guacamole.loci.LociSet
-import org.hammerlab.guacamole.logging.LoggingUtils.progress
-import org.hammerlab.guacamole.reads.{BamReaderAPI, InputFilters, ReadLoadingConfig}
+import org.hammerlab.guacamole.loci.{LociArgs, LociSet}
+import org.hammerlab.guacamole.logging.DebugLogArgs
+import org.hammerlab.guacamole.reads.{InputFilters, ReadLoadingConfigArgs}
+import org.hammerlab.guacamole.variants.Concordance.ConcordanceArgs
+import org.hammerlab.guacamole.variants.GenotypeOutputArgs
 import org.kohsuke.args4j.{Option => Args4jOption}
 
 /**
@@ -46,104 +39,33 @@ import org.kohsuke.args4j.{Option => Args4jOption}
  *
  */
 object Common extends Logging {
-  object Arguments {
-    /** Common argument(s) we always want.*/
-    trait Base extends Args4jBase with ParquetArgs {
-      @Args4jOption(name = "--debug", usage = "If set, prints a higher level of debug output.")
-      var debug = false
-    }
-
-    /** Argument for accepting a set of loci. */
-    trait Loci extends Base {
-      @Args4jOption(name = "--loci", usage = "Loci at which to call variants. Either 'all' or contig:start-end,contig:start-end,...",
-        forbids = Array("--loci-from-file"))
-      var loci: String = ""
-
-      @Args4jOption(name = "--loci-from-file", usage = "Path to file giving loci at which to call variants.",
-        forbids = Array("--loci"))
-      var lociFromFile: String = ""
-    }
-
-    /** Argument for using / not using sequence dictionaries to get contigs and lengths. */
-    trait NoSequenceDictionary extends Base {
-      @Args4jOption(name = "--no-sequence-dictionary",
-        usage = "If set, get contigs and lengths directly from reads instead of from sequence dictionary.")
-      var noSequenceDictionary: Boolean = false
-    }
-
-    /** Argument for configuring read loading with a ReadLoadingConfig object. */
-    trait ReadLoadingConfigArgs extends Base {
-      @Args4jOption(name = "--bam-reader-api",
-        usage = "API to use for reading BAMs, one of: best (use samtools if file local), samtools, hadoopbam")
-      var bamReaderAPI: String = "best"
-    }
-    object ReadLoadingConfigArgs {
-      /** Given commandline arguments, return a ReadLoadingConfig. */
-      def fromArguments(args: ReadLoadingConfigArgs): ReadLoadingConfig = {
-        ReadLoadingConfig(BamReaderAPI.withNameCaseInsensitive(args.bamReaderAPI))
-      }
-    }
-
-    /** Argument for accepting a single set of reads (for non-somatic variant calling). */
-    trait Reads extends Base with NoSequenceDictionary with ReadLoadingConfigArgs {
-      @Args4jOption(name = "--reads", metaVar = "X", required = true, usage = "Aligned reads")
-      var reads: String = ""
-    }
-
-    /** Arguments for accepting two sets of reads (tumor + normal). */
-    trait TumorNormalReads extends Base with NoSequenceDictionary with ReadLoadingConfigArgs {
-      @Args4jOption(name = "--normal-reads", metaVar = "X", required = true, usage = "Aligned reads: normal")
-      var normalReads: String = ""
-
-      @Args4jOption(name = "--tumor-reads", metaVar = "X", required = true, usage = "Aligned reads: tumor")
-      var tumorReads: String = ""
-    }
-
-    /** Argument for writing output genotypes. */
-    trait GenotypeOutput extends Base {
-      @Args4jOption(name = "--out", metaVar = "VARIANTS_OUT", required = false,
-        usage = "Variant output path. If not specified, print to screen.")
-      var variantOutput: String = ""
-
-      @Args4jOption(name = "--out-chunks", metaVar = "X", required = false,
-        usage = "When writing out to json format, number of chunks to coalesce the genotypes RDD into.")
-      var outChunks: Int = 1
-
-      @Args4jOption(name = "--max-genotypes", metaVar = "X", required = false,
-        usage = "Maximum number of genotypes to output. 0 (default) means output all genotypes.")
-      var maxGenotypes: Int = 0
-    }
-
-    /** Arguments for accepting a reference genome. */
-    trait Reference extends Base {
-      @Args4jOption(required = false, name = "--reference", usage = "ADAM or FASTA reference genome data")
-      var referenceInput: String = ""
-
-      @Args4jOption(required = false, name = "--fragment-length",
-        usage = "Sets maximum fragment length. Default value is 10,000. Values greater than 1e9 should be avoided.")
-      var fragmentLength: Long = 10000L
-    }
-
-    trait GermlineCallerArgs extends GenotypeOutput with Reads with ConcordanceArgs with LociPartitionUtils.Arguments
-
-    trait SomaticCallerArgs extends GenotypeOutput with TumorNormalReads with LociPartitionUtils.Arguments
+  /** Argument for using / not using sequence dictionaries to get contigs and lengths. */
+  trait NoSequenceDictionaryArgs extends DebugLogArgs {
+    @Args4jOption(
+      name = "--no-sequence-dictionary",
+      usage = "If set, get contigs and lengths directly from reads instead of from sequence dictionary."
+    )
+    var noSequenceDictionary: Boolean = false
   }
 
-  /**
-   *
-   * Load genotypes from ADAM Parquet or VCF file
-   *
-   * @param path path to VCF or ADAM genotypes
-   * @param sc spark context
-   * @return RDD of ADAM Genotypes
-   */
-  def loadGenotypes(path: String, sc: SparkContext): RDD[Genotype] = {
-    if (path.endsWith(".vcf")) {
-      sc.loadGenotypes(path)
-    } else {
-      sc.loadParquet(path)
-    }
+  /** Argument for accepting a single set of reads (for non-somatic variant calling). */
+  trait ReadsArgs extends DebugLogArgs with NoSequenceDictionaryArgs with ReadLoadingConfigArgs {
+    @Args4jOption(name = "--reads", metaVar = "X", required = true, usage = "Aligned reads")
+    var reads: String = ""
   }
+
+  /** Arguments for accepting two sets of reads (tumor + normal). */
+  trait TumorNormalReadsArgs extends DebugLogArgs with NoSequenceDictionaryArgs with ReadLoadingConfigArgs {
+    @Args4jOption(name = "--normal-reads", metaVar = "X", required = true, usage = "Aligned reads: normal")
+    var normalReads: String = ""
+
+    @Args4jOption(name = "--tumor-reads", metaVar = "X", required = true, usage = "Aligned reads: tumor")
+    var tumorReads: String = ""
+  }
+
+  trait GermlineCallerArgs extends GenotypeOutputArgs with ReadsArgs with ConcordanceArgs with LociPartitionUtils.Arguments
+
+  trait SomaticCallerArgs extends GenotypeOutputArgs with TumorNormalReadsArgs with LociPartitionUtils.Arguments
 
   /**
    * Given arguments for a single set of reads, and a spark context, return a ReadSet.
@@ -153,17 +75,15 @@ object Common extends Logging {
    * @param filters input filters to apply
    * @return
    */
-  def loadReadsFromArguments(
-    args: Arguments.Reads,
-    sc: SparkContext,
-    filters: InputFilters): ReadSet = {
-
+  def loadReadsFromArguments(args: ReadsArgs,
+                             sc: SparkContext,
+                             filters: InputFilters): ReadSet = {
     ReadSet(
       sc,
       args.reads,
       filters,
       contigLengthsFromDictionary = !args.noSequenceDictionary,
-      config = ReadLoadingConfigArgs.fromArguments(args)
+      config = ReadLoadingConfigArgs(args)
     )
   }
 
@@ -174,17 +94,16 @@ object Common extends Logging {
    * @param sc spark context
    * @param filters input filters to apply
    */
-  def loadTumorNormalReadsFromArguments(
-    args: Arguments.TumorNormalReads,
-    sc: SparkContext,
-    filters: InputFilters): (ReadSet, ReadSet) = {
+  def loadTumorNormalReadsFromArguments(args: TumorNormalReadsArgs,
+                                        sc: SparkContext,
+                                        filters: InputFilters): (ReadSet, ReadSet) = {
 
     val tumor = ReadSet(
       sc,
       args.tumorReads,
       filters,
       !args.noSequenceDictionary,
-      ReadLoadingConfigArgs.fromArguments(args)
+      ReadLoadingConfigArgs(args)
     )
 
     val normal = ReadSet(
@@ -192,8 +111,9 @@ object Common extends Logging {
       args.normalReads,
       filters,
       !args.noSequenceDictionary,
-      ReadLoadingConfigArgs.fromArguments(args)
+      ReadLoadingConfigArgs(args)
     )
+
     (tumor, normal)
   }
 
@@ -202,7 +122,7 @@ object Common extends Logging {
    *
    * @param args parsed arguments
    */
-  def lociFromArguments(args: Arguments.Loci, default: String = "all"): LociSet.Builder = {
+  def lociFromArguments(args: LociArgs, default: String = "all"): LociSet.Builder = {
     if (args.loci.nonEmpty && args.lociFromFile.nonEmpty) {
       throw new IllegalArgumentException("Specify at most one of the 'loci' and 'loci-from-file' arguments")
     }
@@ -217,7 +137,6 @@ object Common extends Logging {
       default
     }
     LociSet.parse(lociToParse)
-
   }
 
   /**
@@ -247,7 +166,8 @@ object Common extends Logging {
       ).result(contigLengths)
     } else {
       throw new IllegalArgumentException(
-        "Couldn't guess format for file: %s. Expected file extensions: '.loci' or '.txt' for loci string format; '.vcf' for VCFs.".format(filePath))
+        s"Couldn't guess format for file: $filePath. Expected file extensions: '.loci' or '.txt' for loci string format; '.vcf' for VCFs."
+      )
     }
   }
 
@@ -276,76 +196,10 @@ object Common extends Logging {
   }
 
   /**
-   * Write out an RDD of Genotype instances to a file.
- *
-   * @param args parsed arguments
-   * @param genotypes ADAM genotypes (i.e. the variants)
-   */
-  def writeVariantsFromArguments(args: Arguments.GenotypeOutput, genotypes: RDD[Genotype]): Unit = {
-    val subsetGenotypes = if (args.maxGenotypes > 0) {
-      progress("Subsetting to %d genotypes.".format(args.maxGenotypes))
-      genotypes.sample(withReplacement = false, args.maxGenotypes, 0)
-    } else {
-      genotypes
-    }
-    val outputPath = args.variantOutput.stripMargin
-    if (outputPath.isEmpty || outputPath.toLowerCase.endsWith(".json")) {
-      val out: OutputStream = if (outputPath.isEmpty) {
-        progress("Writing genotypes to stdout.")
-        System.out
-      } else {
-        progress("Writing genotypes serially in json format to: %s.".format(outputPath))
-        val filesystem = FileSystem.get(new Configuration())
-        val path = new Path(outputPath)
-        filesystem.create(path, true)
-      }
-      val coalescedSubsetGenotypes = if (args.outChunks > 0) subsetGenotypes.coalesce(args.outChunks) else subsetGenotypes
-      coalescedSubsetGenotypes.persist()
-
-      // Write each Genotype with a JsonEncoder.
-      val schema = Genotype.getClassSchema
-      val writer = new GenericDatumWriter[Object](schema)
-      val encoder = EncoderFactory.get.jsonEncoder(schema, out)
-      val generator = new JsonFactory().createJsonGenerator(out)
-      generator.useDefaultPrettyPrinter()
-      encoder.configure(generator)
-      var partitionNum = 0
-      val numPartitions = coalescedSubsetGenotypes.partitions.length
-      while (partitionNum < numPartitions) {
-        progress("Collecting partition %d of %d.".format(partitionNum + 1, numPartitions))
-        val chunk = coalescedSubsetGenotypes.mapPartitionsWithIndex((num, genotypes) => {
-          if (num == partitionNum) genotypes else Iterator.empty
-        }).collect
-        chunk.foreach(genotype => {
-          writer.write(genotype, encoder)
-          encoder.flush()
-        })
-        partitionNum += 1
-      }
-      out.write("\n".getBytes())
-      generator.close()
-      coalescedSubsetGenotypes.unpersist()
-    } else if (outputPath.toLowerCase.endsWith(".vcf")) {
-      progress("Writing genotypes to VCF file: %s.".format(outputPath))
-      val sc = subsetGenotypes.sparkContext
-      subsetGenotypes.toVariantContext.coalesce(1, shuffle = true).saveAsVcf(outputPath)
-    } else {
-      progress("Writing genotypes to: %s.".format(outputPath))
-      subsetGenotypes.adamParquetSave(
-        outputPath,
-        args.blockSize,
-        args.pageSize,
-        args.compressionCodec,
-        args.disableDictionaryEncoding
-      )
-    }
-  }
-
-  /**
    * Parse spark environment variables from commandline. Copied from ADAM.
    *
    * Commandline format is -spark_env foo=1 -spark_env bar=2
- *
+   *
    * @param envVariables The variables found on the commandline
    * @return array of (key, value) pairs parsed from the command line.
    */
@@ -427,7 +281,7 @@ object Common extends Logging {
    * Perform validation of command line arguments at startup.
    * This allows some late failures (e.g. output file already exists) to be surfaced more quickly.
    */
-  def validateArguments(args: Arguments.GenotypeOutput) = {
+  def validateArguments(args: GenotypeOutputArgs) = {
     val outputPath = args.variantOutput.stripMargin
     if (outputPath.toLowerCase.endsWith(".vcf")) {
       val filesystem = FileSystem.get(new Configuration())

--- a/src/main/scala/org/hammerlab/guacamole/Common.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Common.scala
@@ -38,8 +38,7 @@ import org.hammerlab.guacamole.Concordance.ConcordanceArgs
 import org.hammerlab.guacamole.distributed.LociPartitionUtils
 import org.hammerlab.guacamole.loci.LociSet
 import org.hammerlab.guacamole.logging.LoggingUtils.progress
-import org.hammerlab.guacamole.reads.BamReaderAPI.BamReaderAPI
-import org.hammerlab.guacamole.reads.{BamReaderAPI, Read, ReadLoadingConfig}
+import org.hammerlab.guacamole.reads.{BamReaderAPI, InputFilters, ReadLoadingConfig}
 import org.kohsuke.args4j.{Option => Args4jOption}
 
 /**
@@ -157,7 +156,7 @@ object Common extends Logging {
   def loadReadsFromArguments(
     args: Arguments.Reads,
     sc: SparkContext,
-    filters: Read.InputFilters): ReadSet = {
+    filters: InputFilters): ReadSet = {
 
     ReadSet(
       sc,
@@ -178,7 +177,7 @@ object Common extends Logging {
   def loadTumorNormalReadsFromArguments(
     args: Arguments.TumorNormalReads,
     sc: SparkContext,
-    filters: Read.InputFilters): (ReadSet, ReadSet) = {
+    filters: InputFilters): (ReadSet, ReadSet) = {
 
     val tumor = ReadSet(
       sc,
@@ -278,6 +277,7 @@ object Common extends Logging {
 
   /**
    * Write out an RDD of Genotype instances to a file.
+ *
    * @param args parsed arguments
    * @param genotypes ADAM genotypes (i.e. the variants)
    */
@@ -345,6 +345,7 @@ object Common extends Logging {
    * Parse spark environment variables from commandline. Copied from ADAM.
    *
    * Commandline format is -spark_env foo=1 -spark_env bar=2
+ *
    * @param envVariables The variables found on the commandline
    * @return array of (key, value) pairs parsed from the command line.
    */

--- a/src/main/scala/org/hammerlab/guacamole/Concordance.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Concordance.scala
@@ -123,7 +123,16 @@ object Concordance {
 
   def printGenotypeConcordance(args: ConcordanceArgs, genotypes: RDD[Genotype], sc: SparkContext) = {
     val trueGenotypes = Common.loadGenotypes(args.truthGenotypesFile, sc)
-    val (precision, recall, f1score) = computePrecisionAndRecall(genotypes, trueGenotypes, args.excludeSNVs, args.excludeIndels, args.chromosome)
+
+    val (precision, recall, f1score) =
+      computePrecisionAndRecall(
+        genotypes,
+        trueGenotypes,
+        args.excludeSNVs,
+        args.excludeIndels,
+        args.chromosome
+      )
+
     println("Precision\tRecall\tF1Score")
     println("%f\t%f\t%f".format(precision, recall, f1score))
   }

--- a/src/main/scala/org/hammerlab/guacamole/Guacamole.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Guacamole.scala
@@ -22,7 +22,7 @@ import java.util.logging.Level
 
 import org.apache.spark.Logging
 import org.bdgenomics.adam.util.ParquetLogger
-import org.hammerlab.guacamole.Common.progress
+import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.commands._
 import org.hammerlab.guacamole.commands.jointcaller.SomaticJoint
 

--- a/src/main/scala/org/hammerlab/guacamole/ReadSet.scala
+++ b/src/main/scala/org/hammerlab/guacamole/ReadSet.scala
@@ -21,7 +21,7 @@ package org.hammerlab.guacamole
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models.SequenceDictionary
-import org.hammerlab.guacamole.reads.{ MappedRead, PairedRead, Read }
+import org.hammerlab.guacamole.reads.{MappedRead, PairedRead, Read, ReadLoadingConfig}
 
 /**
  * A ReadSet contains an RDD of reads along with some metadata about them.
@@ -93,7 +93,7 @@ object ReadSet {
     filename: String,
     filters: Read.InputFilters = Read.InputFilters.empty,
     contigLengthsFromDictionary: Boolean = true,
-    config: Read.ReadLoadingConfig = Read.ReadLoadingConfig.default): ReadSet = {
+    config: ReadLoadingConfig = ReadLoadingConfig.default): ReadSet = {
 
     val (reads, sequenceDictionary) =
       Read.loadReadRDDAndSequenceDictionary(

--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
@@ -5,8 +5,7 @@ import breeze.stats.{mean, median}
 import htsjdk.samtools.CigarOperator
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
-import org.hammerlab.guacamole.Common.Arguments.GermlineCallerArgs
-import org.hammerlab.guacamole._
+import org.hammerlab.guacamole.Common.GermlineCallerArgs
 import org.hammerlab.guacamole.alignment.AffineGapPenaltyAlignment
 import org.hammerlab.guacamole.assembly.DeBruijnGraph
 import org.hammerlab.guacamole.distributed.LociPartitionUtils.partitionLociAccordingToArgs
@@ -18,8 +17,9 @@ import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.pileup.Pileup
 import org.hammerlab.guacamole.reads.{MappedRead, InputFilters}
 import org.hammerlab.guacamole.reference.{ReferenceBroadcast, ReferenceGenome}
-import org.hammerlab.guacamole.variants.{Allele, AlleleConversions, AlleleEvidence, CalledAllele}
+import org.hammerlab.guacamole.variants.{Allele, AlleleConversions, AlleleEvidence, CalledAllele, VariantUtils}
 import org.hammerlab.guacamole.windowing.SlidingWindow
+import org.hammerlab.guacamole.{CigarUtils, Common, SparkCommand}
 import org.kohsuke.args4j.{Option => Args4jOption}
 
 import scala.collection.JavaConversions._
@@ -232,7 +232,7 @@ object GermlineAssemblyCaller {
       val outputGenotypes =
         genotypes.flatMap(AlleleConversions.calledAlleleToADAMGenotype)
 
-      Common.writeVariantsFromArguments(args, outputGenotypes)
+      VariantUtils.writeVariantsFromArguments(args, outputGenotypes)
       DelayedMessages.default.print()
     }
 

--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
@@ -17,6 +17,7 @@ import org.hammerlab.guacamole.logging.DelayedMessages
 import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.pileup.Pileup
 import org.hammerlab.guacamole.reads.{MappedRead, Read}
+import org.hammerlab.guacamole.reads.{MappedRead, InputFilters}
 import org.hammerlab.guacamole.reference.{ReferenceBroadcast, ReferenceGenome}
 import org.hammerlab.guacamole.variants.{Allele, AlleleConversions, AlleleEvidence, CalledAllele}
 import org.hammerlab.guacamole.windowing.SlidingWindow
@@ -196,7 +197,7 @@ object GermlineAssemblyCaller {
       val readSet = Common.loadReadsFromArguments(
         args,
         sc,
-        Read.InputFilters(
+        InputFilters(
           overlapsLoci = Some(loci),
           mapped = true,
           nonDuplicate = true

--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
@@ -16,7 +16,6 @@ import org.hammerlab.guacamole.loci.LociMap
 import org.hammerlab.guacamole.logging.DelayedMessages
 import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.pileup.Pileup
-import org.hammerlab.guacamole.reads.{MappedRead, Read}
 import org.hammerlab.guacamole.reads.{MappedRead, InputFilters}
 import org.hammerlab.guacamole.reference.{ReferenceBroadcast, ReferenceGenome}
 import org.hammerlab.guacamole.variants.{Allele, AlleleConversions, AlleleEvidence, CalledAllele}

--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
@@ -13,6 +13,8 @@ import org.hammerlab.guacamole.distributed.LociPartitionUtils.partitionLociAccor
 import org.hammerlab.guacamole.distributed.WindowFlatMapUtils.windowFlatMapWithState
 import org.hammerlab.guacamole.likelihood.Likelihood
 import org.hammerlab.guacamole.loci.LociMap
+import org.hammerlab.guacamole.logging.DelayedMessages
+import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.pileup.Pileup
 import org.hammerlab.guacamole.reads.{MappedRead, Read}
 import org.hammerlab.guacamole.reference.{ReferenceBroadcast, ReferenceGenome}
@@ -225,7 +227,7 @@ object GermlineAssemblyCaller {
 
       genotypes.persist()
 
-      Common.progress(s"Found ${genotypes.count} variants")
+      progress(s"Found ${genotypes.count} variants")
 
       val outputGenotypes =
         genotypes.flatMap(AlleleConversions.calledAlleleToADAMGenotype)

--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
@@ -198,7 +198,7 @@ object GermlineAssemblyCaller {
         args,
         sc,
         InputFilters(
-          overlapsLoci = Some(loci),
+          overlapsLoci = loci,
           mapped = true,
           nonDuplicate = true
         )

--- a/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
@@ -22,7 +22,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.rdd.ADAMContext
 import org.bdgenomics.formats.avro.DatabaseVariantAnnotation
-import org.hammerlab.guacamole.Common.Arguments.SomaticCallerArgs
+import org.hammerlab.guacamole.Common.SomaticCallerArgs
 import org.hammerlab.guacamole.distributed.LociPartitionUtils.partitionLociAccordingToArgs
 import org.hammerlab.guacamole.distributed.PileupFlatMapUtils.pileupFlatMapTwoRDDs
 import org.hammerlab.guacamole.filters.PileupFilter.PileupFilterArguments
@@ -34,7 +34,7 @@ import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.pileup.Pileup
 import org.hammerlab.guacamole.reads.InputFilters
 import org.hammerlab.guacamole.reference.ReferenceBroadcast
-import org.hammerlab.guacamole.variants.{Allele, AlleleConversions, AlleleEvidence, CalledSomaticAllele}
+import org.hammerlab.guacamole.variants.{Allele, AlleleConversions, AlleleEvidence, CalledSomaticAllele, VariantUtils}
 import org.hammerlab.guacamole.{Common, SparkCommand}
 import org.kohsuke.args4j.{Option => Args4jOption}
 
@@ -154,7 +154,7 @@ object SomaticStandard {
       val filteredGenotypes: RDD[CalledSomaticAllele] = SomaticGenotypeFilter(potentialGenotypes, args)
       progress("Computed %,d genotypes after basic filtering".format(filteredGenotypes.count))
 
-      Common.writeVariantsFromArguments(
+      VariantUtils.writeVariantsFromArguments(
         args,
         filteredGenotypes.flatMap(AlleleConversions.calledSomaticAlleleToADAMGenotype)
       )

--- a/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
@@ -23,18 +23,19 @@ import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.rdd.ADAMContext
 import org.bdgenomics.formats.avro.DatabaseVariantAnnotation
 import org.hammerlab.guacamole.Common.Arguments.SomaticCallerArgs
-import org.hammerlab.guacamole.distributed.{LociPartitionUtils, PileupFlatMapUtils}
+import org.hammerlab.guacamole.distributed.LociPartitionUtils.partitionLociAccordingToArgs
+import org.hammerlab.guacamole.distributed.PileupFlatMapUtils.pileupFlatMapTwoRDDs
 import org.hammerlab.guacamole.filters.PileupFilter.PileupFilterArguments
 import org.hammerlab.guacamole.filters.SomaticGenotypeFilter.SomaticGenotypeFilterArguments
 import org.hammerlab.guacamole.filters.{PileupFilter, SomaticAlternateReadDepthFilter, SomaticGenotypeFilter, SomaticReadDepthFilter}
 import org.hammerlab.guacamole.likelihood.Likelihood
-import LociPartitionUtils.partitionLociAccordingToArgs
+import org.hammerlab.guacamole.logging.DelayedMessages
+import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.pileup.Pileup
-import PileupFlatMapUtils.pileupFlatMapTwoRDDs
 import org.hammerlab.guacamole.reads.Read
 import org.hammerlab.guacamole.reference.ReferenceBroadcast
 import org.hammerlab.guacamole.variants.{Allele, AlleleConversions, AlleleEvidence, CalledSomaticAllele}
-import org.hammerlab.guacamole.{Common, DelayedMessages, SparkCommand}
+import org.hammerlab.guacamole.{Common, SparkCommand}
 import org.kohsuke.args4j.{Option => Args4jOption}
 
 /**
@@ -119,7 +120,7 @@ object SomaticStandard {
         )
 
       potentialGenotypes.persist()
-      Common.progress("Computed %,d potential genotypes".format(potentialGenotypes.count))
+      progress("Computed %,d potential genotypes".format(potentialGenotypes.count))
 
       // Filter potential genotypes to min read values
       potentialGenotypes =
@@ -149,7 +150,7 @@ object SomaticStandard {
       }
 
       val filteredGenotypes: RDD[CalledSomaticAllele] = SomaticGenotypeFilter(potentialGenotypes, args)
-      Common.progress("Computed %,d genotypes after basic filtering".format(filteredGenotypes.count))
+      progress("Computed %,d genotypes after basic filtering".format(filteredGenotypes.count))
 
       Common.writeVariantsFromArguments(
         args,

--- a/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
@@ -32,7 +32,7 @@ import org.hammerlab.guacamole.likelihood.Likelihood
 import org.hammerlab.guacamole.logging.DelayedMessages
 import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.pileup.Pileup
-import org.hammerlab.guacamole.reads.Read
+import org.hammerlab.guacamole.reads.InputFilters
 import org.hammerlab.guacamole.reference.ReferenceBroadcast
 import org.hammerlab.guacamole.variants.{Allele, AlleleConversions, AlleleEvidence, CalledSomaticAllele}
 import org.hammerlab.guacamole.{Common, SparkCommand}
@@ -70,10 +70,12 @@ object SomaticStandard {
     override def run(args: Arguments, sc: SparkContext): Unit = {
       Common.validateArguments(args)
       val loci = Common.lociFromArguments(args)
-      val filters = Read.InputFilters(
-        overlapsLoci = Some(loci),
-        nonDuplicate = true,
-        passedVendorQualityChecks = true)
+      val filters =
+        InputFilters(
+          overlapsLoci = Some(loci),
+          nonDuplicate = true,
+          passedVendorQualityChecks = true
+        )
 
       val reference = ReferenceBroadcast(args.referenceFastaPath, sc)
 

--- a/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
@@ -72,7 +72,7 @@ object SomaticStandard {
       val loci = Common.lociFromArguments(args)
       val filters =
         InputFilters(
-          overlapsLoci = Some(loci),
+          overlapsLoci = loci,
           nonDuplicate = true,
           passedVendorQualityChecks = true
         )

--- a/src/main/scala/org/hammerlab/guacamole/commands/VAFHistogram.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/VAFHistogram.scala
@@ -101,9 +101,10 @@ object VAFHistogram {
 
       val loci = Common.lociFromArguments(args)
       val filters = InputFilters(
-        overlapsLoci = Some(loci),
+        overlapsLoci = loci,
         nonDuplicate = true,
-        passedVendorQualityChecks = true)
+        passedVendorQualityChecks = true
+      )
       val samplePercent = args.samplePercent
 
       val readSets: Seq[ReadSet] = args.bams.zipWithIndex.map(

--- a/src/main/scala/org/hammerlab/guacamole/commands/VAFHistogram.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/VAFHistogram.scala
@@ -9,11 +9,12 @@ import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
 import org.hammerlab.guacamole._
+import org.hammerlab.guacamole.distributed.LociPartitionUtils.partitionLociAccordingToArgs
+import org.hammerlab.guacamole.distributed.PileupFlatMapUtils.pileupFlatMap
 import org.hammerlab.guacamole.distributed.{LociPartitionUtils, PileupFlatMapUtils}
-import LociPartitionUtils.partitionLociAccordingToArgs
 import org.hammerlab.guacamole.loci.LociMap
+import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.pileup.Pileup
-import PileupFlatMapUtils.pileupFlatMap
 import org.hammerlab.guacamole.reads.Read.InputFilters
 import org.hammerlab.guacamole.reads.{MappedRead, Read}
 import org.hammerlab.guacamole.reference.{ReferenceBroadcast, ReferenceGenome}
@@ -245,7 +246,7 @@ object VAFHistogram {
       variantLoci.persist(StorageLevel.MEMORY_ONLY)
 
       val numVariantLoci = variantLoci.count
-      Common.progress("%d non-zero variant loci in sample %s".format(numVariantLoci, sampleName))
+      progress(s"$numVariantLoci non-zero variant loci in sample $sampleName")
 
       // Sample variant loci to compute descriptive statistics
       val sampledVAFs =
@@ -260,15 +261,17 @@ object VAFHistogram {
       sampledVAFs.foreach(v => stats.addValue(v.variantAlleleFrequency))
 
       // Print out descriptive statistics for the variant allele frequency distribution
-      Common.progress("Variant loci stats for %s (min: %f, max: %f, median: %f, mean: %f, 25Pct: %f, 75Pct: %f)".format(
-        sampleName,
-        stats.getMin,
-        stats.getMax,
-        stats.getPercentile(50),
-        stats.getMean,
-        stats.getPercentile(25),
-        stats.getPercentile(75)
-      ))
+      progress(
+        "Variant loci stats for %s (min: %f, max: %f, median: %f, mean: %f, 25Pct: %f, 75Pct: %f)".format(
+          sampleName,
+          stats.getMin,
+          stats.getMax,
+          stats.getPercentile(50),
+          stats.getMean,
+          stats.getPercentile(25),
+          stats.getPercentile(75)
+        )
+      )
     }
 
     variantLoci

--- a/src/main/scala/org/hammerlab/guacamole/commands/VAFHistogram.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/VAFHistogram.scala
@@ -15,7 +15,7 @@ import org.hammerlab.guacamole.distributed.PileupFlatMapUtils.pileupFlatMap
 import org.hammerlab.guacamole.loci.LociMap
 import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.pileup.Pileup
-import org.hammerlab.guacamole.reads.{MappedRead, InputFilters}
+import org.hammerlab.guacamole.reads.{InputFilters, MappedRead, ReadLoadingConfigArgs}
 import org.hammerlab.guacamole.reference.{ReferenceBroadcast, ReferenceGenome}
 import org.kohsuke.args4j.{Argument, Option => Args4jOption}
 
@@ -48,7 +48,7 @@ object VariantLocus {
 
 object VAFHistogram {
 
-  protected class Arguments extends LociPartitionUtils.Arguments with Common.Arguments.ReadLoadingConfigArgs {
+  protected class Arguments extends LociPartitionUtils.Arguments with ReadLoadingConfigArgs {
 
     @Args4jOption(name = "--out", required = false, forbids = Array("--local-out"),
       usage = "HDFS file path to save the variant allele frequency histogram")
@@ -100,11 +100,13 @@ object VAFHistogram {
       val reference = ReferenceBroadcast(args.referenceFastaPath, sc)
 
       val loci = Common.lociFromArguments(args)
-      val filters = InputFilters(
-        overlapsLoci = loci,
-        nonDuplicate = true,
-        passedVendorQualityChecks = true
-      )
+      val filters =
+        InputFilters(
+          overlapsLoci = loci,
+          nonDuplicate = true,
+          passedVendorQualityChecks = true
+        )
+
       val samplePercent = args.samplePercent
 
       val readSets: Seq[ReadSet] = args.bams.zipWithIndex.map(
@@ -112,9 +114,9 @@ object VAFHistogram {
           ReadSet(
             sc,
             bamFile._1,
-            InputFilters.empty,
+            filters,
             contigLengthsFromDictionary = true,
-            config = Common.Arguments.ReadLoadingConfigArgs.fromArguments(args)
+            config = ReadLoadingConfigArgs(args)
           )
       )
 
@@ -152,14 +154,12 @@ object VAFHistogram {
       val histogramOutput =
         sampleAndFileNames
           .zip(variantAlleleHistograms)
-          .flatMap(kv => {
-            val fileName = kv._1._1
-            val sampleName = kv._1._2
-            val histogram = kv._2
-            histogram.toSeq
-              .sortBy(_._1)
-              .map(kv => s"$fileName, $sampleName, ${histogramToString(kv)}").toSeq
-          })
+          .flatMap {
+            case ((filename, sampleName), histogram) =>
+              histogram.toSeq
+                .sortBy(_._1)
+                .map(kv => s"$filename, $sampleName, ${histogramToString(kv)}")
+          }
 
       if (args.localOutputPath != "") {
         val writer = new BufferedWriter(new FileWriter(args.localOutputPath))

--- a/src/main/scala/org/hammerlab/guacamole/commands/VAFHistogram.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/VAFHistogram.scala
@@ -9,14 +9,13 @@ import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
 import org.hammerlab.guacamole._
+import org.hammerlab.guacamole.distributed.LociPartitionUtils
 import org.hammerlab.guacamole.distributed.LociPartitionUtils.partitionLociAccordingToArgs
 import org.hammerlab.guacamole.distributed.PileupFlatMapUtils.pileupFlatMap
-import org.hammerlab.guacamole.distributed.{LociPartitionUtils, PileupFlatMapUtils}
 import org.hammerlab.guacamole.loci.LociMap
 import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.pileup.Pileup
-import org.hammerlab.guacamole.reads.Read.InputFilters
-import org.hammerlab.guacamole.reads.{MappedRead, Read}
+import org.hammerlab.guacamole.reads.{MappedRead, InputFilters}
 import org.hammerlab.guacamole.reference.{ReferenceBroadcast, ReferenceGenome}
 import org.kohsuke.args4j.{Argument, Option => Args4jOption}
 
@@ -101,7 +100,7 @@ object VAFHistogram {
       val reference = ReferenceBroadcast(args.referenceFastaPath, sc)
 
       val loci = Common.lociFromArguments(args)
-      val filters = Read.InputFilters(
+      val filters = InputFilters(
         overlapsLoci = Some(loci),
         nonDuplicate = true,
         passedVendorQualityChecks = true)

--- a/src/main/scala/org/hammerlab/guacamole/commands/VariantSupport.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/VariantSupport.scala
@@ -22,19 +22,19 @@ import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.rdd.ADAMContext
 import org.bdgenomics.formats.avro.Variant
-import org.hammerlab.guacamole._
 import org.hammerlab.guacamole.distributed.LociPartitionUtils
 import org.hammerlab.guacamole.distributed.LociPartitionUtils.partitionLociUniformly
 import org.hammerlab.guacamole.distributed.PileupFlatMapUtils.pileupFlatMap
 import org.hammerlab.guacamole.loci.LociSet
 import org.hammerlab.guacamole.pileup.Pileup
-import org.hammerlab.guacamole.reads.{InputFilters, MappedRead}
+import org.hammerlab.guacamole.reads.{MappedRead, InputFilters, ReadLoadingConfigArgs}
 import org.hammerlab.guacamole.reference.ReferenceBroadcast
+import org.hammerlab.guacamole.{Bases, ReadSet, SparkCommand}
 import org.kohsuke.args4j.{Argument, Option => Args4jOption}
 
 object VariantSupport {
 
-  protected class Arguments extends LociPartitionUtils.Arguments with Common.Arguments.ReadLoadingConfigArgs {
+  protected class Arguments extends LociPartitionUtils.Arguments with ReadLoadingConfigArgs {
     @Args4jOption(name = "--input-variant", required = true, aliases = Array("-v"),
       usage = "")
     var variants: String = ""
@@ -81,7 +81,7 @@ object VariantSupport {
             sc,
             bamFile._1,
             InputFilters.empty,
-            config = Common.Arguments.ReadLoadingConfigArgs.fromArguments(args)
+            config = ReadLoadingConfigArgs(args)
           ).mappedReads
       )
 
@@ -98,7 +98,7 @@ object VariantSupport {
           pileupFlatMap[AlleleCount](
             sampleReads,
             lociPartitions,
-            true,
+            skipEmpty = true,
             pileupToAlleleCounts,
             reference = reference
           )

--- a/src/main/scala/org/hammerlab/guacamole/commands/VariantSupport.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/VariantSupport.scala
@@ -29,7 +29,7 @@ import org.hammerlab.guacamole.loci.LociSet
 import org.hammerlab.guacamole.pileup.Pileup
 import PileupFlatMapUtils.pileupFlatMap
 import org.hammerlab.guacamole.reads.MappedRead
-import org.hammerlab.guacamole.reads.Read.InputFilters
+import org.hammerlab.guacamole.reads.InputFilters
 import org.hammerlab.guacamole.reference.ReferenceBroadcast
 import org.kohsuke.args4j.{Argument, Option => Args4jOption}
 

--- a/src/main/scala/org/hammerlab/guacamole/commands/VariantSupport.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/VariantSupport.scala
@@ -23,13 +23,12 @@ import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.rdd.ADAMContext
 import org.bdgenomics.formats.avro.Variant
 import org.hammerlab.guacamole._
-import org.hammerlab.guacamole.distributed.{LociPartitionUtils, PileupFlatMapUtils}
-import LociPartitionUtils.partitionLociUniformly
+import org.hammerlab.guacamole.distributed.LociPartitionUtils
+import org.hammerlab.guacamole.distributed.LociPartitionUtils.partitionLociUniformly
+import org.hammerlab.guacamole.distributed.PileupFlatMapUtils.pileupFlatMap
 import org.hammerlab.guacamole.loci.LociSet
 import org.hammerlab.guacamole.pileup.Pileup
-import PileupFlatMapUtils.pileupFlatMap
-import org.hammerlab.guacamole.reads.MappedRead
-import org.hammerlab.guacamole.reads.InputFilters
+import org.hammerlab.guacamole.reads.{InputFilters, MappedRead}
 import org.hammerlab.guacamole.reference.ReferenceBroadcast
 import org.kohsuke.args4j.{Argument, Option => Args4jOption}
 

--- a/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/Parameters.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/Parameters.scala
@@ -1,7 +1,7 @@
 package org.hammerlab.guacamole.commands.jointcaller
 
-import org.hammerlab.guacamole.Common
-import org.kohsuke.args4j.{ Option => Args4jOption }
+import org.hammerlab.guacamole.logging.DebugLogArgs
+import org.kohsuke.args4j.{Option => Args4jOption}
 
 /**
  * Model parameters for the joint caller. Anything that affects the math for the joint caller should go here.
@@ -31,7 +31,7 @@ case class Parameters(
   def asStringPairs(): Seq[(String, String)] = {
     // We use reflection to avoid re-specifying all the parameters.
     // See: http://stackoverflow.com/questions/7457972/getting-public-fields-and-their-respective-values-of-an-instance-in-scala-java
-    val fields = this.getClass.getDeclaredFields()
+    val fields = this.getClass.getDeclaredFields
     for (field <- fields) yield {
       field.setAccessible(true)
       (field.getName, field.get(this).toString)
@@ -45,7 +45,7 @@ object Parameters {
   }
 
   /** Commandline arguments to specify each parameter. */
-  trait CommandlineArguments extends Common.Arguments.Base {
+  trait CommandlineArguments extends DebugLogArgs {
     @Args4jOption(name = "--max-alleles-per-site",
       usage = "maximum number of alt alleles to consider at a site")
     var maxAllelesPerSite: Int = 4

--- a/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCaller.scala
@@ -3,7 +3,7 @@ package org.hammerlab.guacamole.commands.jointcaller
 import htsjdk.samtools.SAMSequenceDictionary
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
-import org.hammerlab.guacamole.Common.Arguments.NoSequenceDictionary
+import org.hammerlab.guacamole.Common.NoSequenceDictionaryArgs
 import org.hammerlab.guacamole._
 import org.hammerlab.guacamole.commands.jointcaller.evidence.{MultiSampleMultiAlleleEvidence, MultiSampleSingleAlleleEvidence}
 import org.hammerlab.guacamole.distributed.LociPartitionUtils
@@ -17,7 +17,12 @@ import org.kohsuke.args4j.spi.StringArrayOptionHandler
 import org.kohsuke.args4j.{Option => Args4jOption}
 
 object SomaticJoint {
-  class Arguments extends Parameters.CommandlineArguments with LociPartitionUtils.Arguments with NoSequenceDictionary with InputCollection.Arguments {
+  class Arguments
+    extends Parameters.CommandlineArguments
+      with LociPartitionUtils.Arguments
+      with NoSequenceDictionaryArgs
+      with InputCollection.Arguments {
+
     @Args4jOption(name = "--out", usage = "Output path for all variants in VCF. Default: no output")
     var out: String = ""
 

--- a/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCaller.scala
@@ -11,7 +11,7 @@ import org.hammerlab.guacamole.distributed.LociPartitionUtils.partitionLociAccor
 import org.hammerlab.guacamole.distributed.PileupFlatMapUtils.pileupFlatMapMultipleRDDs
 import org.hammerlab.guacamole.loci.LociSet
 import org.hammerlab.guacamole.logging.LoggingUtils.progress
-import org.hammerlab.guacamole.reads._
+import org.hammerlab.guacamole.reads.InputFilters
 import org.hammerlab.guacamole.reference.ReferenceBroadcast
 import org.kohsuke.args4j.spi.StringArrayOptionHandler
 import org.kohsuke.args4j.{Option => Args4jOption}
@@ -65,7 +65,7 @@ object SomaticJoint {
       case (input, index) => ReadSet(
         sc,
         input.path,
-        Read.InputFilters(overlapsLoci = Some(loci)),
+        InputFilters(overlapsLoci = Some(loci)),
         contigLengthsFromDictionary = contigLengthsFromDictionary
       )
     })

--- a/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCaller.scala
@@ -65,7 +65,7 @@ object SomaticJoint {
       case (input, index) => ReadSet(
         sc,
         input.path,
-        InputFilters(overlapsLoci = Some(loci)),
+        InputFilters(overlapsLoci = loci),
         contigLengthsFromDictionary = contigLengthsFromDictionary
       )
     })

--- a/src/main/scala/org/hammerlab/guacamole/distributed/LociPartitionUtils.scala
+++ b/src/main/scala/org/hammerlab/guacamole/distributed/LociPartitionUtils.scala
@@ -1,9 +1,9 @@
 package org.hammerlab.guacamole.distributed
 
 import org.apache.spark.rdd.RDD
-import org.hammerlab.guacamole.Common.Arguments.{Base, Loci}
 import org.hammerlab.guacamole.HasReferenceRegion
-import org.hammerlab.guacamole.loci.{LociMap, LociSet}
+import org.hammerlab.guacamole.loci.{LociArgs, LociMap, LociSet}
+import org.hammerlab.guacamole.logging.DebugLogArgs
 import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.kohsuke.args4j.{Option => Args4jOption}
 
@@ -11,7 +11,7 @@ import scala.reflect.ClassTag
 
 object LociPartitionUtils {
 
-  trait Arguments extends Base with Loci {
+  trait Arguments extends DebugLogArgs with LociArgs {
     @Args4jOption(name = "--parallelism", usage = "Num variant calling tasks. Set to 0 (default) to use the number of Spark partitions.")
     var parallelism: Int = 0
 

--- a/src/main/scala/org/hammerlab/guacamole/distributed/LociPartitionUtils.scala
+++ b/src/main/scala/org/hammerlab/guacamole/distributed/LociPartitionUtils.scala
@@ -2,9 +2,9 @@ package org.hammerlab.guacamole.distributed
 
 import org.apache.spark.rdd.RDD
 import org.hammerlab.guacamole.Common.Arguments.{Base, Loci}
-import org.hammerlab.guacamole.Common._
 import org.hammerlab.guacamole.HasReferenceRegion
 import org.hammerlab.guacamole.loci.{LociMap, LociSet}
+import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.kohsuke.args4j.{Option => Args4jOption}
 
 import scala.reflect.ClassTag

--- a/src/main/scala/org/hammerlab/guacamole/distributed/WindowFlatMapUtils.scala
+++ b/src/main/scala/org/hammerlab/guacamole/distributed/WindowFlatMapUtils.scala
@@ -3,15 +3,17 @@ package org.hammerlab.guacamole.distributed
 import org.apache.commons.math3
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
-import org.hammerlab.guacamole.Common._
 import org.hammerlab.guacamole.loci.{LociMap, LociSet}
+import org.hammerlab.guacamole.logging.DelayedMessages
+import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.windowing.{SlidingWindow, SplitIterator}
-import org.hammerlab.guacamole.{DelayedMessages, HasReferenceRegion, PerSample}
+import org.hammerlab.guacamole.{HasReferenceRegion, PerSample}
 
 import scala.collection.mutable.{HashMap => MutableHashMap}
 import scala.reflect.ClassTag
 
 object WindowFlatMapUtils {
+
   /**
     * FlatMap across loci, and any number of RDDs of regions, where at each locus the provided function is passed a
     * sliding window instance for each RDD containing the regions overlapping an interval of halfWindowSize to either side
@@ -236,5 +238,4 @@ object WindowFlatMapUtils {
       generateFromWindows(taskLoci.onContig(contig), windows)
     }).iterator
   }
-
 }

--- a/src/main/scala/org/hammerlab/guacamole/filters/GenotypeFilter.scala
+++ b/src/main/scala/org/hammerlab/guacamole/filters/GenotypeFilter.scala
@@ -19,10 +19,10 @@
 package org.hammerlab.guacamole.filters
 
 import org.apache.spark.rdd.RDD
-import org.hammerlab.guacamole.Common
 import org.hammerlab.guacamole.Common.Arguments.Base
-import org.hammerlab.guacamole.variants.{ AlleleEvidence, CalledAllele }
-import org.kohsuke.args4j.{ Option => Args4jOption }
+import org.hammerlab.guacamole.logging.LoggingUtils.progress
+import org.hammerlab.guacamole.variants.{AlleleEvidence, CalledAllele}
+import org.kohsuke.args4j.{Option => Args4jOption}
 
 /**
  * Filter to remove genotypes where the likelihood is low
@@ -168,7 +168,7 @@ object GenotypeFilter {
 
   def printFilterProgress(filteredGenotypes: RDD[CalledAllele]) = {
     filteredGenotypes.persist()
-    Common.progress("Filtered genotypes down to %d genotypes".format(filteredGenotypes.count()))
+    progress(s"Filtered genotypes down to ${filteredGenotypes.count} genotypes")
   }
 
   trait GenotypeFilterArguments extends Base {

--- a/src/main/scala/org/hammerlab/guacamole/filters/GenotypeFilter.scala
+++ b/src/main/scala/org/hammerlab/guacamole/filters/GenotypeFilter.scala
@@ -19,7 +19,7 @@
 package org.hammerlab.guacamole.filters
 
 import org.apache.spark.rdd.RDD
-import org.hammerlab.guacamole.Common.Arguments.Base
+import org.hammerlab.guacamole.logging.DebugLogArgs
 import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.variants.{AlleleEvidence, CalledAllele}
 import org.kohsuke.args4j.{Option => Args4jOption}
@@ -171,7 +171,7 @@ object GenotypeFilter {
     progress(s"Filtered genotypes down to ${filteredGenotypes.count} genotypes")
   }
 
-  trait GenotypeFilterArguments extends Base {
+  trait GenotypeFilterArguments extends DebugLogArgs {
 
     @Args4jOption(name = "--min-read-depth", usage = "Minimum number of reads for a genotype call")
     var minReadDepth: Int = 0

--- a/src/main/scala/org/hammerlab/guacamole/filters/PileupFilter.scala
+++ b/src/main/scala/org/hammerlab/guacamole/filters/PileupFilter.scala
@@ -18,7 +18,7 @@
 
 package org.hammerlab.guacamole.filters
 
-import org.hammerlab.guacamole.Common.Arguments.Base
+import org.hammerlab.guacamole.logging.DebugLogArgs
 import org.hammerlab.guacamole.pileup.{ Pileup, PileupElement }
 import org.kohsuke.args4j.{ Option => Args4jOption }
 
@@ -45,7 +45,7 @@ object MultiAllelicPileupFilter {
 
 object PileupFilter {
 
-  trait PileupFilterArguments extends Base {
+  trait PileupFilterArguments extends DebugLogArgs {
 
     @Args4jOption(name = "--min-mapq", usage = "Minimum read mapping quality for a read (Phred-scaled). (default: 1)")
     var minAlignmentQuality: Int = 1

--- a/src/main/scala/org/hammerlab/guacamole/filters/SomaticGenotypeFilter.scala
+++ b/src/main/scala/org/hammerlab/guacamole/filters/SomaticGenotypeFilter.scala
@@ -20,9 +20,9 @@ package org.hammerlab.guacamole.filters
 
 import org.apache.spark.rdd.RDD
 import org.hammerlab.guacamole.Common.Arguments.Base
-import org.hammerlab.guacamole._
+import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.variants.CalledSomaticAllele
-import org.kohsuke.args4j.{ Option => Args4jOption }
+import org.kohsuke.args4j.{Option => Args4jOption}
 
 /**
  * Filter to remove genotypes where the somatic likelihood is low
@@ -239,7 +239,7 @@ object SomaticGenotypeFilter {
 
   def printFilterProgress(filteredGenotypes: RDD[CalledSomaticAllele]) = {
     filteredGenotypes.persist()
-    Common.progress("Filtered genotypes down to %d genotypes".format(filteredGenotypes.count()))
+    progress(s"Filtered genotypes down to ${filteredGenotypes.count} genotypes")
   }
 
   trait SomaticGenotypeFilterArguments extends Base {

--- a/src/main/scala/org/hammerlab/guacamole/filters/SomaticGenotypeFilter.scala
+++ b/src/main/scala/org/hammerlab/guacamole/filters/SomaticGenotypeFilter.scala
@@ -19,7 +19,7 @@
 package org.hammerlab.guacamole.filters
 
 import org.apache.spark.rdd.RDD
-import org.hammerlab.guacamole.Common.Arguments.Base
+import org.hammerlab.guacamole.logging.DebugLogArgs
 import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.variants.CalledSomaticAllele
 import org.kohsuke.args4j.{Option => Args4jOption}
@@ -82,7 +82,11 @@ object SomaticReadDepthFilter {
             maxTumorReadDepth: Int,
             minNormalReadDepth: Int,
             debug: Boolean = false): RDD[CalledSomaticAllele] = {
-    var filteredGenotypes = genotypes.filter(withinReadDepthRange(_, minTumorReadDepth, maxTumorReadDepth, minNormalReadDepth))
+    val filteredGenotypes =
+      genotypes.filter(
+        withinReadDepthRange(_, minTumorReadDepth, maxTumorReadDepth, minNormalReadDepth)
+      )
+
     if (debug) SomaticGenotypeFilter.printFilterProgress(filteredGenotypes)
     filteredGenotypes
   }
@@ -242,7 +246,7 @@ object SomaticGenotypeFilter {
     progress(s"Filtered genotypes down to ${filteredGenotypes.count} genotypes")
   }
 
-  trait SomaticGenotypeFilterArguments extends Base {
+  trait SomaticGenotypeFilterArguments extends DebugLogArgs {
 
     @Args4jOption(name = "--min-likelihood", usage = "Minimum likelihood (Phred-scaled)")
     var minLikelihood: Int = 0

--- a/src/main/scala/org/hammerlab/guacamole/kryo/GuacamoleKryoRegistrator.scala
+++ b/src/main/scala/org/hammerlab/guacamole/kryo/GuacamoleKryoRegistrator.scala
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.hammerlab.guacamole
+package org.hammerlab.guacamole.kryo
 
 import com.esotericsoftware.kryo.Kryo
 import org.bdgenomics.adam.serialization.ADAMKryoRegistrator

--- a/src/main/scala/org/hammerlab/guacamole/loci/LociArgs.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/LociArgs.scala
@@ -1,0 +1,22 @@
+package org.hammerlab.guacamole.loci
+
+import org.hammerlab.guacamole.logging.DebugLogArgs
+import org.kohsuke.args4j.{Option => Args4jOption}
+
+/** Argument for accepting a set of loci. */
+trait LociArgs extends DebugLogArgs {
+  @Args4jOption(
+    name = "--loci",
+    usage = "Loci at which to call variants. Either 'all' or contig:start-end,contig:start-end,...",
+    forbids = Array("--loci-from-file")
+  )
+  var loci: String = ""
+
+  @Args4jOption(
+    name = "--loci-from-file",
+    usage = "Path to file giving loci at which to call variants.",
+    forbids = Array("--loci")
+  )
+  var lociFromFile: String = ""
+}
+

--- a/src/main/scala/org/hammerlab/guacamole/loci/LociMap.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/LociMap.scala
@@ -83,7 +83,7 @@ case class LociMap[T](private val map: Map[String, LociMap.SingleContig[T]]) {
     LociMap.union(this, other)
   }
 
-  override def toString(): String = truncatedString(Int.MaxValue)
+  override def toString: String = truncatedString(Int.MaxValue)
 
   /**
    * String representation, truncated to maxLength characters.
@@ -338,7 +338,7 @@ object LociMap {
       })
     }
 
-    override def toString(): String = truncatedString(Int.MaxValue)
+    override def toString: String = truncatedString(Int.MaxValue)
   }
 }
 

--- a/src/main/scala/org/hammerlab/guacamole/logging/DebugLogArgs.scala
+++ b/src/main/scala/org/hammerlab/guacamole/logging/DebugLogArgs.scala
@@ -1,0 +1,10 @@
+package org.hammerlab.guacamole.logging
+
+import org.bdgenomics.utils.cli.{Args4jBase, ParquetArgs}
+import org.kohsuke.args4j.{Option => Args4jOption}
+
+trait DebugLogArgs extends Args4jBase with ParquetArgs {
+  @Args4jOption(name = "--debug", usage = "If set, prints a higher level of debug output.")
+  var debug = false
+}
+

--- a/src/main/scala/org/hammerlab/guacamole/logging/DelayedMessages.scala
+++ b/src/main/scala/org/hammerlab/guacamole/logging/DelayedMessages.scala
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.hammerlab.guacamole
+package org.hammerlab.guacamole.logging
 
 import scala.collection.mutable
 

--- a/src/main/scala/org/hammerlab/guacamole/logging/LoggingUtils.scala
+++ b/src/main/scala/org/hammerlab/guacamole/logging/LoggingUtils.scala
@@ -1,0 +1,23 @@
+package org.hammerlab.guacamole.logging
+
+object LoggingUtils {
+
+  /** Time in milliseconds of last progress message. */
+  var lastProgressTime: Long = 0
+
+  /**
+   * Print or log a progress message. For now, we just print to standard out, since ADAM's logging setup makes it
+   * difficult to see log messages at the INFO level without flooding ourselves with parquet messages.
+   * @param message String to print or log.
+   */
+  def progress(message: String): Unit = {
+    val current = System.currentTimeMillis
+    val time = if (lastProgressTime == 0)
+      java.util.Calendar.getInstance.getTime.toString
+    else
+      "%.2f sec. later".format((current - lastProgressTime) / 1000.0)
+    println("--> [%15s]: %s".format(time, message))
+    System.out.flush()
+    lastProgressTime = current
+  }
+}

--- a/src/main/scala/org/hammerlab/guacamole/reads/BamReaderAPI.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/BamReaderAPI.scala
@@ -1,0 +1,23 @@
+package org.hammerlab.guacamole.reads
+
+/**
+ * Specification of which API to use when reading BAM and SAM files.
+ *
+ * Best - use Samtools when the file is on the local filesystem otherwise HadoopBAM
+ * Samtools - use Samtools. This supports using the bam index when available.
+ * HadoopBAM - use HadoopBAM. This supports reading the file in parallel when it is on HDFS.
+ */
+object BamReaderAPI extends Enumeration {
+  type BamReaderAPI = Value
+  val Best, Samtools, HadoopBAM = Value
+
+  /**
+   * Like Enumeration.withName but case insensitive
+   */
+  def withNameCaseInsensitive(s: String): Value = {
+    val result = values.find(_.toString.compareToIgnoreCase(s) == 0)
+    result.getOrElse(throw new IllegalArgumentException(
+      "Unsupported bam reading API: %s. Valid APIs are: %s".format(s, values.map(_.toString).mkString(", "))))
+  }
+}
+

--- a/src/main/scala/org/hammerlab/guacamole/reads/InputFilters.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/InputFilters.scala
@@ -30,16 +30,16 @@ object InputFilters {
    *               overlapsLoci.
    */
   def apply(mapped: Boolean = false,
-            overlapsLoci: Option[LociSet.Builder] = None,
+            overlapsLoci: LociSet.Builder = null,
             nonDuplicate: Boolean = false,
             passedVendorQualityChecks: Boolean = false,
             isPaired: Boolean = false): InputFilters = {
     new InputFilters(
       overlapsLoci =
-        if (overlapsLoci.isEmpty && mapped)
+        if (overlapsLoci == null && mapped)
           Some(LociSet.newBuilder.putAllContigs)
         else
-          overlapsLoci,
+          Option(overlapsLoci),
       nonDuplicate,
       passedVendorQualityChecks,
       isPaired

--- a/src/main/scala/org/hammerlab/guacamole/reads/InputFilters.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/InputFilters.scala
@@ -1,0 +1,78 @@
+package org.hammerlab.guacamole.reads
+
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.models.SequenceDictionary
+import org.hammerlab.guacamole.loci.LociSet
+
+/**
+ * Filtering reads while they are loaded can be an important optimization.
+ *
+ * These fields are commonly used filters. For boolean fields, setting a field to true will result in filtering on
+ * that field. The result is the intersection of the filters (i.e. reads must satisfy ALL filters).
+ *
+ * @param overlapsLoci if not None, include only mapped reads that overlap the given loci
+ * @param nonDuplicate include only reads that do not have the duplicate bit set
+ * @param passedVendorQualityChecks include only reads that do not have the failedVendorQualityChecks bit set
+ * @param isPaired include only reads are paired-end reads
+ */
+case class InputFilters(overlapsLoci: Option[LociSet.Builder],
+                        nonDuplicate: Boolean,
+                        passedVendorQualityChecks: Boolean,
+                        isPaired: Boolean)
+
+object InputFilters {
+  val empty = InputFilters()
+
+  /**
+   * See InputFilters for full documentation.
+   *
+   * @param mapped include only mapped reads. Convenience argument that is equivalent to specifying all sites in
+   *               overlapsLoci.
+   */
+  def apply(mapped: Boolean = false,
+            overlapsLoci: Option[LociSet.Builder] = None,
+            nonDuplicate: Boolean = false,
+            passedVendorQualityChecks: Boolean = false,
+            isPaired: Boolean = false): InputFilters = {
+    new InputFilters(
+      overlapsLoci =
+        if (overlapsLoci.isEmpty && mapped)
+          Some(LociSet.newBuilder.putAllContigs)
+        else
+          overlapsLoci,
+      nonDuplicate,
+      passedVendorQualityChecks,
+      isPaired
+    )
+  }
+
+  /**
+   * Apply filters to an RDD of reads.
+   *
+   * @param filters
+   * @param reads
+   * @param sequenceDictionary
+   * @return filtered RDD
+   */
+  def filterRDD(filters: InputFilters, reads: RDD[Read], sequenceDictionary: SequenceDictionary): RDD[Read] = {
+    /* Note that the InputFilter properties are public, and some loaders directly apply
+     * the filters as the reads are loaded, instead of filtering an existing RDD as we do here. If more filters
+     * are added, be sure to update those implementations.
+     *
+     * This is implemented as a static function instead of a method in InputFilters because the overlapsLoci
+     * attribute cannot be serialized.
+     */
+    var result = reads
+    if (filters.overlapsLoci.nonEmpty) {
+      val loci = filters.overlapsLoci.get.result(Read.contigLengths(sequenceDictionary))
+      val broadcastLoci = reads.sparkContext.broadcast(loci)
+      result = result.filter(
+        read => read.isMapped && read.asMappedRead.get.overlapsLociSet(broadcastLoci.value))
+    }
+    if (filters.nonDuplicate) result = result.filter(!_.isDuplicate)
+    if (filters.passedVendorQualityChecks) result = result.filter(!_.failedVendorQualityChecks)
+    if (filters.isPaired) result = result.filter(_.isPaired)
+    result
+  }
+}
+

--- a/src/main/scala/org/hammerlab/guacamole/reads/MappedRead.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/MappedRead.scala
@@ -22,7 +22,7 @@ import htsjdk.samtools.Cigar
 import org.bdgenomics.adam.util.PhredUtils
 import org.hammerlab.guacamole.pileup.PileupElement
 import org.hammerlab.guacamole.reference.ContigSequence
-import org.hammerlab.guacamole.{Bases, HasReferenceRegion}
+import org.hammerlab.guacamole.{Bases, CigarUtils, HasReferenceRegion}
 
 import scala.collection.JavaConversions
 
@@ -62,7 +62,6 @@ case class MappedRead(
    * @param referenceContigSequence the reference sequence for this read's contig
    * @return count of mismatching bases
    */
-
   private var cachedCountOfMismatches = -1
   def countOfMismatches(referenceContigSequence: ContigSequence): Int = {
     if (cachedCountOfMismatches == -1) {
@@ -92,14 +91,14 @@ case class MappedRead(
    * A read can be "clipped", meaning that some prefix or suffix of it did not align. This is the start of the whole
    * read's alignment, including any initial clipped bases.
    */
-  val unclippedStart = cigarElements.takeWhile(Read.cigarElementIsClipped).foldLeft(start)({
+  val unclippedStart = cigarElements.takeWhile(CigarUtils.isClipped).foldLeft(start)({
     (pos, element) => pos - element.getLength
   })
 
   /**
    * The end of the read's alignment, including any final clipped bases, exclusive.
    */
-  val unclippedEnd = cigarElements.reverse.takeWhile(Read.cigarElementIsClipped).foldLeft(end)({
+  val unclippedEnd = cigarElements.reverse.takeWhile(CigarUtils.isClipped).foldLeft(end)({
     (pos, element) => pos + element.getLength
   })
 

--- a/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
@@ -71,43 +71,6 @@ trait Read {
 
 object Read extends Logging {
   /**
-   * Convenience function (intended for test cases), to construct a Read from unparsed values.
-   */
-  def apply(
-    sequence: String,
-    name: String,
-    baseQualities: String = "",
-    isDuplicate: Boolean = false,
-    sampleName: String = "",
-    referenceContig: String = "",
-    alignmentQuality: Int = -1,
-    start: Long = -1L,
-    cigarString: String = "",
-    failedVendorQualityChecks: Boolean = false,
-    isPositiveStrand: Boolean = true,
-    isPaired: Boolean = true) = {
-
-    val sequenceArray = sequence.map(_.toByte).toArray
-    val qualityScoresArray = baseQualityStringToArray(baseQualities, sequenceArray.length)
-
-    val cigar = TextCigarCodec.decode(cigarString)
-    MappedRead(
-      name,
-      sequenceArray,
-      qualityScoresArray,
-      isDuplicate,
-      sampleName.intern,
-      referenceContig,
-      alignmentQuality,
-      start,
-      cigar,
-      failedVendorQualityChecks,
-      isPositiveStrand,
-      isPaired
-    )
-  }
-
-  /**
    * Converts the ascii-string encoded base qualities into an array of integers
    * quality scores in Phred-scale
    *

--- a/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
@@ -253,38 +253,6 @@ object Read extends Logging {
   }
 
   /**
-   * Configuration for read loading. These options should affect performance but not results.
-   *
-   * @param bamReaderAPI which library to use to load SAM and BAM files
-   */
-  case class ReadLoadingConfig(
-    bamReaderAPI: ReadLoadingConfig.BamReaderAPI.BamReaderAPI = ReadLoadingConfig.BamReaderAPI.Best) {}
-  object ReadLoadingConfig {
-    val default = ReadLoadingConfig()
-
-    /**
-     * Specification of which API to use when reading BAM and SAM files.
-     *
-     * Best - use Samtools when the file is on the local filesystem otherwise HadoopBAM
-     * Samtools - use Samtools. This supports using the bam index when available.
-     * HadoopBAM - use HadoopBAM. This supports reading the file in parallel when it is on HDFS.
-     */
-    object BamReaderAPI extends Enumeration {
-      type BamReaderAPI = Value
-      val Best, Samtools, HadoopBAM = Value
-
-      /**
-       * Like Enumeration.withName but case insensitive
-       */
-      def withNameCaseInsensitive(s: String): Value = {
-        val result = values.find(_.toString.compareToIgnoreCase(s) == 0)
-        result.getOrElse(throw new IllegalArgumentException(
-          "Unsupported bam reading API: %s. Valid APIs are: %s".format(s, values.map(_.toString).mkString(", "))))
-      }
-    }
-  }
-
-  /**
    * Given a filename and a spark context, return a pair (RDD, SequenceDictionary), where the first element is an RDD
    * of Reads, and the second element is the Sequence Dictionary giving info (e.g. length) about the contigs in the BAM.
    *
@@ -323,8 +291,12 @@ object Read extends Logging {
 
     val path = new Path(filename)
     val scheme = path.getFileSystem(sc.hadoopConfiguration).getScheme
-    val useSamtools = config.bamReaderAPI == ReadLoadingConfig.BamReaderAPI.Samtools ||
-      (config.bamReaderAPI == ReadLoadingConfig.BamReaderAPI.Best && scheme == "file")
+    val useSamtools =
+      config.bamReaderAPI == BamReaderAPI.Samtools ||
+        (
+          config.bamReaderAPI == BamReaderAPI.Best &&
+          scheme == "file"
+        )
 
     if (useSamtools) {
       // Load with samtools

--- a/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
@@ -29,7 +29,6 @@ import org.bdgenomics.adam.models.SequenceDictionary
 import org.bdgenomics.adam.rdd.{ADAMContext, ADAMSpecificRecordSequenceDictionaryRDDAggregator}
 import org.bdgenomics.formats.avro.AlignmentRecord
 import org.hammerlab.guacamole.Bases
-import org.hammerlab.guacamole.loci.LociSet
 import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.seqdoop.hadoop_bam.util.SAMHeaderReader
 import org.seqdoop.hadoop_bam.{AnySAMInputFormat, SAMRecordWritable}

--- a/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
@@ -28,8 +28,9 @@ import org.apache.spark.{Logging, SparkContext}
 import org.bdgenomics.adam.models.SequenceDictionary
 import org.bdgenomics.adam.rdd.{ADAMContext, ADAMSpecificRecordSequenceDictionaryRDDAggregator}
 import org.bdgenomics.formats.avro.AlignmentRecord
+import org.hammerlab.guacamole.Bases
 import org.hammerlab.guacamole.loci.LociSet
-import org.hammerlab.guacamole.{Bases, Common}
+import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.seqdoop.hadoop_bam.util.SAMHeaderReader
 import org.seqdoop.hadoop_bam.{AnySAMInputFormat, SAMRecordWritable}
 
@@ -340,7 +341,7 @@ object Read extends Logging {
       val sequenceDictionary = SequenceDictionary.fromSAMSequenceDictionary(samSequenceDictionary)
       val loci = filters.overlapsLoci.map(_.result(contigLengths(sequenceDictionary)))
       val recordIterator: SAMRecordIterator = if (filters.overlapsLoci.nonEmpty && reader.hasIndex) {
-        Common.progress("Using samtools with BAM index to read: %s".format(filename))
+        progress(s"Using samtools with BAM index to read: $filename")
         requiresFilteringByLocus = false
         val queryIntervals = loci.get.contigs.flatMap(contig => {
           val contigIndex = samSequenceDictionary.getSequenceIndex(contig)
@@ -352,11 +353,15 @@ object Read extends Logging {
         val optimizedQueryIntervals = QueryInterval.optimizeIntervals(queryIntervals.toArray)
         reader.query(optimizedQueryIntervals, false) // Note: this can return unmapped reads, which we filter below.
       } else {
-        val skippedReason = if (reader.hasIndex)
-          "(index is available but not needed)"
-        else
-          "(index unavailable)"
-        Common.progress("Using samtools without BAM index %s to read: %s".format(skippedReason, filename))
+
+        val skippedReason =
+          if (reader.hasIndex)
+            "index is available but not needed"
+          else
+            "index unavailable"
+
+        progress(s"Using samtools without BAM index %($skippedReason) to read: $filename")
+
         reader.iterator
       }
       val reads = JavaConversions.asScalaIterator(recordIterator).flatMap(record => {
@@ -377,7 +382,7 @@ object Read extends Logging {
       (sc.parallelize(reads.toSeq), sequenceDictionary)
     } else {
       // Load with hadoop bam
-      Common.progress("Using hadoop bam to read: %s".format(filename))
+      progress(s"Using hadoop bam to read: $filename")
       val samHeader = SAMHeaderReader.readSAMHeaderFrom(path, sc.hadoopConfiguration)
       val sequenceDictionary = SequenceDictionary.fromSAMHeader(samHeader)
 
@@ -398,7 +403,7 @@ object Read extends Logging {
                                                filters: InputFilters = InputFilters.empty,
                                                config: ReadLoadingConfig = ReadLoadingConfig.default): (RDD[Read], SequenceDictionary) = {
 
-    Common.progress("Using ADAM to read: %s".format(filename))
+    progress(s"Using ADAM to read: $filename")
 
     val adamContext = new ADAMContext(sc)
 

--- a/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
@@ -180,10 +180,10 @@ object Read extends Logging {
 
   /** Returns an RDD of Reads and SequenceDictionary from reads in BAM format **/
   def loadReadRDDAndSequenceDictionaryFromBAM(
-                                               filename: String,
-                                               sc: SparkContext,
-                                               filters: InputFilters = InputFilters.empty,
-                                               config: ReadLoadingConfig = ReadLoadingConfig.default): (RDD[Read], SequenceDictionary) = {
+    filename: String,
+    sc: SparkContext,
+    filters: InputFilters = InputFilters.empty,
+    config: ReadLoadingConfig = ReadLoadingConfig.default): (RDD[Read], SequenceDictionary) = {
 
     val path = new Path(filename)
     val scheme = path.getFileSystem(sc.hadoopConfiguration).getScheme
@@ -266,10 +266,11 @@ object Read extends Logging {
   }
 
   /** Returns an RDD of Reads and SequenceDictionary from reads in ADAM format **/
-  def loadReadRDDAndSequenceDictionaryFromADAM(filename: String,
-                                               sc: SparkContext,
-                                               filters: InputFilters = InputFilters.empty,
-                                               config: ReadLoadingConfig = ReadLoadingConfig.default): (RDD[Read], SequenceDictionary) = {
+  def loadReadRDDAndSequenceDictionaryFromADAM(
+    filename: String,
+    sc: SparkContext,
+    filters: InputFilters = InputFilters.empty,
+    config: ReadLoadingConfig = ReadLoadingConfig.default): (RDD[Read], SequenceDictionary) = {
 
     progress(s"Using ADAM to read: $filename")
 
@@ -277,7 +278,8 @@ object Read extends Logging {
 
     val adamRecords: RDD[AlignmentRecord] = adamContext.loadAlignments(
       filename, projection = None, stringency = ValidationStringency.LENIENT).rdd
-    val sequenceDictionary = new ADAMSpecificRecordSequenceDictionaryRDDAggregator(adamRecords).adamGetSequenceDictionary()
+    val sequenceDictionary =
+      new ADAMSpecificRecordSequenceDictionaryRDDAggregator(adamRecords).adamGetSequenceDictionary()
 
     val allReads: RDD[Read] = adamRecords.map(fromADAMRecord(_))
     val reads = InputFilters.filterRDD(filters, allReads, sequenceDictionary)

--- a/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
@@ -447,11 +447,6 @@ object Read extends Logging {
     }
   }
 
-  /** Is the given samtools CigarElement a (hard/soft) clip? */
-  def cigarElementIsClipped(element: CigarElement): Boolean = {
-    element.getOperator == CigarOperator.SOFT_CLIP || element.getOperator == CigarOperator.HARD_CLIP
-  }
-
   /** Extract the length of each contig from a sequence dictionary */
   def contigLengths(sequenceDictionary: SequenceDictionary): Map[String, Long] = {
     val builder = Map.newBuilder[String, Long]

--- a/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
@@ -71,72 +71,6 @@ trait Read {
 
 object Read extends Logging {
   /**
-   * Filtering reads while they are loaded can be an important optimization.
-   *
-   * These fields are commonly used filters. For boolean fields, setting a field to true will result in filtering on
-   * that field. The result is the intersection of the filters (i.e. reads must satisfy ALL filters).
-   *
-   * @param overlapsLoci if not None, include only mapped reads that overlap the given loci
-   * @param nonDuplicate include only reads that do not have the duplicate bit set
-   * @param passedVendorQualityChecks include only reads that do not have the failedVendorQualityChecks bit set
-   * @param isPaired include only reads are paired-end reads
-   */
-  case class InputFilters(
-    overlapsLoci: Option[LociSet.Builder],
-    nonDuplicate: Boolean,
-    passedVendorQualityChecks: Boolean,
-    isPaired: Boolean) {}
-  object InputFilters {
-    val empty = InputFilters()
-
-    /**
-     * See InputFilters for full documentation.
-     * @param mapped include only mapped reads. Convenience argument that is equivalent to specifying all sites in
-     *               overlapsLoci.
-     */
-    def apply(mapped: Boolean = false,
-              overlapsLoci: Option[LociSet.Builder] = None,
-              nonDuplicate: Boolean = false,
-              passedVendorQualityChecks: Boolean = false,
-              isPaired: Boolean = false): InputFilters = {
-      new InputFilters(
-        overlapsLoci = if (overlapsLoci.isEmpty && mapped) Some(LociSet.newBuilder.putAllContigs) else overlapsLoci,
-        nonDuplicate = nonDuplicate,
-        passedVendorQualityChecks = passedVendorQualityChecks,
-        isPaired = isPaired)
-    }
-
-    /**
-     * Apply filters to an RDD of reads.
-     *
-     * @param filters
-     * @param reads
-     * @param sequenceDictionary
-     * @return filtered RDD
-     */
-    def filterRDD(filters: InputFilters, reads: RDD[Read], sequenceDictionary: SequenceDictionary): RDD[Read] = {
-      /* Note that the InputFilter properties are public, and some loaders directly apply
-       * the filters as the reads are loaded, instead of filtering an existing RDD as we do here. If more filters
-       * are added, be sure to update those implementations.
-       * 
-       * This is implemented as a static function instead of a method in InputFilters because the overlapsLoci
-       * attribute cannot be serialized.
-       */
-      var result = reads
-      if (filters.overlapsLoci.nonEmpty) {
-        val loci = filters.overlapsLoci.get.result(contigLengths(sequenceDictionary))
-        val broadcastLoci = reads.sparkContext.broadcast(loci)
-        result = result.filter(
-          read => read.isMapped && read.asMappedRead.get.overlapsLociSet(broadcastLoci.value))
-      }
-      if (filters.nonDuplicate) result = result.filter(!_.isDuplicate)
-      if (filters.passedVendorQualityChecks) result = result.filter(!_.failedVendorQualityChecks)
-      if (filters.isPaired) result = result.filter(_.isPaired)
-      result
-    }
-  }
-
-  /**
    * Convenience function (intended for test cases), to construct a Read from unparsed values.
    */
   def apply(
@@ -284,10 +218,10 @@ object Read extends Logging {
 
   /** Returns an RDD of Reads and SequenceDictionary from reads in BAM format **/
   def loadReadRDDAndSequenceDictionaryFromBAM(
-    filename: String,
-    sc: SparkContext,
-    filters: InputFilters = InputFilters.empty,
-    config: ReadLoadingConfig = ReadLoadingConfig.default): (RDD[Read], SequenceDictionary) = {
+                                               filename: String,
+                                               sc: SparkContext,
+                                               filters: InputFilters = InputFilters.empty,
+                                               config: ReadLoadingConfig = ReadLoadingConfig.default): (RDD[Read], SequenceDictionary) = {
 
     val path = new Path(filename)
     val scheme = path.getFileSystem(sc.hadoopConfiguration).getScheme

--- a/src/main/scala/org/hammerlab/guacamole/reads/ReadLoadingConfig.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/ReadLoadingConfig.scala
@@ -1,0 +1,12 @@
+package org.hammerlab.guacamole.reads
+
+/**
+ * Configuration for read loading. These options should affect performance but not results.
+ *
+ * @param bamReaderAPI which library to use to load SAM and BAM files
+ */
+case class ReadLoadingConfig(bamReaderAPI: BamReaderAPI.BamReaderAPI = BamReaderAPI.Best)
+
+object ReadLoadingConfig {
+  val default = ReadLoadingConfig()
+}

--- a/src/main/scala/org/hammerlab/guacamole/reads/ReadLoadingConfigArgs.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/ReadLoadingConfigArgs.scala
@@ -1,0 +1,21 @@
+package org.hammerlab.guacamole.reads
+
+import org.hammerlab.guacamole.logging.DebugLogArgs
+import org.kohsuke.args4j.{Option => Args4jOption}
+
+/** Arguments for configuring read loading with a ReadLoadingConfig object. */
+trait ReadLoadingConfigArgs extends DebugLogArgs {
+  @Args4jOption(
+    name = "--bam-reader-api",
+    usage = "API to use for reading BAMs, one of: best (use samtools if file local), samtools, hadoopbam"
+  )
+  var bamReaderAPI: String = "best"
+}
+
+object ReadLoadingConfigArgs {
+  /** Given commandline arguments, return a ReadLoadingConfig. */
+  def apply(args: ReadLoadingConfigArgs): ReadLoadingConfig = {
+    ReadLoadingConfig(BamReaderAPI.withNameCaseInsensitive(args.bamReaderAPI))
+  }
+}
+

--- a/src/main/scala/org/hammerlab/guacamole/reference/ReferenceArgs.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reference/ReferenceArgs.scala
@@ -1,0 +1,15 @@
+package org.hammerlab.guacamole.reference
+
+import org.hammerlab.guacamole.logging.DebugLogArgs
+import org.kohsuke.args4j.{Option => Args4jOption}
+
+/** Arguments for accepting a reference genome. */
+trait ReferenceArgs extends DebugLogArgs {
+  @Args4jOption(required = false, name = "--reference", usage = "ADAM or FASTA reference genome data")
+  var referenceInput: String = ""
+
+  @Args4jOption(required = false, name = "--fragment-length",
+    usage = "Sets maximum fragment length. Default value is 10,000. Values greater than 1e9 should be avoided.")
+  var fragmentLength: Long = 10000L
+}
+

--- a/src/main/scala/org/hammerlab/guacamole/variants/Concordance.scala
+++ b/src/main/scala/org/hammerlab/guacamole/variants/Concordance.scala
@@ -16,16 +16,18 @@
  * limitations under the License.
  */
 
-package org.hammerlab.guacamole
+package org.hammerlab.guacamole.variants
 
 import java.util.EnumSet
 
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rich.RichVariant
-import org.bdgenomics.formats.avro.{ Genotype, GenotypeType }
-import org.bdgenomics.qc.rdd.variation.{ ConcordanceTable, GenotypeConcordanceRDDFunctions }
-import org.kohsuke.args4j.{ Option => Args4jOption }
+import org.bdgenomics.formats.avro.{GenotypeType, Genotype => BDGGenotype}
+import org.bdgenomics.qc.rdd.variation.{ConcordanceTable, GenotypeConcordanceRDDFunctions}
+import org.hammerlab.guacamole.logging.DebugLogArgs
+import org.kohsuke.args4j.{Option => Args4jOption}
 
 /**
  * As a convenience to users experimenting with different callers, some variant callers include functionality to compare
@@ -37,7 +39,7 @@ object Concordance {
   /**
    * Arguments that callers can include to support concordance calculations.
    */
-  trait ConcordanceArgs extends Common.Arguments.Base {
+  trait ConcordanceArgs extends DebugLogArgs {
     @Args4jOption(name = "--truth", metaVar = "truth", usage = "The truth ADAM or VCF genotypes file")
     var truthGenotypesFile: String = ""
 
@@ -69,25 +71,41 @@ object Concordance {
    * @param chromosome name of a chromosome, if any, to filter to (default: null)
    * @return  precision, recall and f1score
    */
-  def computePrecisionAndRecall(calledGenotypes: RDD[Genotype],
-                                trueGenotypes: RDD[Genotype],
+  def computePrecisionAndRecall(calledGenotypes: RDD[BDGGenotype],
+                                trueGenotypes: RDD[BDGGenotype],
                                 excludeSNVs: Boolean = false,
                                 excludeIndels: Boolean = true,
                                 chromosome: String = null): (Double, Double, Double) = {
-    val chromosomeFilter: (Genotype => Boolean) = chromosome == "" || _.getVariant.getContig.getContigName.toString == chromosome
-    val variantTypeFilter: (Genotype => Boolean) = genotype => {
+
+    def chromosomeFilter(genotype: BDGGenotype): Boolean =
+      chromosome == "" ||
+        genotype.getVariant.getContig.getContigName == chromosome
+
+    def variantTypeFilter(genotype: BDGGenotype): Boolean = {
       val variant = new RichVariant(genotype.getVariant)
-      (!excludeSNVs && variant.isSingleNucleotideVariant()) || (!excludeIndels && (variant.isInsertion() || variant.isDeletion()))
+      (
+        !excludeSNVs &&
+        variant.isSingleNucleotideVariant()
+      ) ||
+      (
+        !excludeIndels &&
+        (variant.isInsertion() || variant.isDeletion())
+      )
     }
 
-    val relevantVariants: (Genotype => Boolean) = v => chromosomeFilter(v) && variantTypeFilter(v)
+    def relevantVariants(genotype: BDGGenotype): Boolean =
+      chromosomeFilter(genotype) &&
+        variantTypeFilter(genotype)
 
     val filteredCalledAlleles = calledGenotypes.filter(relevantVariants)
     val filteredTrueGenotypes = trueGenotypes.filter(relevantVariants)
 
-    val sampleName = filteredCalledAlleles.take(1)(0).getSampleId.toString
+    val sampleName = filteredCalledAlleles.take(1)(0).getSampleId
 
-    val sampleAccuracy = new GenotypeConcordanceRDDFunctions(filteredCalledAlleles).concordanceWith(filteredTrueGenotypes).collectAsMap()(sampleName)
+    val sampleAccuracy =
+      new GenotypeConcordanceRDDFunctions(filteredCalledAlleles)
+        .concordanceWith(filteredTrueGenotypes)
+        .collectAsMap()(sampleName)
 
     // We called AND it was called in truth
     val truePositives = sampleAccuracy.total(ConcordanceTable.CALLED, ConcordanceTable.CALLED)
@@ -121,8 +139,8 @@ object Concordance {
    * @param sc spark context
    */
 
-  def printGenotypeConcordance(args: ConcordanceArgs, genotypes: RDD[Genotype], sc: SparkContext) = {
-    val trueGenotypes = Common.loadGenotypes(args.truthGenotypesFile, sc)
+  def printGenotypeConcordance(args: ConcordanceArgs, genotypes: RDD[BDGGenotype], sc: SparkContext) = {
+    val trueGenotypes = loadGenotypes(args.truthGenotypesFile, sc)
 
     val (precision, recall, f1score) =
       computePrecisionAndRecall(
@@ -137,4 +155,18 @@ object Concordance {
     println("%f\t%f\t%f".format(precision, recall, f1score))
   }
 
+  /**
+   * Load genotypes from ADAM Parquet or VCF file
+   *
+   * @param path path to VCF or ADAM genotypes
+   * @param sc spark context
+   * @return RDD of ADAM Genotypes
+   */
+  def loadGenotypes(path: String, sc: SparkContext): RDD[BDGGenotype] = {
+    if (path.endsWith(".vcf")) {
+      sc.loadGenotypes(path)
+    } else {
+      sc.loadParquet(path)
+    }
+  }
 }

--- a/src/main/scala/org/hammerlab/guacamole/variants/GenotypeOutputArgs.scala
+++ b/src/main/scala/org/hammerlab/guacamole/variants/GenotypeOutputArgs.scala
@@ -1,0 +1,20 @@
+package org.hammerlab.guacamole.variants
+
+import org.hammerlab.guacamole.logging.DebugLogArgs
+import org.kohsuke.args4j.{Option => Args4jOption}
+
+/** Argument for writing output genotypes. */
+trait GenotypeOutputArgs extends DebugLogArgs {
+  @Args4jOption(name = "--out", metaVar = "VARIANTS_OUT", required = false,
+    usage = "Variant output path. If not specified, print to screen.")
+  var variantOutput: String = ""
+
+  @Args4jOption(name = "--out-chunks", metaVar = "X", required = false,
+    usage = "When writing out to json format, number of chunks to coalesce the genotypes RDD into.")
+  var outChunks: Int = 1
+
+  @Args4jOption(name = "--max-genotypes", metaVar = "X", required = false,
+    usage = "Maximum number of genotypes to output. 0 (default) means output all genotypes.")
+  var maxGenotypes: Int = 0
+}
+

--- a/src/main/scala/org/hammerlab/guacamole/variants/VariantUtils.scala
+++ b/src/main/scala/org/hammerlab/guacamole/variants/VariantUtils.scala
@@ -1,0 +1,82 @@
+package org.hammerlab.guacamole.variants
+
+import java.io.OutputStream
+
+import org.apache.avro.generic.GenericDatumWriter
+import org.apache.avro.io.EncoderFactory
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.formats.avro.{Genotype => BDGGenotype}
+import org.codehaus.jackson.JsonFactory
+import org.hammerlab.guacamole.logging.LoggingUtils._
+
+object VariantUtils {
+  /**
+   * Write out an RDD of Genotype instances to a file.
+   *
+   * @param args parsed arguments
+   * @param genotypes ADAM genotypes (i.e. the variants)
+   */
+  def writeVariantsFromArguments(args: GenotypeOutputArgs, genotypes: RDD[BDGGenotype]): Unit = {
+    val subsetGenotypes = if (args.maxGenotypes > 0) {
+      progress(s"Subsetting to ${args.maxGenotypes} genotypes.")
+      genotypes.sample(withReplacement = false, args.maxGenotypes, 0)
+    } else {
+      genotypes
+    }
+    val outputPath = args.variantOutput.stripMargin
+    if (outputPath.isEmpty || outputPath.toLowerCase.endsWith(".json")) {
+      val out: OutputStream = if (outputPath.isEmpty) {
+        progress("Writing genotypes to stdout.")
+        System.out
+      } else {
+        progress(s"Writing genotypes serially in json format to: $outputPath")
+        val filesystem = FileSystem.get(new Configuration())
+        val path = new Path(outputPath)
+        filesystem.create(path, true)
+      }
+      val coalescedSubsetGenotypes = if (args.outChunks > 0) subsetGenotypes.coalesce(args.outChunks) else subsetGenotypes
+      coalescedSubsetGenotypes.persist()
+
+      // Write each Genotype with a JsonEncoder.
+      val schema = BDGGenotype.getClassSchema
+      val writer = new GenericDatumWriter[Object](schema)
+      val encoder = EncoderFactory.get.jsonEncoder(schema, out)
+      val generator = new JsonFactory().createJsonGenerator(out)
+      generator.useDefaultPrettyPrinter()
+      encoder.configure(generator)
+      var partitionNum = 0
+      val numPartitions = coalescedSubsetGenotypes.partitions.length
+      while (partitionNum < numPartitions) {
+        progress(s"Collecting partition ${partitionNum + 1} of $numPartitions")
+        val chunk = coalescedSubsetGenotypes.mapPartitionsWithIndex((num, genotypes) => {
+          if (num == partitionNum) genotypes else Iterator.empty
+        }).collect
+        chunk.foreach(genotype => {
+          writer.write(genotype, encoder)
+          encoder.flush()
+        })
+        partitionNum += 1
+      }
+      out.write("\n".getBytes())
+      generator.close()
+      coalescedSubsetGenotypes.unpersist()
+    } else if (outputPath.toLowerCase.endsWith(".vcf")) {
+      progress(s"Writing genotypes to VCF file: $outputPath")
+      subsetGenotypes.toVariantContext.coalesce(1, shuffle = true).saveAsVcf(outputPath)
+    } else {
+      progress(s"Writing genotypes to: $outputPath.")
+      subsetGenotypes.adamParquetSave(
+        outputPath,
+        args.blockSize,
+        args.pageSize,
+        args.compressionCodec,
+        args.disableDictionaryEncoding
+      )
+    }
+  }
+
+
+}

--- a/src/main/scala/org/hammerlab/guacamole/windowing/SlidingWindow.scala
+++ b/src/main/scala/org/hammerlab/guacamole/windowing/SlidingWindow.scala
@@ -19,8 +19,8 @@
 package org.hammerlab.guacamole.windowing
 
 import org.apache.spark.Logging
-import org.hammerlab.guacamole.loci.LociSet
 import org.hammerlab.guacamole.{HasReferenceRegion, PerSample}
+import org.hammerlab.guacamole.loci.LociSet
 
 import scala.collection.mutable
 

--- a/src/test/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCallerSuite.scala
@@ -5,9 +5,9 @@ import org.hammerlab.guacamole._
 import org.hammerlab.guacamole.commands.GermlineAssemblyCaller.Arguments
 import org.hammerlab.guacamole.distributed.LociPartitionUtils
 import org.hammerlab.guacamole.loci.LociSet
-import org.hammerlab.guacamole.util.TestUtil
-import org.hammerlab.guacamole.reads.Read
+import org.hammerlab.guacamole.reads.InputFilters
 import org.hammerlab.guacamole.reference.ReferenceBroadcast
+import org.hammerlab.guacamole.util.TestUtil
 import org.hammerlab.guacamole.variants.CalledAllele
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
 
@@ -53,7 +53,7 @@ class GermlineAssemblyCallerSuite extends FunSuite with Matchers with BeforeAndA
       Common.loadReadsFromArguments(
         args,
         sc,
-        Read.InputFilters(
+        InputFilters(
           mapped = true,
           nonDuplicate = true,
           overlapsLoci = Some(lociBuilder)

--- a/src/test/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCallerSuite.scala
@@ -56,7 +56,7 @@ class GermlineAssemblyCallerSuite extends FunSuite with Matchers with BeforeAndA
         InputFilters(
           mapped = true,
           nonDuplicate = true,
-          overlapsLoci = Some(lociBuilder)
+          overlapsLoci = lociBuilder
         )
       )
 

--- a/src/test/scala/org/hammerlab/guacamole/commands/VariantSupportSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/VariantSupportSuite.scala
@@ -54,7 +54,7 @@ class VariantSupportSuite extends GuacFunSuite with TableDrivenPropertyChecks {
       InputFilters(
         mapped = true,
         nonDuplicate = false,
-        overlapsLoci = Some(LociSet.parse(loci))
+        overlapsLoci = LociSet.parse(loci)
       )
     ).mappedReads.collect().sortBy(_.start)
 
@@ -65,7 +65,7 @@ class VariantSupportSuite extends GuacFunSuite with TableDrivenPropertyChecks {
       InputFilters(
         mapped = true,
         nonDuplicate = true,
-        overlapsLoci = Some(LociSet.parse(loci))
+        overlapsLoci = LociSet.parse(loci)
       )
     ).mappedReads.collect().sortBy(_.start)
 

--- a/src/test/scala/org/hammerlab/guacamole/commands/VariantSupportSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/VariantSupportSuite.scala
@@ -3,7 +3,7 @@ package org.hammerlab.guacamole.commands
 import org.hammerlab.guacamole.commands.VariantSupport.Caller.AlleleCount
 import org.hammerlab.guacamole.loci.LociSet
 import org.hammerlab.guacamole.pileup.Pileup
-import org.hammerlab.guacamole.reads.{MappedRead, Read}
+import org.hammerlab.guacamole.reads.{MappedRead, InputFilters}
 import org.hammerlab.guacamole.reference.ReferenceBroadcast
 import org.hammerlab.guacamole.util.{GuacFunSuite, TestUtil}
 import org.hammerlab.guacamole.windowing.SlidingWindow
@@ -51,7 +51,7 @@ class VariantSupportSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     TestUtil.loadReads(
       sc,
       "gatk_mini_bundle_extract.bam",
-      Read.InputFilters(
+      InputFilters(
         mapped = true,
         nonDuplicate = false,
         overlapsLoci = Some(LociSet.parse(loci))
@@ -62,7 +62,7 @@ class VariantSupportSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     TestUtil.loadReads(
       sc,
       "gatk_mini_bundle_extract.bam",
-      Read.InputFilters(
+      InputFilters(
         mapped = true,
         nonDuplicate = true,
         overlapsLoci = Some(LociSet.parse(loci))

--- a/src/test/scala/org/hammerlab/guacamole/likelihood/LikelihoodSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/likelihood/LikelihoodSuite.scala
@@ -18,7 +18,7 @@
 
 package org.hammerlab.guacamole.likelihood
 
-import org.hammerlab.guacamole.ReadsUtil._
+import org.hammerlab.guacamole.likelihood.LikelihoodUtil._
 import org.hammerlab.guacamole.pileup.Pileup
 import org.hammerlab.guacamole.reads.MappedRead
 import org.hammerlab.guacamole.util.{GuacFunSuite, TestUtil}

--- a/src/test/scala/org/hammerlab/guacamole/likelihood/LikelihoodUtil.scala
+++ b/src/test/scala/org/hammerlab/guacamole/likelihood/LikelihoodUtil.scala
@@ -16,18 +16,18 @@
  * limitations under the License.
  */
 
-package org.hammerlab.guacamole
+package org.hammerlab.guacamole.likelihood
 
 import org.apache.spark.SparkContext
 import org.bdgenomics.adam.util.PhredUtils
-import org.hammerlab.guacamole.likelihood.LikelihoodSuite
+import org.hammerlab.guacamole.Bases
 import org.hammerlab.guacamole.util.TestUtil
 import org.hammerlab.guacamole.variants.{Allele, Genotype}
 
 /**
  * Some utility functions for [[LikelihoodSuite]].
  */
-object ReadsUtil {
+object LikelihoodUtil {
 
   def referenceBroadcast(sc: SparkContext) = TestUtil.makeReference(sc, Seq(("chr1", 1, "C")))
   val referenceBase = 'C'.toByte

--- a/src/test/scala/org/hammerlab/guacamole/loci/LociSetSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/loci/LociSetSuite.scala
@@ -20,6 +20,7 @@ package org.hammerlab.guacamole.loci
 
 import org.apache.spark.rdd.RDD
 import org.hammerlab.guacamole.Common
+import org.hammerlab.guacamole.logging.DebugLogArgs
 import org.hammerlab.guacamole.reads.Read
 import org.hammerlab.guacamole.util.{GuacFunSuite, TestUtil}
 
@@ -117,7 +118,7 @@ class LociSetSuite extends GuacFunSuite {
   sparkTest("loci argument parsing in Common") {
     val read = TestUtil.makeRead("C", "1M", 500, "20")
     val reads: RDD[Read] = sc.parallelize(Seq(read))
-    class TestArgs extends Common.Arguments.Base with Common.Arguments.Loci {}
+    class TestArgs extends DebugLogArgs with LociArgs {}
 
     // Test -loci argument
     val args1 = new TestArgs()

--- a/src/test/scala/org/hammerlab/guacamole/main/GeneratePartialFasta.scala
+++ b/src/test/scala/org/hammerlab/guacamole/main/GeneratePartialFasta.scala
@@ -7,7 +7,7 @@ import org.bdgenomics.utils.cli.Args4j
 import org.hammerlab.guacamole.Common.Arguments.{ReadLoadingConfigArgs, Reference}
 import org.hammerlab.guacamole.distributed.LociPartitionUtils
 import org.hammerlab.guacamole.logging.LoggingUtils.progress
-import org.hammerlab.guacamole.reads.Read.InputFilters
+import org.hammerlab.guacamole.reads.InputFilters
 import org.hammerlab.guacamole.reference.{ContigNotFound, ReferenceBroadcast}
 import org.hammerlab.guacamole.{Bases, Common, ReadSet}
 import org.kohsuke.args4j.{Argument, Option => Args4jOption}

--- a/src/test/scala/org/hammerlab/guacamole/main/GeneratePartialFasta.scala
+++ b/src/test/scala/org/hammerlab/guacamole/main/GeneratePartialFasta.scala
@@ -4,11 +4,10 @@ import java.io.{BufferedWriter, File, FileWriter}
 
 import org.apache.spark.Logging
 import org.bdgenomics.utils.cli.Args4j
-import org.hammerlab.guacamole.Common.Arguments.{ReadLoadingConfigArgs, Reference}
 import org.hammerlab.guacamole.distributed.LociPartitionUtils
 import org.hammerlab.guacamole.logging.LoggingUtils.progress
-import org.hammerlab.guacamole.reads.InputFilters
-import org.hammerlab.guacamole.reference.{ContigNotFound, ReferenceBroadcast}
+import org.hammerlab.guacamole.reads.{InputFilters, ReadLoadingConfigArgs}
+import org.hammerlab.guacamole.reference.{ContigNotFound, ReferenceArgs, ReferenceBroadcast}
 import org.hammerlab.guacamole.{Bases, Common, ReadSet}
 import org.kohsuke.args4j.{Argument, Option => Args4jOption}
 
@@ -28,7 +27,7 @@ object GeneratePartialFasta extends Logging {
   protected class Arguments
     extends LociPartitionUtils.Arguments
       with ReadLoadingConfigArgs
-      with Reference {
+      with ReferenceArgs {
 
     @Args4jOption(name = "--output", metaVar = "OUT", required = true, aliases = Array("-o"),
       usage = "Output path for partial fasta")
@@ -52,7 +51,7 @@ object GeneratePartialFasta extends Logging {
         sc,
         fileAndIndex._1,
         InputFilters.empty,
-        config = Common.Arguments.ReadLoadingConfigArgs.fromArguments(args)
+        config = ReadLoadingConfigArgs(args)
       )
     )
 
@@ -82,14 +81,5 @@ object GeneratePartialFasta extends Logging {
     })
     writer.close()
     progress(s"Wrote: ${args.output}")
-  }
-
-  private def printUsage() = {
-    println("Usage: java ... bam1.bam ... bamN.bam --output result.partial.fasta \n")
-    println(
-      """
-        |Given a full fasta and some loci (either specified directly or from reads), write out a fasta containing only
-        |the subset of the reference overlapped by the loci in a guacamole -specific fasta format
-      """.trim.stripMargin)
   }
 }

--- a/src/test/scala/org/hammerlab/guacamole/main/GeneratePartialFasta.scala
+++ b/src/test/scala/org/hammerlab/guacamole/main/GeneratePartialFasta.scala
@@ -4,10 +4,12 @@ import java.io.{BufferedWriter, File, FileWriter}
 
 import org.apache.spark.Logging
 import org.bdgenomics.utils.cli.Args4j
-import org.hammerlab.guacamole._
+import org.hammerlab.guacamole.Common.Arguments.{ReadLoadingConfigArgs, Reference}
 import org.hammerlab.guacamole.distributed.LociPartitionUtils
+import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.reads.Read.InputFilters
 import org.hammerlab.guacamole.reference.{ContigNotFound, ReferenceBroadcast}
+import org.hammerlab.guacamole.{Bases, Common, ReadSet}
 import org.kohsuke.args4j.{Argument, Option => Args4jOption}
 
 /**
@@ -20,11 +22,14 @@ import org.kohsuke.args4j.{Argument, Option => Args4jOption}
  *
  * This lets us package up a subset of a reference fasta into a file that is small enough to version control and
  * distribute.
- *
  */
 object GeneratePartialFasta extends Logging {
 
-  protected class Arguments extends LociPartitionUtils.Arguments with Common.Arguments.ReadLoadingConfigArgs with Common.Arguments.Reference {
+  protected class Arguments
+    extends LociPartitionUtils.Arguments
+      with ReadLoadingConfigArgs
+      with Reference {
+
     @Args4jOption(name = "--output", metaVar = "OUT", required = true, aliases = Array("-o"),
       usage = "Output path for partial fasta")
     var output: String = ""
@@ -32,8 +37,7 @@ object GeneratePartialFasta extends Logging {
     @Args4jOption(name = "--reference-fasta", required = true, usage = "Local path to a reference FASTA file")
     var referenceFastaPath: String = null
 
-    @Argument(required = true, multiValued = true,
-      usage = "Reads to write out overlapping fasta sequence for")
+    @Argument(required = true, multiValued = true, usage = "Reads to write out overlapping fasta sequence for")
     var bams: Array[String] = Array.empty
   }
 
@@ -77,7 +81,7 @@ object GeneratePartialFasta extends Logging {
       })
     })
     writer.close()
-    Common.progress("Wrote: %s".format(args.output))
+    progress(s"Wrote: ${args.output}")
   }
 
   private def printUsage() = {

--- a/src/test/scala/org/hammerlab/guacamole/reads/ReadSetSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/ReadSetSuite.scala
@@ -86,16 +86,16 @@ class ReadSetSuite extends GuacFunSuite {
     Seq(
       InputFilters(),
       InputFilters(mapped = true, nonDuplicate = true),
-      InputFilters(overlapsLoci = Some(LociSet.parse("20:10220390-10220490")))
+      InputFilters(overlapsLoci = LociSet.parse("20:10220390-10220490"))
     ).foreach(filter => {
-        check(Seq("gatk_mini_bundle_extract.bam", "gatk_mini_bundle_extract.sam"), filter)
-      })
+      check(Seq("gatk_mini_bundle_extract.bam", "gatk_mini_bundle_extract.sam"), filter)
+    })
 
     Seq(
-      InputFilters(overlapsLoci = Some(LociSet.parse("19:147033")))
+      InputFilters(overlapsLoci = LociSet.parse("19:147033"))
     ).foreach(filter => {
-        check(Seq("synth1.normal.100k-200k.withmd.bam", "synth1.normal.100k-200k.withmd.sam"), filter)
-      })
+      check(Seq("synth1.normal.100k-200k.withmd.bam", "synth1.normal.100k-200k.withmd.sam"), filter)
+    })
   }
 
   sparkTest("load and test filters") {

--- a/src/test/scala/org/hammerlab/guacamole/reads/ReadSetSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/ReadSetSuite.scala
@@ -42,9 +42,7 @@ class ReadSetSuite extends GuacFunSuite {
 
         val firstPath = paths.head
 
-        val configs =
-          Read.ReadLoadingConfig.BamReaderAPI.values
-            .map(api => Read.ReadLoadingConfig(bamReaderAPI = api))
+        val configs = BamReaderAPI.values.map(ReadLoadingConfig(_))
 
         val firstConfig = configs.head
 

--- a/src/test/scala/org/hammerlab/guacamole/reads/ReadSetSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/ReadSetSuite.scala
@@ -22,15 +22,9 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName
 import org.bdgenomics.adam.rdd.read.AlignmentRecordRDDFunctions
 import org.bdgenomics.adam.rdd.{ADAMContext, ADAMSaveAnyArgs}
 import org.hammerlab.guacamole.loci.LociSet
-import org.hammerlab.guacamole.reads.Read.InputFilters
-import org.hammerlab.guacamole.reference.ReferenceBroadcast
-import org.hammerlab.guacamole.util.TestUtil
 import org.hammerlab.guacamole.util.{GuacFunSuite, TestUtil}
-import org.scalatest.Matchers
 
 class ReadSetSuite extends GuacFunSuite {
-
-  def chr22Fasta = ReferenceBroadcast.readFasta(TestUtil.testDataPath("chr22.fa.gz"), sc)
 
   case class LazyMessage(msg: () => String) {
     override def toString: String = msg()
@@ -108,13 +102,13 @@ class ReadSetSuite extends GuacFunSuite {
     val allReads = TestUtil.loadReads(sc, "mdtagissue.sam")
     allReads.reads.count() should be(8)
 
-    val mdTagReads = TestUtil.loadReads(sc, "mdtagissue.sam", Read.InputFilters(mapped = true))
+    val mdTagReads = TestUtil.loadReads(sc, "mdtagissue.sam", InputFilters(mapped = true))
     mdTagReads.reads.count() should be(5)
 
     val nonDuplicateReads = TestUtil.loadReads(
       sc,
       "mdtagissue.sam",
-      Read.InputFilters(mapped = true, nonDuplicate = true)
+      InputFilters(mapped = true, nonDuplicate = true)
     )
     nonDuplicateReads.reads.count() should be(3)
   }
@@ -147,13 +141,13 @@ class ReadSetSuite extends GuacFunSuite {
     val (filteredReads, _) = Read.loadReadRDDAndSequenceDictionary(
       adamOut,
       sc,
-      Read.InputFilters(mapped = true, nonDuplicate = true)
+      InputFilters(mapped = true, nonDuplicate = true)
     )
     filteredReads.count() should be(3)
   }
 
   sparkTest("load and serialize / deserialize reads") {
-    val reads = TestUtil.loadReads(sc, "mdtagissue.sam", Read.InputFilters(mapped = true)).mappedReads.collect()
+    val reads = TestUtil.loadReads(sc, "mdtagissue.sam", InputFilters(mapped = true)).mappedReads.collect()
     val serializedReads = reads.map(TestUtil.serialize)
     val deserializedReads: Seq[MappedRead] = serializedReads.map(TestUtil.deserialize[MappedRead](_))
     for ((read, deserialized) <- reads.zip(deserializedReads)) {

--- a/src/test/scala/org/hammerlab/guacamole/util/GuacFunSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/GuacFunSuite.scala
@@ -8,7 +8,7 @@ trait GuacFunSuite extends SparkFunSuite with Matchers {
   override val properties: Map[String, String] =
     Map(
       "spark.serializer" -> "org.apache.spark.serializer.KryoSerializer",
-      "spark.kryo.registrator" -> "org.hammerlab.guacamole.GuacamoleKryoRegistrator",
+      "spark.kryo.registrator" -> "org.hammerlab.guacamole.kryo.GuacamoleKryoRegistrator",
       "spark.kryoserializer.buffer" -> "4",
       "spark.kryo.referenceTracking" -> "true"
     )

--- a/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
@@ -28,7 +28,7 @@ import org.apache.commons.io.FileUtils
 import org.apache.spark.SparkContext
 import org.hammerlab.guacamole.loci.LociSet
 import org.hammerlab.guacamole.pileup.Pileup
-import org.hammerlab.guacamole.reads.Read.InputFilters
+import org.hammerlab.guacamole.reads.InputFilters
 import org.hammerlab.guacamole.reads._
 import org.hammerlab.guacamole.reference.ReferenceBroadcast.MapBackedReferenceSequence
 import org.hammerlab.guacamole.reference.{ContigSequence, ReferenceBroadcast}
@@ -173,7 +173,7 @@ object TestUtil extends Matchers {
   def loadTumorNormalReads(sc: SparkContext,
                            tumorFile: String,
                            normalFile: String): (Seq[MappedRead], Seq[MappedRead]) = {
-    val filters = Read.InputFilters(mapped = true, nonDuplicate = true, passedVendorQualityChecks = true)
+    val filters = InputFilters(mapped = true, nonDuplicate = true, passedVendorQualityChecks = true)
     (
       loadReads(sc, tumorFile, filters = filters).mappedReads.collect(),
       loadReads(sc, normalFile, filters = filters).mappedReads.collect()
@@ -182,7 +182,7 @@ object TestUtil extends Matchers {
 
   def loadReads(sc: SparkContext,
                 filename: String,
-                filters: Read.InputFilters = Read.InputFilters.empty,
+                filters: InputFilters = InputFilters.empty,
                 config: ReadLoadingConfig = ReadLoadingConfig.default): ReadSet = {
     /* grab the path to the SAM file we've stashed in the resources subdirectory */
     val path = testDataPath(filename)

--- a/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
@@ -27,13 +27,14 @@ import com.twitter.chill.{IKryoRegistrar, KryoInstantiator, KryoPool}
 import htsjdk.samtools.TextCigarCodec
 import org.apache.commons.io.FileUtils
 import org.apache.spark.SparkContext
+import org.hammerlab.guacamole.kryo.GuacamoleKryoRegistrator
 import org.hammerlab.guacamole.loci.LociSet
 import org.hammerlab.guacamole.pileup.Pileup
 import org.hammerlab.guacamole.reads.InputFilters
 import org.hammerlab.guacamole.reads._
 import org.hammerlab.guacamole.reference.ReferenceBroadcast.MapBackedReferenceSequence
 import org.hammerlab.guacamole.reference.{ContigSequence, ReferenceBroadcast}
-import org.hammerlab.guacamole.{Bases, GuacamoleKryoRegistrator, ReadSet}
+import org.hammerlab.guacamole.{Bases, ReadSet}
 import org.scalatest._
 
 import scala.collection.mutable

--- a/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
@@ -183,7 +183,7 @@ object TestUtil extends Matchers {
   def loadReads(sc: SparkContext,
                 filename: String,
                 filters: Read.InputFilters = Read.InputFilters.empty,
-                config: Read.ReadLoadingConfig = Read.ReadLoadingConfig.default): ReadSet = {
+                config: ReadLoadingConfig = ReadLoadingConfig.default): ReadSet = {
     /* grab the path to the SAM file we've stashed in the resources subdirectory */
     val path = testDataPath(filename)
     assert(sc != null)

--- a/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
@@ -213,7 +213,7 @@ object TestUtil extends Matchers {
         filters = InputFilters(
           overlapsLoci = maybeContig.map(
             contig => LociSet.parse(s"$contig:$locus-${locus + 1}")
-          )
+          ).orNull
         )
       ).mappedReads
     val localReads = records.collect


### PR DESCRIPTION
* new `logging` package: `Common.progress`, `DelayedMessages`
* separate files for `ReadLoadingConfig`, `BamReaderAPI`, `ReadInputFilters`
- Arguments.BaseArgs → logging.DebugLogArgs
- Arguments.GenotypeOutput → variants.GenotypeOutputArgs
- Arguments.Loci → loci.LociArgs
- Arguments.ReadLoadingConfigArgs → reads.ReadLoadingConfigArgs
- Arguments.Reference → reference.ReferenceArgs
- Concordance → variants pkg
- Common.loadGenotypes → Concordance
- writeVariantsFromArguments → variants.VariantUtils.…
- use buggily-unused filters in VAFHistogram
- unroll other Common.Arguments members into Common; will move them
  out as well soon.
- GuacamoleKryoRegistrator → `kryo` package

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/430)
<!-- Reviewable:end -->
