### PR TITLE
bump Spark, Hadoop, Scala versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,10 @@
     <adam.version>0.19.0</adam.version>
     <bdg-formats.version>0.7.0</bdg-formats.version>
     <java.version>1.8</java.version>
-    <scala.version>2.10.3</scala.version>
+    <scala.version>2.10.5</scala.version>
     <scala.version.prefix>2.10</scala.version.prefix>
-    <hadoop.version>2.3.0</hadoop.version>
-    <spark.version>1.6.0</spark.version>
+    <hadoop.version>2.6.0</hadoop.version>
+    <spark.version>1.6.1</spark.version>
     <maven.release.plugin.version>2.4.1</maven.release.plugin.version>
   </properties>
 


### PR DESCRIPTION
- I use Spark 1.6.1 exclusively; an important crashy failure mode went away between 1.6.0 and 1.6.1 with Spark's move off of Akka, if my memory of my experiences serves me right.
- Bumping from Scala 2.10.3 to 2.10.5 shouldn't break anything; seems like a good small step toward #438.
- We use Hadoop 2.6.0+ (cdh5.5.1), so might as well codify that here.

If anyone feels like this is a dangerous change I'm open to trying to run some tests, but other things equal I'd bump these and then post-hoc troubleshoot if anything goes wrong.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/440)
<!-- Reviewable:end -->
