### PR TITLE
Add read-based path scoring

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
@@ -11,8 +11,9 @@ import org.hammerlab.guacamole.alignment.AffineGapPenaltyAlignment
 import org.hammerlab.guacamole.assembly.DeBruijnGraph
 import org.hammerlab.guacamole.distributed.LociPartitionUtils.partitionLociAccordingToArgs
 import org.hammerlab.guacamole.distributed.WindowFlatMapUtils.windowFlatMapWithState
-import org.hammerlab.guacamole.distributed.{LociPartitionUtils, WindowFlatMapUtils}
+import org.hammerlab.guacamole.likelihood.Likelihood
 import org.hammerlab.guacamole.loci.LociMap
+import org.hammerlab.guacamole.pileup.Pileup
 import org.hammerlab.guacamole.reads.{MappedRead, Read}
 import org.hammerlab.guacamole.reference.{ReferenceBroadcast, ReferenceGenome}
 import org.hammerlab.guacamole.variants.{Allele, AlleleConversions, AlleleEvidence, CalledAllele}
@@ -47,7 +48,7 @@ object GermlineAssemblyCaller {
     @Args4jOption(name = "--min-alignment-quality", usage = "Minimum alignment qualities of the read")
     var minAlignmentQuality: Int = 30
 
-    @Args4jOption(name = "--reference-fasta", required = false, usage = "Local path to a reference FASTA file")
+    @Args4jOption(name = "--reference-fasta", required = true, usage = "Local path to a reference FASTA file")
     var referenceFastaPath: String = null
 
     @Args4jOption(name = "--min-area-vaf", required = false, usage = "Minimum variant allele frequency to investigate area")
@@ -55,6 +56,12 @@ object GermlineAssemblyCaller {
 
     @Args4jOption(name = "--min-occurrence", required = false, usage = "Minimum occurrences to include a kmer ")
     var minOccurrence: Int = 3
+
+    @Args4jOption(name = "--min-likelihood", usage = "Minimum Phred-scaled likelihood. Default: 0 (off)")
+    var minLikelihood: Int = 0
+
+    @Args4jOption(name = "--shortcut-assembly", required = false, usage = "Skip assembly process in inactive regions")
+    var shortcutAssembly: Boolean = false
 
   }
 
@@ -118,23 +125,20 @@ object GermlineAssemblyCaller {
      * @param minOccurrence Minimum times a kmer must appear to be in the DeBruijn graph
      * @param expectedPloidy Expected ploidy, or expected number of valid paths through the graph
      * @param maxPathsToScore Number of paths to align to the reference to score them
-     * @return A set of variants in the window
-     *         TODO: This currently passes along a graph as state, but rebuilds it each time
-     *         This can be updated to use the existing graph and just update it
+     * @return
      */
-    def discoverGermlineVariants(graph: Option[DeBruijnGraph],
-                                 currentWindow: SlidingWindow[MappedRead],
-                                 kmerSize: Int,
-                                 reference: ReferenceGenome,
-                                 minOccurrence: Int = 3,
-                                 expectedPloidy: Int = 2,
-                                 maxPathsToScore: Int = 16,
-                                 debugPrint: Boolean = false): (Option[DeBruijnGraph], Iterator[CalledAllele]) = {
+    def discoverHaplotypes(graph: Option[DeBruijnGraph],
+                           currentWindow: SlidingWindow[MappedRead],
+                           kmerSize: Int,
+                           reference: ReferenceGenome,
+                           minOccurrence: Int = 3,
+                           expectedPloidy: Int = 2,
+                           maxPathsToScore: Int = 16,
+                           debugPrint: Boolean = false): Seq[DeBruijnGraph#Sequence] = {
 
       val locus = currentWindow.currentLocus
       val reads = currentWindow.currentRegions()
 
-      val sampleName = reads.head.sampleName
       val referenceContig = reads.head.referenceContig
 
       val referenceStart = (locus - currentWindow.halfWindowSize).toInt
@@ -159,98 +163,26 @@ object GermlineAssemblyCaller {
         .toVector
 
       // Score up to the maximum number of paths
-      val topPaths =
-        if (paths.size <= expectedPloidy) {
-          paths
-        } else if (paths.size <= maxPathsToScore) {
-          val pathScores = DenseVector.zeros[Int](paths.size)
-          reads.foreach(
-            read => {
-              pathScores :+= DenseVector(paths.map(path => -AffineGapPenaltyAlignment.align(read.sequence, path).alignmentScore): _*)
-            })
-
-          argtopk(pathScores, expectedPloidy).map(paths(_))
-
-        } else {
-          log.warn(s"In window ${referenceContig}:${referenceStart}-$referenceEnd " +
-            s"there were ${paths.size} paths found, all variants skipped")
-          List.empty
-        }
-
-      val pathsAndAlignments =
-        topPaths.map(path => (path, AffineGapPenaltyAlignment.align(path, currentReference)))
-
-      // Build a variant using the current offset and read evidence
-      def buildVariant(referenceOffset: Int,
-                       referenceBases: Array[Byte],
-                       alternateBases: Array[Byte]) = {
-        val allele = Allele(
-          referenceBases,
-          alternateBases
-        )
-
-        val depth = reads.length
-        val mappingQualities = DenseVector(reads.map(_.alignmentQuality.toFloat).toArray)
-        val baseQualities = DenseVector(reads.flatMap(_.baseQualities).map(_.toFloat).toArray)
-        CalledAllele(
-          sampleName,
-          referenceContig,
-          referenceStart + referenceOffset,
-          allele,
-          AlleleEvidence(
-            likelihood = 1,
-            readDepth = depth,
-            alleleReadDepth = depth,
-            forwardDepth = depth,
-            alleleForwardDepth = depth,
-            meanMappingQuality = mean(mappingQualities),
-            medianMappingQuality = median(mappingQualities),
-            meanBaseQuality = mean(baseQualities),
-            medianBaseQuality = median(baseQualities),
-            medianMismatchesPerRead = 0
-          )
-        )
-      }
-
-      val variants =
-        pathsAndAlignments.flatMap(kv => {
-          val path = kv._1
-          val alignment = kv._2
-
-          var referenceIndex = alignment.refStartIdx
-          var pathIndex = 0
-
-          // Find the alignment sequences using the CIGAR
-          val cigarElements = alignment.toCigar.getCigarElements
-
-          cigarElements.flatMap(cigarElement => {
-            val cigarOperator = cigarElement.getOperator
-            val referenceLength = CigarUtils.getReferenceLength(cigarElement)
-            val pathLength = CigarUtils.getReadLength(cigarElement)
-
-            // Yield a resulting variant when there is a mismatch, insertion or deletion
-            val possibleVariant = cigarOperator match {
-              case CigarOperator.X =>
-                val referenceAllele = currentReference.slice(referenceIndex, referenceIndex + referenceLength)
-                val alternateAllele = path.slice(pathIndex, pathIndex + pathLength)
-                Some(buildVariant(referenceIndex, referenceAllele, alternateAllele.toArray))
-              case (CigarOperator.I | CigarOperator.D) if referenceIndex != 0 =>
-                // For insertions and deletions, report the variant with the last reference base attached
-                val referenceAllele = currentReference.slice(referenceIndex - 1, referenceIndex + referenceLength)
-                val alternateAllele = path.slice(pathIndex - 1, pathIndex + pathLength)
-                Some(buildVariant(referenceIndex - 1, referenceAllele, alternateAllele.toArray))
-              case _ => None
-            }
-
-            referenceIndex += referenceLength
-            pathIndex += pathLength
-
-            possibleVariant
+      if (paths.size == 0) {
+        log.warn(s"In window ${referenceContig}:${referenceStart}-$referenceEnd " +
+          s"assembly failed")
+        List.empty
+      } else if (paths.size <= expectedPloidy) {
+        paths
+      } else if (paths.size <= maxPathsToScore) {
+        val pathScores = DenseVector.zeros[Int](paths.size)
+        reads.foreach(
+          read => {
+            pathScores :+= DenseVector(paths.map(path => -AffineGapPenaltyAlignment.align(read.sequence, path).alignmentScore): _*)
           })
 
-        })
+        argtopk(pathScores, expectedPloidy).map(paths(_))
 
-      (graph, variants.iterator)
+      } else {
+        log.warn(s"In window ${referenceContig}:${referenceStart}-$referenceEnd " +
+          s"there were ${paths.size} paths found, all variants skipped")
+        List.empty
+      }
     }
 
     override def run(args: Arguments, sc: SparkContext): Unit = {
@@ -277,14 +209,16 @@ object GermlineAssemblyCaller {
         readSet.mappedReads
       )
 
-      val genotypes: RDD[CalledAllele] = discoverGenotypes(
+      val genotypes: RDD[CalledAllele] = discoverGermlineVariants(
         qualityReads,
         kmerSize = args.kmerSize,
         snvWindowRange = args.snvWindowRange,
         minOccurrence = args.minOccurrence,
         minAreaVaf = args.minAreaVaf / 100.0f,
-        reference,
-        lociPartitions)
+        reference = reference,
+        lociPartitions = lociPartitions,
+        minPhredScaledLikelihood = args.minLikelihood,
+        shortcutAssembly = args.shortcutAssembly)
 
       genotypes.persist()
 
@@ -297,37 +231,56 @@ object GermlineAssemblyCaller {
       DelayedMessages.default.print()
     }
 
-    def discoverGenotypes(reads: RDD[MappedRead],
+    def discoverGermlineVariants(reads: RDD[MappedRead],
                           kmerSize: Int,
                           snvWindowRange: Int,
                           minOccurrence: Int,
                           minAreaVaf: Float,
                           reference: ReferenceBroadcast,
-                          lociPartitions: LociMap[Long]): RDD[CalledAllele] = {
+                          lociPartitions: LociMap[Long],
+                          minAltReads: Int = 2,
+                          minPhredScaledLikelihood: Int = 0,
+                          shortcutAssembly: Boolean = false): RDD[CalledAllele] = {
 
       val genotypes: RDD[CalledAllele] =
-        windowFlatMapWithState[MappedRead, CalledAllele, Option[DeBruijnGraph]](
+        windowFlatMapWithState[MappedRead, CalledAllele, Option[Long]](
           Vector(reads),
           lociPartitions,
           skipEmpty = true,
           halfWindowSize = snvWindowRange,
           initialState = None,
-          (graph, windows) => {
+          (lastCalledLocus, windows) => {
             val window = windows.head
+            val referenceName = window.referenceName
+            val locus = window.currentLocus
+
+            val referenceStart = (locus - window.halfWindowSize).toInt
+            val referenceEnd = (locus + window.halfWindowSize).toInt
+            val currentReference =
+              reference.getReferenceSequence(
+                window.referenceName,
+                referenceStart,
+                referenceEnd
+              )
+
             // Find the reads the overlap the center locus/ current locus
             val currentLocusReads =
               window
                 .currentRegions()
                 .filter(_.overlapsLocus(window.currentLocus))
-            val variableReads =
-              currentLocusReads
-                .count(read =>
-                  read.cigar.numCigarElements() > 1 || read.countOfMismatches(reference.getContig(window.referenceName)) > 0)
+
+            val pileup = Pileup(currentLocusReads, referenceName, window.currentLocus, reference.getContig(referenceName))
 
             // Compute the number reads with variant bases from the reads overlapping the currentLocus
-            val currentLocusVAF = variableReads.toFloat / currentLocusReads.length
-            if (currentLocusVAF > minAreaVaf) {
-              val result = discoverHaplotypes(
+            val pileupAltReads = (pileup.depth - pileup.referenceDepth)
+            if (currentLocusReads.isEmpty || pileupAltReads < minAltReads) {
+              (lastCalledLocus, Iterator.empty)
+            } else if (shortcutAssembly &&
+              currentLocusReads.count(r => r.countOfMismatches > 1 || r.cigar.numCigarElements() > 1) / currentLocusReads.size.toFloat < minAreaVaf) {
+              val variants = callPileupVariant(pileup).filter(_.evidence.phredScaledLikelihood > minPhredScaledLikelihood)
+              (variants.lastOption.map(_.start).orElse(lastCalledLocus), variants.iterator)
+            } else {
+              val paths = discoverHaplotypes(
                 None,
                 window,
                 kmerSize,
@@ -335,11 +288,24 @@ object GermlineAssemblyCaller {
                 minOccurrence
               )
 
-              // Jump to the next region
-              window.setCurrentLocus(window.currentLocus + snvWindowRange)
-              (graph, result._2)
-            } else {
-              (graph, Iterator.empty)
+              if (paths.nonEmpty) {
+                val variants =
+                  buildVariantsFromPaths(
+                    paths,
+                    currentLocusReads.head.sampleName,
+                    referenceName,
+                    referenceStart = (window.currentLocus - window.halfWindowSize).toInt,
+                    currentReference,
+                    window.currentRegions()
+                  )
+                    .filter(variant => lastCalledLocus.forall(_ < variant.start)) // Filter variants before last called
+                    .toSet // Remove any duplicate variants due to paths that have overlapping segments
+                // Jump to the next region
+                window.setCurrentLocus(window.currentLocus + snvWindowRange)
+                (variants.lastOption.map(_.start).orElse(lastCalledLocus), variants.iterator)
+              } else {
+                (lastCalledLocus, Iterator.empty)
+              }
             }
           }
         )
@@ -405,4 +371,132 @@ object GermlineAssemblyCaller {
       }
     }
   }
+
+  /**
+    * Call variants from the paths discovered from the reads
+    * @param paths Sequence of possible paths through the reads
+    * @param sampleName Name of the sample
+    * @param referenceContig Reference contig or chromosome
+    * @param referenceStart Start locus on the reference contig or chromosome
+    * @param currentReference Reference sequence overlapping the reference region
+    * @param reads Set of reads used to build paths
+    * @return Possible sequence of called variants
+    */
+  def buildVariantsFromPaths(paths: Seq[DeBruijnGraph#Sequence],
+                             sampleName: String,
+                             referenceContig: String,
+                             referenceStart: Int,
+                             currentReference: Array[Byte],
+                             reads: Seq[MappedRead]): Set[CalledAllele] = {
+
+    val pathsAndAlignments = paths.map(path => (path, AffineGapPenaltyAlignment.align(path, currentReference)))
+    // Build a variant using the current offset and read evidence
+    def buildVariant(referenceOffset: Int,
+                     referenceBases: Array[Byte],
+                     alternateBases: Array[Byte]) = {
+      val allele = Allele(
+        referenceBases,
+        alternateBases
+      )
+
+      val depth = reads.length
+      val mappingQualities = DenseVector(reads.map(_.alignmentQuality.toFloat).toArray)
+      val baseQualities = DenseVector(reads.flatMap(_.baseQualities).map(_.toFloat).toArray)
+      CalledAllele(
+        sampleName,
+        referenceContig,
+        referenceStart + referenceOffset,
+        allele,
+        AlleleEvidence(
+          likelihood = 1,
+          readDepth = depth,
+          alleleReadDepth = depth,
+          forwardDepth = depth,
+          alleleForwardDepth = depth,
+          meanMappingQuality = mean(mappingQualities),
+          medianMappingQuality = median(mappingQualities),
+          meanBaseQuality = mean(baseQualities),
+          medianBaseQuality = median(baseQualities),
+          medianMismatchesPerRead = 0
+        )
+      )
+    }
+
+    val variants =
+      pathsAndAlignments.flatMap(kv => {
+        val path = kv._1
+        val alignment = kv._2
+
+        var referenceIndex = alignment.refStartIdx
+        var pathIndex = 0
+
+        // Find the alignment sequences using the CIGAR
+        val cigarElements = alignment.toCigar.getCigarElements
+
+        cigarElements.flatMap(cigarElement => {
+          val cigarOperator = cigarElement.getOperator
+          val referenceLength = CigarUtils.getReferenceLength(cigarElement)
+          val pathLength = CigarUtils.getReadLength(cigarElement)
+
+          // Yield a resulting variant when there is a mismatch, insertion or deletion
+          val possibleVariant = cigarOperator match {
+            case CigarOperator.X =>
+              val referenceAllele = currentReference.slice(referenceIndex, referenceIndex + referenceLength)
+              val alternateAllele = path.slice(pathIndex, pathIndex + pathLength)
+              Some(buildVariant(referenceIndex, referenceAllele, alternateAllele.toArray))
+            case (CigarOperator.I | CigarOperator.D) if referenceIndex != 0 =>
+              // For insertions and deletions, report the variant with the last reference base attached
+              val referenceAllele = currentReference.slice(referenceIndex - 1, referenceIndex + referenceLength)
+              val alternateAllele = path.slice(pathIndex - 1, pathIndex + pathLength)
+              Some(buildVariant(referenceIndex - 1, referenceAllele, alternateAllele.toArray))
+            case _ => None
+          }
+
+          referenceIndex += referenceLength
+          pathIndex += pathLength
+
+          possibleVariant
+        })
+
+      })
+    variants.toSet
+  }
+
+  /**
+    * Call variants using a pileup and genotype likelihoods
+    * @param pileup Pileup at a given locus
+    * @return Possible set of called variants
+    */
+  def callPileupVariant(pileup: Pileup): Set[CalledAllele] = {
+    val genotypeLikelihoods = Likelihood.likelihoodsOfAllPossibleGenotypesFromPileup(
+      pileup,
+      logSpace = true,
+      normalize = true
+    )
+
+
+    // If we did not have any valid genotypes to evaluate
+    // we do not return any variants
+    if (genotypeLikelihoods.isEmpty) {
+      Set.empty
+    } else {
+      val mostLikelyGenotypeAndProbability = genotypeLikelihoods.maxBy(_._2)
+
+      val genotype = mostLikelyGenotypeAndProbability._1
+      val probability = math.exp(mostLikelyGenotypeAndProbability._2)
+      genotype
+        .getNonReferenceAlleles
+        .toSet // Collapse homozygous genotypes
+        .filter(_.altBases.nonEmpty)
+        .map(allele => {
+          CalledAllele(
+            pileup.head.read.sampleName,
+            pileup.referenceName,
+            pileup.locus,
+            allele,
+            AlleleEvidence(probability, allele, pileup))
+        })
+    }
+  }
+
 }

--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
@@ -125,7 +125,7 @@ object GermlineAssemblyCaller {
      * @param minOccurrence Minimum times a kmer must appear to be in the DeBruijn graph
      * @param expectedPloidy Expected ploidy, or expected number of valid paths through the graph
      * @param maxPathsToScore Number of paths to align to the reference to score them
-     * @return
+     * @return Collection of paths through the reads
      */
     def discoverHaplotypes(graph: Option[DeBruijnGraph],
                            currentWindow: SlidingWindow[MappedRead],
@@ -276,7 +276,8 @@ object GermlineAssemblyCaller {
             if (currentLocusReads.isEmpty || pileupAltReads < minAltReads) {
               (lastCalledLocus, Iterator.empty)
             } else if (shortcutAssembly &&
-              currentLocusReads.count(r => r.countOfMismatches > 1 || r.cigar.numCigarElements() > 1) / currentLocusReads.size.toFloat < minAreaVaf) {
+              currentLocusReads.count(r =>
+                r.countOfMismatches(reference.getContig(referenceName)) > 1 || r.cigar.numCigarElements() > 1) / currentLocusReads.size.toFloat < minAreaVaf) {
               val variants = callPileupVariant(pileup).filter(_.evidence.phredScaledLikelihood > minPhredScaledLikelihood)
               (variants.lastOption.map(_.start).orElse(lastCalledLocus), variants.iterator)
             } else {

--- a/src/main/scala/org/hammerlab/guacamole/reads/MappedRead.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/MappedRead.scala
@@ -63,18 +63,18 @@ case class MappedRead(
    * @return count of mismatching bases
    */
 
-  var countOfMismatches = -1
+  private var cachedCountOfMismatches = -1
   def countOfMismatches(referenceContigSequence: ContigSequence): Int = {
-    if (countOfMismatches == -1) {
+    if (cachedCountOfMismatches == -1) {
       var element = PileupElement(this, start, referenceContigSequence)
       var count = (if (element.isMismatch) 1 else 0)
       while (element.locus < end - 1) {
         element = element.advanceToLocus(element.locus + 1)
         count += (if (element.isMismatch) 1 else 0)
       }
-      countOfMismatches = count
+      cachedCountOfMismatches = count
     }
-    countOfMismatches
+    cachedCountOfMismatches
   }
 
   lazy val alignmentLikelihood = PhredUtils.phredToSuccessProbability(alignmentQuality)

--- a/src/main/scala/org/hammerlab/guacamole/reads/MappedRead.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/MappedRead.scala
@@ -18,11 +18,11 @@
 
 package org.hammerlab.guacamole.reads
 
-import htsjdk.samtools.{ SAMRecord, Cigar }
-import org.bdgenomics.adam.util.{ PhredUtils, MdTag }
+import htsjdk.samtools.Cigar
+import org.bdgenomics.adam.util.PhredUtils
 import org.hammerlab.guacamole.pileup.PileupElement
-import org.hammerlab.guacamole.reference.{ ContigSequence, ReferenceBroadcast }
-import org.hammerlab.guacamole.{ Bases, HasReferenceRegion }
+import org.hammerlab.guacamole.reference.ContigSequence
+import org.hammerlab.guacamole.{Bases, HasReferenceRegion}
 
 import scala.collection.JavaConversions
 
@@ -54,6 +54,7 @@ case class MappedRead(
   override val isMapped = true
   override def asMappedRead = Some(this)
 
+
   /**
    * Number of mismatching bases in this read. Does *not* include indels: only looks at read bases that align to a
    * single base in the reference and do not match it.
@@ -61,14 +62,19 @@ case class MappedRead(
    * @param referenceContigSequence the reference sequence for this read's contig
    * @return count of mismatching bases
    */
+
+  var countOfMismatches = -1
   def countOfMismatches(referenceContigSequence: ContigSequence): Int = {
-    var element = PileupElement(this, start, referenceContigSequence)
-    var count = (if (element.isMismatch) 1 else 0)
-    while (element.locus < end - 1) {
-      element = element.advanceToLocus(element.locus + 1)
-      count += (if (element.isMismatch) 1 else 0)
+    if (countOfMismatches == -1) {
+      var element = PileupElement(this, start, referenceContigSequence)
+      var count = (if (element.isMismatch) 1 else 0)
+      while (element.locus < end - 1) {
+        element = element.advanceToLocus(element.locus + 1)
+        count += (if (element.isMismatch) 1 else 0)
+      }
+      countOfMismatches = count
     }
-    count
+    countOfMismatches
   }
 
   lazy val alignmentLikelihood = PhredUtils.phredToSuccessProbability(alignmentQuality)

--- a/src/test/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCallerSuite.scala
@@ -17,7 +17,7 @@ class GermlineAssemblyCallerSuite extends FunSuite with Matchers with BeforeAndA
 
   val input = NA12878TestUtils.na12878SubsetBam
   args.reads = TestUtil.testDataPath(input)
-  args.parallelism = 2
+  args.parallelism = 1
 
   var sc: SparkContext = _
   var reference: ReferenceBroadcast = _
@@ -37,7 +37,7 @@ class GermlineAssemblyCallerSuite extends FunSuite with Matchers with BeforeAndA
   def verifyVariantsAtLocus(locus: Int,
                             contig: String = "chr1",
                             kmerSize: Int = 31,
-                            snvWindowRange: Int = 55,
+                            snvWindowRange: Int = 45,
                             minOccurrence: Int = 5,
                             minVaf: Float = 0.1f)(
                              expectedVariants: (String, Int, String, String)*
@@ -66,7 +66,7 @@ class GermlineAssemblyCallerSuite extends FunSuite with Matchers with BeforeAndA
       )
 
     val variants =
-      GermlineAssemblyCaller.Caller.discoverGenotypes(
+      GermlineAssemblyCaller.Caller.discoverGermlineVariants(
         readSet.mappedReads,
         kmerSize = kmerSize,
         snvWindowRange = snvWindowRange,
@@ -105,7 +105,6 @@ class GermlineAssemblyCallerSuite extends FunSuite with Matchers with BeforeAndA
   test (
     "test assembly caller: illumina platinum tests; 2 nearby homozygous snps") {
     verifyVariantsAtLocus(1316669) (
-      ("chr1", 1316647, "C", "T"),
       ("chr1", 1316647, "C", "T"),
       ("chr1", 1316669, "C", "G"),
       ("chr1", 1316673, "C", "T")

--- a/src/test/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCallerSuite.scala
@@ -39,7 +39,8 @@ class GermlineAssemblyCallerSuite extends FunSuite with Matchers with BeforeAndA
                             kmerSize: Int = 31,
                             snvWindowRange: Int = 45,
                             minOccurrence: Int = 5,
-                            minVaf: Float = 0.1f)(
+                            minVaf: Float = 0.1f,
+                            shortcutAssembly: Boolean = false)(
                              expectedVariants: (String, Int, String, String)*
                            ) = {
 
@@ -73,7 +74,8 @@ class GermlineAssemblyCallerSuite extends FunSuite with Matchers with BeforeAndA
         minOccurrence = minOccurrence,
         minAreaVaf = minVaf,
         reference = reference,
-        lociPartitions = lociPartitions
+        lociPartitions = lociPartitions,
+        shortcutAssembly = shortcutAssembly
       ).collect().sortBy(_.start)
 
     val actualVariants =
@@ -90,6 +92,14 @@ class GermlineAssemblyCallerSuite extends FunSuite with Matchers with BeforeAndA
   test (
     "test assembly caller: illumina platinum tests; homozygous snp") {
     verifyVariantsAtLocus(772754) (
+      ("chr1", 772754, "A", "C")
+    )
+  }
+
+
+  test (
+    "test assembly caller: illumina platinum tests; homozygous snp; shortcut assembly") {
+    verifyVariantsAtLocus(772754, shortcutAssembly = true) (
       ("chr1", 772754, "A", "C")
     )
   }
@@ -112,6 +122,15 @@ class GermlineAssemblyCallerSuite extends FunSuite with Matchers with BeforeAndA
   }
 
   test (
+    "test assembly caller: illumina platinum tests; 2 nearby homozygous snps; shortcut assembly") {
+    verifyVariantsAtLocus(1316669, shortcutAssembly = true) (
+      ("chr1", 1316647, "C", "T"),
+      ("chr1", 1316669, "C", "G"),
+      ("chr1", 1316673, "C", "T")
+    )
+  }
+
+  test (
     "test assembly caller: illumina platinum tests; het snp") {
     verifyVariantsAtLocus(1342611) (
       ("chr1", 1342611, "G", "C")
@@ -121,6 +140,13 @@ class GermlineAssemblyCallerSuite extends FunSuite with Matchers with BeforeAndA
   test (
     "test assembly caller: illumina platinum tests; homozygous deletion") {
     verifyVariantsAtLocus(1296368) (
+      ("chr1", 1296368, "GAC", "G")
+    )
+  }
+
+  test (
+    "test assembly caller: illumina platinum tests; homozygous deletion; shortcut assembly") {
+    verifyVariantsAtLocus(1296368, shortcutAssembly = true) (
       ("chr1", 1296368, "GAC", "G")
     )
   }
@@ -155,6 +181,23 @@ class GermlineAssemblyCallerSuite extends FunSuite with Matchers with BeforeAndA
     "test assembly caller: homozygous snp in a repeat region") {
     verifyVariantsAtLocus(789255) (
       ("chr1", 789255, "T", "C")
+    )
+  }
+
+  test (
+      "test assembly caller: het variant near homozygous variant") {
+      verifyVariantsAtLocus(743020, snvWindowRange = 55) (
+        ("chr1", 743020, "T", "C"),
+        ("chr1", 743071, "C", "A")
+      )
+  }
+
+  test (
+    "test assembly caller: het variant in between two homozygous variants") {
+    verifyVariantsAtLocus(821925, snvWindowRange = 55) (
+      ("chr1", 821886, "A", "G"),
+      ("chr1", 821925, "C", "G"),
+      ("chr1", 821947, "T", "C")
     )
   }
 }

--- a/src/test/scala/org/hammerlab/guacamole/main/GermlineAssemblyIntegrationTests.scala
+++ b/src/test/scala/org/hammerlab/guacamole/main/GermlineAssemblyIntegrationTests.scala
@@ -1,0 +1,45 @@
+package org.hammerlab.guacamole.main
+
+import org.hammerlab.guacamole.VariantComparisonUtils.compareToVCF
+import org.hammerlab.guacamole.commands.jointcaller.SomaticJoint
+import org.hammerlab.guacamole.util.TestUtil
+import org.hammerlab.guacamole.{Common, NA12878TestUtils}
+
+object GermlineAssemblyIntegrationTests {
+
+
+  def main(args: Array[String]): Unit = {
+
+    val sc = Common.createSparkContext("GermlineAssemblyIntegrationTest")
+
+    println("Germline assembly calling on subset of illumina platinum NA12878")
+
+    val resultFile = tempFile(".vcf")
+
+    val outDir = "/tmp/germline-assembly-na12878-guacamole-tests"
+
+
+    val args = new GermlineAssembly.Caller.Arguments()
+    args.out = resultFile
+    args.paths = Seq(NA12878TestUtils.na12878SubsetBam).toArray
+    args.loci = "chr1:0-6700000"
+    args.forceCallLociFromFile = NA12878TestUtils.na12878ExpectedCallsVCF
+    args.referenceFastaPath = NA12878TestUtils.chr1PrefixFasta
+    SomaticJoint.Caller.run(args, sc)
+
+
+    println("************* GUACAMOLE GermlineAssembly *************")
+    compareToVCF(resultFile, NA12878TestUtils.na12878ExpectedCallsVCF)
+
+    println("************* UNIFIED GENOTYPER *************")
+    compareToVCF(TestUtil.testDataPath(
+      "illumina-platinum-na12878/unified_genotyper.vcf"),
+      NA12878TestUtils.na12878ExpectedCallsVCF)
+
+    println("************* HaplotypeCaller *************")
+    compareToVCF(TestUtil.testDataPath(
+      "illumina-platinum-na12878/haplotype_caller.vcf"),
+      NA12878TestUtils.na12878ExpectedCallsVCF)
+
+  }
+}


### PR DESCRIPTION
This updates the scoring mechanism of the germline assembly caller to score the paths based on how the reads align to them. The paths that explain the reads the best are chosen. 

Since this adds a large computational expense, there is now a `shortcut-assembly` flag to skip assembly in 'simple areas' (where there are no indels or multiple mismatches nearby)

I think the last test case displays some of this functionality the best - where we can successfully call the 3 variants without any of the false positives:
![image](https://cloud.githubusercontent.com/assets/455755/14432173/ef96bec0-ffd6-11e5-99af-c97a1fa2e9ef.png)

For a sample dataset (NA12878 chr20), this improve recall significantly, going from:
```
Recall / Sensitivity: 0.913427632367 Precision: 0.880323685189
```
to
```
Recall / Sensitivity: 0.951337972881 Precision: 0.838393433011
```

and specifically on indels, from
```
Recall / Sensitivity: 0.818181818182 Precision: 0.586783204394
```
to
```
Recall / Sensitivity: 0.856719367589 Precision: 0.61954385756
```

HaplotypeCaller on the same data, for all variants
```
Recall / Sensitivity: 0.983819243922 Precision: 0.832385755942
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/434)
<!-- Reviewable:end -->
