### PR TITLE
Require kryo registration

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/Common.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Common.scala
@@ -238,7 +238,7 @@ object Common extends Logging {
     }
 
     if (config.getOption("spark.kryo.registrator").isEmpty) {
-      config.set("spark.kryo.registrator", "org.hammerlab.guacamole.kryo.GuacamoleKryoRegistrator")
+      config.set("spark.kryo.registrator", "org.hammerlab.guacamole.kryo.GuacamoleKryoRegistrar")
     }
 
     if (config.getOption("spark.kryoserializer.buffer").isEmpty) {

--- a/src/main/scala/org/hammerlab/guacamole/kryo/GuacamoleKryoRegistrar.scala
+++ b/src/main/scala/org/hammerlab/guacamole/kryo/GuacamoleKryoRegistrar.scala
@@ -38,7 +38,7 @@ import org.hammerlab.guacamole.reads.{MappedRead, MappedReadSerializer, MateAlig
 import org.hammerlab.guacamole.reference.ReferenceBroadcast.MapBackedReferenceSequence
 import org.hammerlab.guacamole.variants._
 
-class GuacamoleKryoRegistrator extends KryoRegistrator {
+class GuacamoleKryoRegistrar extends KryoRegistrator {
   override def registerClasses(kryo: Kryo) {
 
     // Register ADAM serializers.

--- a/src/main/scala/org/hammerlab/guacamole/kryo/GuacamoleKryoRegistrator.scala
+++ b/src/main/scala/org/hammerlab/guacamole/kryo/GuacamoleKryoRegistrator.scala
@@ -19,35 +19,131 @@
 package org.hammerlab.guacamole.kryo
 
 import com.esotericsoftware.kryo.Kryo
+import org.apache.spark.serializer.KryoRegistrator
+import org.apache.spark.storage.BroadcastBlockId
+import org.bdgenomics.adam.models.{ReferenceRegion, SequenceDictionary, SequenceRecord}
 import org.bdgenomics.adam.serialization.ADAMKryoRegistrator
+import org.bdgenomics.formats.avro.{AlignmentRecord, Genotype => BDGGenotype}
+import org.hammerlab.guacamole.commands.VariantLocus
+import org.hammerlab.guacamole.commands.jointcaller.Parameters.SomaticGenotypePolicy
+import org.hammerlab.guacamole.commands.jointcaller.annotation.{InsufficientNormal, MultiSampleAnnotations, SingleSampleAnnotations, StrandBias}
+import org.hammerlab.guacamole.commands.jointcaller.evidence.{MultiSampleMultiAlleleEvidence, MultiSampleSingleAlleleEvidence, NormalDNASingleSampleSingleAlleleEvidence, TumorDNASingleSampleSingleAlleleEvidence, TumorRNASingleSampleSingleAlleleEvidence}
+import org.hammerlab.guacamole.commands.jointcaller.{AlleleAtLocus, Input, InputCollection, Parameters}
 import org.hammerlab.guacamole.distributed.TaskPosition
+import org.hammerlab.guacamole.loci.SimpleRange
 import org.hammerlab.guacamole.loci.map.{LociMap, Contig => LociMapContig, ContigSerializer => LociMapContigSerializer, Serializer => LociMapSerializer}
 import org.hammerlab.guacamole.loci.set.{LociSet, Contig => LociSetContig, ContigSerializer => LociSetContigSerializer, Serializer => LociSetSerializer}
-import org.hammerlab.guacamole.reads.{MappedRead, MappedReadSerializer, UnmappedRead, UnmappedReadSerializer}
+import org.hammerlab.guacamole.pileup.{Pileup, PileupElement}
+import org.hammerlab.guacamole.reads.{MappedRead, MappedReadSerializer, MateAlignmentProperties, PairedRead, Read, UnmappedRead, UnmappedReadSerializer}
+import org.hammerlab.guacamole.reference.ReferenceBroadcast.MapBackedReferenceSequence
 import org.hammerlab.guacamole.variants._
 
-class GuacamoleKryoRegistrator extends ADAMKryoRegistrator {
+class GuacamoleKryoRegistrator extends KryoRegistrator {
   override def registerClasses(kryo: Kryo) {
-    // For debugging, it can be helpful to uncomment the following line. This will raise an error if we try to serialize
-    // anything without a registered Kryo serializer.
-    // kryo.setRegistrationRequired(true)
-
-    // This allows us to serialize object graphs with cycles. It should default to true, so kind of strange that we have
-    // to set it, but without this line we see infinite recursion.
-    kryo.setReferences(true)
 
     // Register ADAM serializers.
-    super.registerClasses(kryo)
+    new ADAMKryoRegistrator().registerClasses(kryo)
+
+    kryo.register(classOf[Array[BDGGenotype]])
+    kryo.register(classOf[SequenceDictionary])
+    kryo.register(classOf[SequenceRecord])
+
+    kryo.register(classOf[PileupElement])
+    kryo.register(classOf[Array[PileupElement]])
+
+    kryo.register(classOf[NormalDNASingleSampleSingleAlleleEvidence])
+    kryo.register(classOf[TumorDNASingleSampleSingleAlleleEvidence])
+
+    // These are needed for MultiSampleSingleAlleleEvidence; perTumorDnaSampleTopMixtures and probably other fields.
+    kryo.register(Class.forName("scala.collection.immutable.MapLike$$anon$2"))  // MapLike.MappedValues?
+    kryo.register(Class.forName("org.hammerlab.guacamole.commands.jointcaller.evidence.MultiSampleSingleAlleleEvidence$$anonfun$16"))
+    kryo.register(Class.forName("org.hammerlab.guacamole.commands.jointcaller.evidence.MultiSampleSingleAlleleEvidence$$anonfun$10"))
+
+    kryo.register(classOf[Parameters])
+    kryo.register(Class.forName("scala.Enumeration$Val"))
+    kryo.register(SomaticGenotypePolicy.getClass)
+    kryo.register(classOf[MultiSampleAnnotations])
+    kryo.register(classOf[InputCollection])
+    kryo.register(classOf[Input])
+    kryo.register(Input.Analyte.getClass)
+    kryo.register(Input.TissueType.getClass)
+    kryo.register(classOf[InsufficientNormal])
+    kryo.register(classOf[TumorRNASingleSampleSingleAlleleEvidence])
+    kryo.register(Class.forName("org.apache.spark.broadcast.TorrentBroadcast"))
+    kryo.register(classOf[BroadcastBlockId])
+    kryo.register(classOf[Parameters.SomaticGenotypePolicy.Value])
+    kryo.register(classOf[StrandBias])
+    kryo.register(classOf[SingleSampleAnnotations])
+    kryo.register(classOf[AlleleAtLocus])
+    kryo.register(classOf[MultiSampleSingleAlleleEvidence])
+    kryo.register(classOf[MultiSampleMultiAlleleEvidence])
+    kryo.register(classOf[Array[MultiSampleMultiAlleleEvidence]])
+
+    kryo.register(classOf[Pileup])
+    kryo.register(classOf[Array[Pileup]])
+
+    kryo.register(classOf[Array[Seq[_]]])
+
+    kryo.register(classOf[MapBackedReferenceSequence])
 
     // Register Guacamole serializers.
     kryo.register(classOf[MappedRead], new MappedReadSerializer)
+    kryo.register(classOf[Array[MappedRead]])
+    kryo.register(classOf[PairedRead[_]])
+    kryo.register(classOf[MateAlignmentProperties])
+    kryo.register(classOf[Array[Read]])
+    kryo.register(classOf[Array[VariantLocus]])
+    kryo.register(classOf[VariantLocus])
     kryo.register(classOf[UnmappedRead], new UnmappedReadSerializer)
+
     kryo.register(classOf[LociSet], new LociSetSerializer)
     kryo.register(classOf[LociSetContig], new LociSetContigSerializer)
+    kryo.register(classOf[Array[LociSetContig]])
+
     kryo.register(classOf[LociMap[Long]], new LociMapSerializer)
     kryo.register(classOf[LociMapContig[Long]], new LociMapContigSerializer[Long])
+
     kryo.register(classOf[Allele], new AlleleSerializer)
     kryo.register(classOf[Genotype], new GenotypeSerializer)
     kryo.register(classOf[TaskPosition])
+
+    kryo.register(classOf[Array[LociSet]])
+    kryo.register(classOf[Map[_, _]])
+    kryo.register(Map.empty.getClass)
+    kryo.register(scala.math.Numeric.LongIsIntegral.getClass)
+    kryo.register(classOf[SimpleRange])
+    kryo.register(classOf[Array[SimpleRange]])
+
+    kryo.register(classOf[Vector[_]])
+    kryo.register(classOf[Array[Vector[_]]])
+    kryo.register(classOf[scala.collection.mutable.WrappedArray.ofLong])
+    kryo.register(classOf[scala.collection.mutable.WrappedArray.ofByte])
+    kryo.register(classOf[scala.collection.mutable.WrappedArray.ofChar])
+    kryo.register(classOf[Array[Char]])
+
+    // Tuple2[Long, Any], afaict?
+    // "J" == Long (obviously). https://github.com/twitter/chill/blob/6d03f6976f33f6e2e16b8e254fead1625720c281/chill-scala/src/main/scala/com/twitter/chill/TupleSerializers.scala#L861
+    kryo.register(Class.forName("scala.Tuple2$mcJZ$sp"))
+    kryo.register(Class.forName("scala.Tuple2$mcIZ$sp"))
+
+    kryo.register(classOf[Array[String]])
+    kryo.register(classOf[Array[Int]])
+
+    // https://mail-archives.apache.org/mod_mbox/spark-user/201504.mbox/%3CCAC95X6JgXQ3neXF6otj6a+F_MwJ9jbj9P-Ssw3Oqkf518_eT1w@mail.gmail.com%3E
+    kryo.register(Class.forName("scala.reflect.ClassTag$$anon$1"))
+    kryo.register(classOf[java.lang.Class[_]])
+
+    kryo.register(classOf[scala.collection.mutable.WrappedArray.ofRef[_]])
+    kryo.register(classOf[Array[Array[Byte]]])
+
+    kryo.register(classOf[Array[AlignmentRecord]])
+    kryo.register(classOf[ReferenceRegion])
+    kryo.register(classOf[Array[ReferenceRegion]])
+
+    kryo.register(classOf[org.bdgenomics.formats.avro.Strand])
+    kryo.register(classOf[org.bdgenomics.adam.models.MultiContigNonoverlappingRegions])
+    kryo.register(classOf[org.bdgenomics.adam.models.NonoverlappingRegions])
+
+    kryo.register(classOf[Array[Object]])
   }
 }

--- a/src/main/scala/org/hammerlab/guacamole/loci/set/LociSet.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/set/LociSet.scala
@@ -42,7 +42,7 @@ import scala.collection.immutable.TreeMap
 case class LociSet(private val map: SortedMap[String, Contig]) extends TruncatedToString {
 
   /** The contigs included in this LociSet with a nonempty set of loci. */
-  lazy val contigs = map.values.toSeq
+  lazy val contigs = map.values.toArray
 
   /** The number of loci in this LociSet. */
   lazy val count: Long = contigs.map(_.count).sum

--- a/src/main/scala/org/hammerlab/guacamole/loci/set/Serializer.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/set/Serializer.scala
@@ -6,11 +6,11 @@ import com.esotericsoftware.kryo.{Kryo, Serializer => KryoSerializer}
 // We just serialize the underlying contigs, which contain their names which are the string keys of LociSet.map.
 class Serializer extends KryoSerializer[LociSet] {
   def write(kryo: Kryo, output: Output, obj: LociSet) = {
-    kryo.writeClassAndObject(output, obj.contigs)
+    kryo.writeObject(output, obj.contigs)
   }
 
   def read(kryo: Kryo, input: Input, klass: Class[LociSet]): LociSet = {
-    val contigs = kryo.readClassAndObject(input).asInstanceOf[Iterable[Contig]]
+    val contigs = kryo.readObject(input, classOf[Array[Contig]])
     LociSet.fromContigs(contigs)
   }
 }

--- a/src/test/scala/org/hammerlab/guacamole/util/GuacFunSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/GuacFunSuite.scala
@@ -8,7 +8,7 @@ trait GuacFunSuite extends SparkFunSuite with Matchers {
   override val properties: Map[String, String] =
     Map(
       "spark.serializer" -> "org.apache.spark.serializer.KryoSerializer",
-      "spark.kryo.registrator" -> "org.hammerlab.guacamole.kryo.GuacamoleKryoRegistrator",
+      "spark.kryo.registrator" -> "org.hammerlab.guacamole.kryo.GuacamoleKryoRegistrar",
       "spark.kryoserializer.buffer" -> "4",
       "spark.kryo.registrationRequired" -> "true",
       "spark.kryo.referenceTracking" -> "true",

--- a/src/test/scala/org/hammerlab/guacamole/util/GuacFunSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/GuacFunSuite.scala
@@ -10,7 +10,9 @@ trait GuacFunSuite extends SparkFunSuite with Matchers {
       "spark.serializer" -> "org.apache.spark.serializer.KryoSerializer",
       "spark.kryo.registrator" -> "org.hammerlab.guacamole.kryo.GuacamoleKryoRegistrator",
       "spark.kryoserializer.buffer" -> "4",
-      "spark.kryo.referenceTracking" -> "true"
+      "spark.kryo.registrationRequired" -> "true",
+      "spark.kryo.referenceTracking" -> "true",
+      "spark.driver.host" -> "localhost"
     )
 
 }

--- a/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
@@ -26,7 +26,7 @@ import com.twitter.chill.{IKryoRegistrar, KryoInstantiator, KryoPool}
 import htsjdk.samtools.TextCigarCodec
 import org.apache.commons.io.FileUtils
 import org.apache.spark.SparkContext
-import org.hammerlab.guacamole.kryo.GuacamoleKryoRegistrator
+import org.hammerlab.guacamole.kryo.GuacamoleKryoRegistrar
 import org.hammerlab.guacamole.loci.set.LociParser
 import org.hammerlab.guacamole.pileup.Pileup
 import org.hammerlab.guacamole.reads.{InputFilters, MappedRead, MateAlignmentProperties, PairedRead, Read, ReadLoadingConfig}
@@ -52,7 +52,7 @@ object TestUtil {
   // Serialization helper functions.
   lazy val kryoPool = {
     val instantiator = new KryoInstantiator().setRegistrationRequired(true).withRegistrar(new IKryoRegistrar {
-      override def apply(kryo: Kryo): Unit = new GuacamoleKryoRegistrator().registerClasses(kryo)
+      override def apply(kryo: Kryo): Unit = new GuacamoleKryoRegistrar().registerClasses(kryo)
     })
     KryoPool.withByteArrayOutputStream(1, instantiator)
   }


### PR DESCRIPTION
Register a ton of currently unregistered classes.
- unregistered classes are currently serialized with their fully-qualified class name at the front of every record
- I copied a bunch of this from [work I'd done toward this end in Pageant](https://github.com/hammerlab/pageant/blob/045fae6c7f44691f7cac4f21882a46bdce9cd285/src/main/scala/org/hammerlab/pageant/kryo/PageantKryoRegistrar.scala).

As a follow-on, I may try a programmatic whittling down of the class-registrations added here: run `mvn test`, comment out one of them, see if it still passes, if not, uncomment it, run it again, etc.

There *shouldn't* be any missed classes in the below unless a large code path is not covered by any tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/441)
<!-- Reviewable:end -->
