### PR TITLE
Small fixes to joint caller required to load vcf output into pyvcf

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCaller.scala
@@ -157,6 +157,8 @@ object SomaticJoint {
                 includeFiltered: Boolean = false,
                 distributedUtilArguments: LociPartitionUtils.Arguments = new LociPartitionUtils.Arguments {}): RDD[MultiSampleMultiAlleleEvidence] = {
 
+    assume(loci.nonEmpty)
+
     // When mapping over pileups, at locus x we call variants at locus x + 1. Therefore we subtract 1 from the user-
     // specified loci.
     val broadcastForceCallLoci = sc.broadcast(forceCallLoci)

--- a/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCaller.scala
@@ -45,6 +45,8 @@ object SomaticJoint {
     @Args4jOption(name = "-q", usage = "Quiet: less stdout")
     var quiet: Boolean = false
 
+    // For example:
+    //  --header-metadata kind=tuning_test version=4
     @Args4jOption(name = "--header-metadata",
       usage = "Extra header metadata for VCF output in format KEY=VALUE KEY=VALUE ...",
       handler = classOf[StringArrayOptionHandler])

--- a/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/VCFOutput.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/VCFOutput.scala
@@ -34,7 +34,8 @@ object VCFOutput {
                includePooledTumor: Boolean,
                parameters: Parameters,
                sequenceDictionary: SAMSequenceDictionary,
-               reference: ReferenceBroadcast): Unit = {
+               reference: ReferenceBroadcast,
+               extraHeaderMetadata: Seq[(String, String)] = Seq.empty): Unit = {
 
     val writer = new VariantContextWriterBuilder()
       .setOutputFile(path)
@@ -42,7 +43,7 @@ object VCFOutput {
       .build
     val headerLines = new util.HashSet[VCFHeaderLine]()
     headerLines.add(new VCFFormatHeaderLine("GT", 1, VCFHeaderLineType.String, "Genotype"))
-    headerLines.add(new VCFFormatHeaderLine("AD", VCFHeaderLineCount.R, VCFHeaderLineType.Integer,
+    headerLines.add(new VCFFormatHeaderLine("AD", VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.Integer,
       "Allelic depths for the ref and alt alleles"))
     headerLines.add(new VCFFormatHeaderLine("PL", VCFHeaderLineCount.G, VCFHeaderLineType.Integer,
       "Phred scaled genotype likelihoods"))
@@ -77,6 +78,10 @@ object VCFOutput {
     parameters.asStringPairs.foreach(kv => {
       header.addMetaDataLine(new VCFHeaderLine("parameter." + kv._1, kv._2))
     })
+    extraHeaderMetadata.foreach(kv => {
+      header.addMetaDataLine(new VCFHeaderLine(kv._1, kv._2))
+    })
+    header.addMetaDataLine(new VCFHeaderLine("reference", reference.source))
     writer.writeHeader(header)
 
     val sortedEvidences = calls.flatMap(_.singleAlleleEvidences).sortBy(e => (e.allele.referenceContig, e.allele.start))

--- a/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/VCFOutput.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/VCFOutput.scala
@@ -79,7 +79,9 @@ object VCFOutput {
     extraHeaderMetadata.foreach(kv => {
       header.addMetaDataLine(new VCFHeaderLine(kv._1, kv._2))
     })
-    header.addMetaDataLine(new VCFHeaderLine("reference", reference.source))
+    if (reference.source.isDefined) {
+      header.addMetaDataLine(new VCFHeaderLine("reference", reference.source.get))
+    }
     writer.writeHeader(header)
 
     val sortedEvidences = calls.flatMap(_.singleAlleleEvidences).sortBy(e => (e.allele.referenceContig, e.allele.start))

--- a/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/VCFOutput.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/VCFOutput.scala
@@ -230,7 +230,7 @@ object VCFOutput {
       .stop(allele.end) // +1 for one-based and -1 for inclusive
       .genotypes(JavaConversions.seqAsJavaList(genotypes))
       .alleles(JavaConversions.seqAsJavaList(variantGenotypeAlleles.distinct.map(makeHtsjdkAllele _)))
-      .attribute("TRIGGER", triggers.mkString(","))
+      .attribute("TRIGGER", if (triggers.nonEmpty) triggers.mkString(",") else "NONE")
       .attribute("TUMOR_EXPRESSION", if (samplesEvidence.tumorRnaSampleExpressed.nonEmpty) "YES" else "NO")
 
     val failingFilterNames = samplesEvidence.failingFilterNames

--- a/src/main/scala/org/hammerlab/guacamole/distributed/LociPartitionUtils.scala
+++ b/src/main/scala/org/hammerlab/guacamole/distributed/LociPartitionUtils.scala
@@ -26,6 +26,7 @@ object LociPartitionUtils {
   def partitionLociAccordingToArgs[M <: HasReferenceRegion: ClassTag](args: Arguments,
                                                                       loci: LociSet,
                                                                       regionRDDs: RDD[M]*): LociMap[Long] = {
+    assume(loci.nonEmpty)
     val sc = regionRDDs.head.sparkContext
     val tasks = if (args.parallelism > 0) args.parallelism else sc.defaultParallelism
     if (args.partitioningAccuracy == 0) {

--- a/src/main/scala/org/hammerlab/guacamole/reference/ReferenceBroadcast.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reference/ReferenceBroadcast.scala
@@ -11,7 +11,7 @@ import org.hammerlab.guacamole.loci.LociSet
 
 import scala.collection.mutable
 
-case class ReferenceBroadcast(broadcastedContigs: Map[String, ContigSequence]) extends ReferenceGenome {
+case class ReferenceBroadcast(broadcastedContigs: Map[String, ContigSequence], source: String) extends ReferenceGenome {
   override def getContig(contigName: String): ContigSequence = {
     try {
       broadcastedContigs(contigName)
@@ -74,7 +74,7 @@ object ReferenceBroadcast {
       broadcastedSequences += ((sequenceName, broadcastedSequence))
       nextSequence = referenceFasta.nextSequence()
     }
-    ReferenceBroadcast(broadcastedSequences.result)
+    ReferenceBroadcast(broadcastedSequences.result, fastaPath)
   }
 
   /**
@@ -131,8 +131,10 @@ object ReferenceBroadcast {
         })
       }
     })
-    new ReferenceBroadcast(result.map(
-      pair => pair._1 -> MapBackedReferenceSequence(contigLengths(pair._1), sc.broadcast(pair._2.toMap))).toMap)
+    new ReferenceBroadcast(
+      result.map(
+        pair => pair._1 -> MapBackedReferenceSequence(contigLengths(pair._1), sc.broadcast(pair._2.toMap))).toMap,
+      fastaPath)
   }
 
   /**
@@ -155,6 +157,10 @@ object ReferenceBroadcast {
       cache.put(fastaPath, (sc, result))
       result
     }
+  }
+
+  def apply(broadcastedContigs: Map[String, ContigSequence]): ReferenceBroadcast = {
+    ReferenceBroadcast(broadcastedContigs, source = "unknown_source")
   }
 }
 

--- a/src/main/scala/org/hammerlab/guacamole/reference/ReferenceBroadcast.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reference/ReferenceBroadcast.scala
@@ -11,7 +11,7 @@ import org.hammerlab.guacamole.loci.LociSet
 
 import scala.collection.mutable
 
-case class ReferenceBroadcast(broadcastedContigs: Map[String, ContigSequence], source: String) extends ReferenceGenome {
+case class ReferenceBroadcast(broadcastedContigs: Map[String, ContigSequence], source: Option[String]) extends ReferenceGenome {
   override def getContig(contigName: String): ContigSequence = {
     try {
       broadcastedContigs(contigName)
@@ -74,7 +74,7 @@ object ReferenceBroadcast {
       broadcastedSequences += ((sequenceName, broadcastedSequence))
       nextSequence = referenceFasta.nextSequence()
     }
-    ReferenceBroadcast(broadcastedSequences.result, fastaPath)
+    ReferenceBroadcast(broadcastedSequences.result, Some(fastaPath))
   }
 
   /**
@@ -134,7 +134,7 @@ object ReferenceBroadcast {
     new ReferenceBroadcast(
       result.map(
         pair => pair._1 -> MapBackedReferenceSequence(contigLengths(pair._1), sc.broadcast(pair._2.toMap))).toMap,
-      fastaPath)
+      Some(fastaPath))
   }
 
   /**
@@ -160,7 +160,7 @@ object ReferenceBroadcast {
   }
 
   def apply(broadcastedContigs: Map[String, ContigSequence]): ReferenceBroadcast = {
-    ReferenceBroadcast(broadcastedContigs, source = "unknown_source")
+    ReferenceBroadcast(broadcastedContigs, source = None)
   }
 }
 

--- a/src/main/scala/org/hammerlab/guacamole/reference/ReferenceGenome.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reference/ReferenceGenome.scala
@@ -7,12 +7,12 @@ import org.hammerlab.guacamole.Bases
 trait ReferenceGenome {
 
   /**
-    * Path where this reference was loaded from, or other description of its provenance.
+    * Path where this reference was loaded from, or other description of its provenance (optional).
     *
     * For provenance tracking only. Not guaranteed to be a valid path or on a filesystem that is currently accessible.
     *
     */
-  val source: String
+  val source: Option[String]
 
   /**
    * Retrieve a full contig/chromosome sequence

--- a/src/main/scala/org/hammerlab/guacamole/reference/ReferenceGenome.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reference/ReferenceGenome.scala
@@ -7,6 +7,14 @@ import org.hammerlab.guacamole.Bases
 trait ReferenceGenome {
 
   /**
+    * Path where this reference was loaded from, or other description of its provenance.
+    *
+    * For provenance tracking only. Not guaranteed to be a valid path or on a filesystem that is currently accessible.
+    *
+    */
+  val source: String
+
+  /**
    * Retrieve a full contig/chromosome sequence
    *
    * @param contigName contig/chromosome to retrieve reference sequence from

--- a/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
@@ -85,7 +85,7 @@ object TestUtil extends Matchers {
         map.put(contig, MapBackedReferenceSequence(contigLengths, sc.broadcast(locusToBase)))
       }
     })
-    new ReferenceBroadcast(map.toMap, source="test_values")
+    new ReferenceBroadcast(map.toMap, source=Some("test_values"))
   }
 
   def makeRead(sequence: String,

--- a/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
@@ -85,7 +85,7 @@ object TestUtil extends Matchers {
         map.put(contig, MapBackedReferenceSequence(contigLengths, sc.broadcast(locusToBase)))
       }
     })
-    new ReferenceBroadcast(map.toMap)
+    new ReferenceBroadcast(map.toMap, source="test_values")
   }
 
   def makeRead(sequence: String,


### PR DESCRIPTION
A few joint caller VCF output fixes
 * change some attributes that had spaces in the values, which was confusing `pyvcf`
 * add reference fasta path to VCF output so `varcode` can guess the reference genome (required adding a field to `ReferenceGenome` to record this in)
 * support user specified metadata in VCF output (example use: record which guacamole git sha1 was used to generate the file)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/448)
<!-- Reviewable:end -->
