### PR TITLE
factor out, comment some kryo registrations

### DIFF
--- a/scripts/guacamole-spark-defaults.conf
+++ b/scripts/guacamole-spark-defaults.conf
@@ -1,4 +1,4 @@
 spark.serializer               org.apache.spark.serializer.KryoSerializer
-spark.kryo.registrator         org.hammerlab.guacamole.kryo.GuacamoleKryoRegistrator
+spark.kryo.registrator         org.hammerlab.guacamole.kryo.Registrar
 spark.kryoserializer.buffer.mb 4
 spark.kryo.referenceTracking   true

--- a/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/kryo/Registrar.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/kryo/Registrar.scala
@@ -1,0 +1,38 @@
+package org.hammerlab.guacamole.commands.jointcaller.kryo
+
+import com.esotericsoftware.kryo.Kryo
+import org.apache.spark.serializer.KryoRegistrator
+import org.hammerlab.guacamole.commands.jointcaller.Parameters.SomaticGenotypePolicy
+import org.hammerlab.guacamole.commands.jointcaller.annotation.{InsufficientNormal, MultiSampleAnnotations, SingleSampleAnnotations, StrandBias}
+import org.hammerlab.guacamole.commands.jointcaller.evidence.{MultiSampleMultiAlleleEvidence, MultiSampleSingleAlleleEvidence, NormalDNASingleSampleSingleAlleleEvidence, TumorDNASingleSampleSingleAlleleEvidence, TumorRNASingleSampleSingleAlleleEvidence}
+import org.hammerlab.guacamole.commands.jointcaller.{AlleleAtLocus, Input, InputCollection, Parameters}
+
+class Registrar extends KryoRegistrator {
+  override def registerClasses(kryo: Kryo): Unit = {
+    kryo.register(classOf[NormalDNASingleSampleSingleAlleleEvidence])
+    kryo.register(classOf[TumorDNASingleSampleSingleAlleleEvidence])
+
+    // These are needed for MultiSampleSingleAlleleEvidence; perTumorDnaSampleTopMixtures and probably other fields.
+    kryo.register(Class.forName("scala.collection.immutable.MapLike$$anon$2"))  // MapLike.MappedValues?
+    kryo.register(Class.forName("org.hammerlab.guacamole.commands.jointcaller.evidence.MultiSampleSingleAlleleEvidence$$anonfun$16"))
+    kryo.register(Class.forName("org.hammerlab.guacamole.commands.jointcaller.evidence.MultiSampleSingleAlleleEvidence$$anonfun$10"))
+
+    kryo.register(classOf[Parameters])
+    kryo.register(Class.forName("scala.Enumeration$Val"))
+    kryo.register(SomaticGenotypePolicy.getClass)
+    kryo.register(classOf[MultiSampleAnnotations])
+    kryo.register(classOf[InputCollection])
+    kryo.register(classOf[Input])
+    kryo.register(Input.Analyte.getClass)
+    kryo.register(Input.TissueType.getClass)
+    kryo.register(classOf[InsufficientNormal])
+    kryo.register(classOf[TumorRNASingleSampleSingleAlleleEvidence])
+    kryo.register(classOf[Parameters.SomaticGenotypePolicy.Value])
+    kryo.register(classOf[StrandBias])
+    kryo.register(classOf[SingleSampleAnnotations])
+    kryo.register(classOf[AlleleAtLocus])
+    kryo.register(classOf[MultiSampleSingleAlleleEvidence])
+    kryo.register(classOf[MultiSampleMultiAlleleEvidence])
+    kryo.register(classOf[Array[MultiSampleMultiAlleleEvidence]])
+  }
+}

--- a/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/kryo/Registrar.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/kryo/Registrar.scala
@@ -16,6 +16,7 @@ class Registrar extends KryoRegistrator {
     kryo.register(Class.forName("scala.collection.immutable.MapLike$$anon$2"))  // MapLike.MappedValues?
     kryo.register(Class.forName("org.hammerlab.guacamole.commands.jointcaller.evidence.MultiSampleSingleAlleleEvidence$$anonfun$16"))
     kryo.register(Class.forName("org.hammerlab.guacamole.commands.jointcaller.evidence.MultiSampleSingleAlleleEvidence$$anonfun$10"))
+    kryo.register(Map.empty.getClass)
 
     kryo.register(classOf[Parameters])
     kryo.register(Class.forName("scala.Enumeration$Val"))

--- a/src/main/scala/org/hammerlab/guacamole/kryo/GuacamoleKryoRegistrar.scala
+++ b/src/main/scala/org/hammerlab/guacamole/kryo/GuacamoleKryoRegistrar.scala
@@ -25,15 +25,11 @@ import org.bdgenomics.adam.models.{ReferenceRegion, SequenceDictionary, Sequence
 import org.bdgenomics.adam.serialization.ADAMKryoRegistrator
 import org.bdgenomics.formats.avro.{AlignmentRecord, Genotype => BDGGenotype}
 import org.hammerlab.guacamole.commands.VariantLocus
-import org.hammerlab.guacamole.commands.jointcaller.Parameters.SomaticGenotypePolicy
-import org.hammerlab.guacamole.commands.jointcaller.annotation.{InsufficientNormal, MultiSampleAnnotations, SingleSampleAnnotations, StrandBias}
-import org.hammerlab.guacamole.commands.jointcaller.evidence.{MultiSampleMultiAlleleEvidence, MultiSampleSingleAlleleEvidence, NormalDNASingleSampleSingleAlleleEvidence, TumorDNASingleSampleSingleAlleleEvidence, TumorRNASingleSampleSingleAlleleEvidence}
-import org.hammerlab.guacamole.commands.jointcaller.{AlleleAtLocus, Input, InputCollection, Parameters}
+import org.hammerlab.guacamole.commands.jointcaller.kryo.{Registrar => JointCallerRegistrar}
 import org.hammerlab.guacamole.distributed.TaskPosition
 import org.hammerlab.guacamole.loci.SimpleRange
 import org.hammerlab.guacamole.loci.map.{LociMap, Contig => LociMapContig, ContigSerializer => LociMapContigSerializer, Serializer => LociMapSerializer}
 import org.hammerlab.guacamole.loci.set.{LociSet, Contig => LociSetContig, ContigSerializer => LociSetContigSerializer, Serializer => LociSetSerializer}
-import org.hammerlab.guacamole.pileup.{Pileup, PileupElement}
 import org.hammerlab.guacamole.reads.{MappedRead, MappedReadSerializer, MateAlignmentProperties, PairedRead, Read, UnmappedRead, UnmappedReadSerializer}
 import org.hammerlab.guacamole.reference.ReferenceBroadcast.MapBackedReferenceSequence
 import org.hammerlab.guacamole.variants._
@@ -44,111 +40,75 @@ class GuacamoleKryoRegistrar extends KryoRegistrator {
     // Register ADAM serializers.
     new ADAMKryoRegistrator().registerClasses(kryo)
 
-    kryo.register(classOf[Array[BDGGenotype]])
+    // Register Joint-Caller serializers.
+    new JointCallerRegistrar().registerClasses(kryo)
+
+    // SequenceDictionary (and its records) are serialized when loading Reads from ADAM, in
+    // Read.ADAMSequenceDictionaryRDDAggregator. ADAM should register these itself.
     kryo.register(classOf[SequenceDictionary])
     kryo.register(classOf[SequenceRecord])
 
-    kryo.register(classOf[PileupElement])
-    kryo.register(classOf[Array[PileupElement]])
-
-    kryo.register(classOf[NormalDNASingleSampleSingleAlleleEvidence])
-    kryo.register(classOf[TumorDNASingleSampleSingleAlleleEvidence])
-
-    // These are needed for MultiSampleSingleAlleleEvidence; perTumorDnaSampleTopMixtures and probably other fields.
-    kryo.register(Class.forName("scala.collection.immutable.MapLike$$anon$2"))  // MapLike.MappedValues?
-    kryo.register(Class.forName("org.hammerlab.guacamole.commands.jointcaller.evidence.MultiSampleSingleAlleleEvidence$$anonfun$16"))
-    kryo.register(Class.forName("org.hammerlab.guacamole.commands.jointcaller.evidence.MultiSampleSingleAlleleEvidence$$anonfun$10"))
-
-    kryo.register(classOf[Parameters])
-    kryo.register(Class.forName("scala.Enumeration$Val"))
-    kryo.register(SomaticGenotypePolicy.getClass)
-    kryo.register(classOf[MultiSampleAnnotations])
-    kryo.register(classOf[InputCollection])
-    kryo.register(classOf[Input])
-    kryo.register(Input.Analyte.getClass)
-    kryo.register(Input.TissueType.getClass)
-    kryo.register(classOf[InsufficientNormal])
-    kryo.register(classOf[TumorRNASingleSampleSingleAlleleEvidence])
-    kryo.register(Class.forName("org.apache.spark.broadcast.TorrentBroadcast"))
-    kryo.register(classOf[BroadcastBlockId])
-    kryo.register(classOf[Parameters.SomaticGenotypePolicy.Value])
-    kryo.register(classOf[StrandBias])
-    kryo.register(classOf[SingleSampleAnnotations])
-    kryo.register(classOf[AlleleAtLocus])
-    kryo.register(classOf[MultiSampleSingleAlleleEvidence])
-    kryo.register(classOf[MultiSampleMultiAlleleEvidence])
-    kryo.register(classOf[Array[MultiSampleMultiAlleleEvidence]])
-
-    kryo.register(classOf[Pileup])
-    kryo.register(classOf[Array[Pileup]])
-
-    kryo.register(classOf[Array[Seq[_]]])
-
-    kryo.register(classOf[MapBackedReferenceSequence])
-
-    // Register Guacamole serializers.
     kryo.register(classOf[MappedRead], new MappedReadSerializer)
     kryo.register(classOf[Array[MappedRead]])
     kryo.register(classOf[PairedRead[_]])
     kryo.register(classOf[MateAlignmentProperties])
     kryo.register(classOf[Array[Read]])
-    kryo.register(classOf[Array[VariantLocus]])
-    kryo.register(classOf[VariantLocus])
     kryo.register(classOf[UnmappedRead], new UnmappedReadSerializer)
 
+    // LociSet is serialized when broadcast in InputFilters.filterRDD. Serde'ing a LociSet delegates to an Array of
+    // Contigs.
     kryo.register(classOf[LociSet], new LociSetSerializer)
+    kryo.register(classOf[Array[LociSet]])
     kryo.register(classOf[LociSetContig], new LociSetContigSerializer)
     kryo.register(classOf[Array[LociSetContig]])
 
+    // LociMap is serialized when broadcast in LociPartitionUtils.partitionLociByApproximateDepth.
     kryo.register(classOf[LociMap[Long]], new LociMapSerializer)
     kryo.register(classOf[LociMapContig[Long]], new LociMapContigSerializer[Long])
 
-    kryo.register(classOf[Allele], new AlleleSerializer)
-    kryo.register(classOf[Genotype], new GenotypeSerializer)
-    kryo.register(classOf[TaskPosition])
-
-    // Germline-assembly caller flatmaps some CalledAlleles.
-    kryo.register(classOf[Array[CalledAllele]])
-    kryo.register(classOf[CalledAllele])
-    kryo.register(classOf[AlleleEvidence])
-
-    kryo.register(classOf[Array[LociSet]])
-    kryo.register(classOf[Map[_, _]])
-    kryo.register(Map.empty.getClass)
-    kryo.register(scala.math.Numeric.LongIsIntegral.getClass)
     kryo.register(classOf[SimpleRange])
     kryo.register(classOf[Array[SimpleRange]])
 
+    kryo.register(classOf[TaskPosition])
+
+    kryo.register(classOf[Array[VariantLocus]])
+    kryo.register(classOf[VariantLocus])
+
+    kryo.register(classOf[Genotype], new GenotypeSerializer)
+
+    // Germline-assembly caller flatmaps some CalledAlleles.
+    kryo.register(classOf[Array[CalledAllele]])
+    kryo.register(classOf[Allele], new AlleleSerializer)
+    kryo.register(classOf[CalledAllele])
+    kryo.register(classOf[AlleleEvidence])
+
+    kryo.register(classOf[Map[_, _]])
+    kryo.register(Map.empty.getClass)
+    kryo.register(scala.math.Numeric.LongIsIntegral.getClass)
+
     kryo.register(classOf[Vector[_]])
     kryo.register(classOf[Array[Vector[_]]])
+
+    kryo.register(classOf[Array[Seq[_]]])
+
     kryo.register(classOf[scala.collection.mutable.WrappedArray.ofLong])
     kryo.register(classOf[scala.collection.mutable.WrappedArray.ofByte])
     kryo.register(classOf[scala.collection.mutable.WrappedArray.ofChar])
+    kryo.register(classOf[scala.collection.mutable.WrappedArray.ofRef[_]])
+
+    kryo.register(classOf[Array[Array[Byte]]])
     kryo.register(classOf[Array[Char]])
+    kryo.register(classOf[Array[String]])
+    kryo.register(classOf[Array[Int]])
+    kryo.register(classOf[Array[Object]])
 
     // Tuple2[Long, Any], afaict?
     // "J" == Long (obviously). https://github.com/twitter/chill/blob/6d03f6976f33f6e2e16b8e254fead1625720c281/chill-scala/src/main/scala/com/twitter/chill/TupleSerializers.scala#L861
     kryo.register(Class.forName("scala.Tuple2$mcJZ$sp"))
     kryo.register(Class.forName("scala.Tuple2$mcIZ$sp"))
 
-    kryo.register(classOf[Array[String]])
-    kryo.register(classOf[Array[Int]])
-
     // https://mail-archives.apache.org/mod_mbox/spark-user/201504.mbox/%3CCAC95X6JgXQ3neXF6otj6a+F_MwJ9jbj9P-Ssw3Oqkf518_eT1w@mail.gmail.com%3E
     kryo.register(Class.forName("scala.reflect.ClassTag$$anon$1"))
     kryo.register(classOf[java.lang.Class[_]])
-
-    kryo.register(classOf[scala.collection.mutable.WrappedArray.ofRef[_]])
-    kryo.register(classOf[Array[Array[Byte]]])
-
-    kryo.register(classOf[Array[AlignmentRecord]])
-    kryo.register(classOf[ReferenceRegion])
-    kryo.register(classOf[Array[ReferenceRegion]])
-
-    kryo.register(classOf[org.bdgenomics.formats.avro.Strand])
-    kryo.register(classOf[org.bdgenomics.adam.models.MultiContigNonoverlappingRegions])
-    kryo.register(classOf[org.bdgenomics.adam.models.NonoverlappingRegions])
-
-    kryo.register(classOf[Array[Object]])
   }
 }

--- a/src/main/scala/org/hammerlab/guacamole/kryo/Registrar.scala
+++ b/src/main/scala/org/hammerlab/guacamole/kryo/Registrar.scala
@@ -29,7 +29,7 @@ import org.hammerlab.guacamole.loci.set.{LociSet, Contig => LociSetContig, Conti
 import org.hammerlab.guacamole.reads.{MappedRead, MappedReadSerializer, MateAlignmentProperties, PairedRead, Read, UnmappedRead, UnmappedReadSerializer}
 import org.hammerlab.guacamole.variants.{Allele, AlleleEvidence, AlleleSerializer, CalledAllele}
 
-class GuacamoleKryoRegistrar extends KryoRegistrator {
+class Registrar extends KryoRegistrator {
   override def registerClasses(kryo: Kryo) {
 
     // Register ADAM serializers.

--- a/src/main/scala/org/hammerlab/guacamole/pileup/Pileup.scala
+++ b/src/main/scala/org/hammerlab/guacamole/pileup/Pileup.scala
@@ -34,7 +34,11 @@ import org.hammerlab.guacamole.variants.{Allele, Genotype}
  * @param elements Sequence of [[PileupElement]] instances giving the sequenced bases that align to a particular
  *                 reference locus, in arbitrary order.
  */
-case class Pileup(referenceName: String, locus: Long, referenceContigSequence: ContigSequence, elements: Seq[PileupElement]) {
+case class Pileup(referenceName: String,
+                  locus: Long,
+                  referenceContigSequence: ContigSequence,
+                  elements: Seq[PileupElement]) {
+
   val referenceBase: Byte = referenceContigSequence(locus.toInt)
 
   /** The first element in the pileup. */

--- a/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
@@ -278,11 +278,13 @@ object Read extends Logging {
 
     val adamRecords: RDD[AlignmentRecord] = adamContext.loadAlignments(
       filename, projection = None, stringency = ValidationStringency.LENIENT).rdd
+
     val sequenceDictionary =
       new ADAMSpecificRecordSequenceDictionaryRDDAggregator(adamRecords).adamGetSequenceDictionary()
 
     val allReads: RDD[Read] = adamRecords.map(fromADAMRecord(_))
     val reads = InputFilters.filterRDD(filters, allReads, sequenceDictionary)
+
     (reads, sequenceDictionary)
   }
 

--- a/src/test/scala/org/hammerlab/guacamole/commands/VAFHistogramSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/VAFHistogramSuite.scala
@@ -1,9 +1,19 @@
 package org.hammerlab.guacamole.commands
 
-import org.hammerlab.guacamole.util.GuacFunSuite
+import com.esotericsoftware.kryo.Kryo
+import org.hammerlab.guacamole.util.{GuacFunSuite, KryoTestRegistrar}
 import org.scalatest.Matchers
 
+class VAFHistogramSuiteRegistrar extends KryoTestRegistrar {
+  override def registerTestClasses(kryo: Kryo): Unit = {
+    kryo.register(classOf[Array[VariantLocus]])
+    kryo.register(classOf[VariantLocus])
+  }
+}
+
 class VAFHistogramSuite extends GuacFunSuite {
+
+  override def registrar = "org.hammerlab.guacamole.commands.VAFHistogramSuiteRegistrar"
 
   test("generating the histogram") {
 

--- a/src/test/scala/org/hammerlab/guacamole/distributed/PileupFlatMapUtilsSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/distributed/PileupFlatMapUtilsSuite.scala
@@ -18,11 +18,31 @@
 
 package org.hammerlab.guacamole.distributed
 
+import com.esotericsoftware.kryo.Kryo
+import org.apache.spark.storage.BroadcastBlockId
 import org.hammerlab.guacamole.loci.set.LociSet
 import org.hammerlab.guacamole.pileup.{Pileup, PileupElement}
-import org.hammerlab.guacamole.util.{AssertBases, Bases, GuacFunSuite, TestUtil}
+import org.hammerlab.guacamole.reference.ReferenceBroadcast.MapBackedReferenceSequence
+import org.hammerlab.guacamole.util.{AssertBases, Bases, GuacFunSuite, KryoTestRegistrar, TestUtil}
+
+class PileupFlatMapUtilsSuiteRegistrar extends KryoTestRegistrar {
+  override def registerTestClasses(kryo: Kryo): Unit = {
+    // In some test cases below, we serialize Pileups, which requires PileupElements and MapBackedReferenceSequences.
+    kryo.register(classOf[Pileup])
+    kryo.register(classOf[Array[Pileup]])
+
+    kryo.register(classOf[PileupElement])
+    kryo.register(classOf[Array[PileupElement]])
+
+    kryo.register(classOf[MapBackedReferenceSequence])
+    kryo.register(Class.forName("org.apache.spark.broadcast.TorrentBroadcast"))
+    kryo.register(classOf[BroadcastBlockId])
+  }
+}
 
 class PileupFlatMapUtilsSuite extends GuacFunSuite {
+
+  override def registrar: String = "org.hammerlab.guacamole.distributed.PileupFlatMapUtilsSuiteRegistrar"
 
   test("test pileup flatmap parallelism 0; create pileups") {
 
@@ -254,6 +274,6 @@ class PileupFlatMapUtilsSuite extends GuacFunSuite {
 
     pileups.length should be(24)
     val insertionPileups = pileups.filter(_.isInsertion)
-    insertionPileups.size should be(1)
+    insertionPileups.length should be(1)
   }
 }

--- a/src/test/scala/org/hammerlab/guacamole/distributed/PileupFlatMapUtilsSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/distributed/PileupFlatMapUtilsSuite.scala
@@ -34,9 +34,14 @@ class PileupFlatMapUtilsSuiteRegistrar extends KryoTestRegistrar {
     kryo.register(classOf[PileupElement])
     kryo.register(classOf[Array[PileupElement]])
 
+    // Closed over by PileupElement
     kryo.register(classOf[MapBackedReferenceSequence])
     kryo.register(Class.forName("org.apache.spark.broadcast.TorrentBroadcast"))
     kryo.register(classOf[BroadcastBlockId])
+    kryo.register(classOf[Map[_, _]])
+
+    // "test pileup flatmap multiple rdds; skip empty pileups" collects an RDD of Arrays
+    kryo.register(classOf[Array[Seq[_]]])
   }
 }
 

--- a/src/test/scala/org/hammerlab/guacamole/loci/set/LociSetSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/loci/set/LociSetSuite.scala
@@ -196,13 +196,4 @@ class LociSetSuite extends GuacFunSuite {
     iter3.next() should be(100000000000L - 1L)
     iter3.hasNext() should be(false)
   }
-
-  // We do not provide java serialization for LociSet, instead broadcasting it (which uses Kryo serialization).
-  test("serialization: a closure that includes a LociSet") {
-    val set = LociSet("chr21:100-200,chr20:0-10,chr20:8-15,chr20:100-120,empty:10-10")
-    val setBC = sc.broadcast(set)
-    val rdd = sc.parallelize(0L until 1000L)
-    val result = rdd.filter(i => setBC.value.onContig("chr21").contains(i)).collect
-    result should equal(100L until 200)
-  }
 }

--- a/src/test/scala/org/hammerlab/guacamole/reads/MappedReadSerializerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/MappedReadSerializerSuite.scala
@@ -24,7 +24,7 @@ import org.hammerlab.guacamole.util.{GuacFunSuite, TestUtil}
 
 class MappedReadSerializerSuite extends GuacFunSuite {
 
-  test("serialize / deserialize mapped read") {
+  test("mapped read") {
     val read = MappedRead(
       "read1",
       "TCGACCCTCGA",
@@ -40,8 +40,8 @@ class MappedReadSerializerSuite extends GuacFunSuite {
       isPaired = true
     )
 
-    val serialized = TestUtil.serialize(read)
-    val deserialized = TestUtil.deserialize[MappedRead](serialized)
+    val serialized = serialize(read)
+    val deserialized = deserialize[MappedRead](serialized)
 
     // We *should* be able to just use MappedRead's equality implementation, since Scala should implement the equals
     // method for case classes. Somehow, something goes wrong though, and this fails:
@@ -63,7 +63,7 @@ class MappedReadSerializerSuite extends GuacFunSuite {
     deserialized.isPaired should equal(read.isPaired)
   }
 
-  test("serialize / deserialize mapped read with mdtag") {
+  test("mapped read with mdtag") {
     val read = MappedRead(
       "read1",
       "TCGACCCTCGA",
@@ -79,8 +79,8 @@ class MappedReadSerializerSuite extends GuacFunSuite {
       isPaired = true
     )
 
-    val serialized = TestUtil.serialize(read)
-    val deserialized = TestUtil.deserialize[MappedRead](serialized)
+    val serialized = serialize(read)
+    val deserialized = deserialize[MappedRead](serialized)
 
     // We *should* be able to just use MappedRead's equality implementation, since Scala should implement the equals
     // method for case classes. Somehow, something goes wrong though, and this fails:
@@ -102,7 +102,7 @@ class MappedReadSerializerSuite extends GuacFunSuite {
     deserialized.isPaired should equal(read.isPaired)
   }
 
-  test("serialize / deserialize mapped read with unmapped pair") {
+  test("mapped read with unmapped pair") {
     val read = MappedRead(
       "read1",
       "TCGACCCTCGA",
@@ -118,8 +118,8 @@ class MappedReadSerializerSuite extends GuacFunSuite {
       isPaired = true
     )
 
-    val serialized = TestUtil.serialize(read)
-    val deserialized = TestUtil.deserialize[MappedRead](serialized)
+    val serialized = serialize(read)
+    val deserialized = deserialize[MappedRead](serialized)
 
     // We *should* be able to just use MappedRead's equality implementation, since Scala should implement the equals
     // method for case classes. Somehow, something goes wrong though, and this fails:

--- a/src/test/scala/org/hammerlab/guacamole/reads/ReadSetSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/ReadSetSuite.scala
@@ -148,8 +148,8 @@ class ReadSetSuite extends GuacFunSuite {
 
   test("load and serialize / deserialize reads") {
     val reads = TestUtil.loadReads(sc, "mdtagissue.sam", InputFilters(mapped = true)).mappedReads.collect()
-    val serializedReads = reads.map(TestUtil.serialize)
-    val deserializedReads: Seq[MappedRead] = serializedReads.map(TestUtil.deserialize[MappedRead](_))
+    val serializedReads = reads.map(serialize)
+    val deserializedReads: Seq[MappedRead] = serializedReads.map(deserialize[MappedRead](_))
     for ((read, deserialized) <- reads.zip(deserializedReads)) {
       deserialized.referenceContig should equal(read.referenceContig)
       deserialized.alignmentQuality should equal(read.alignmentQuality)

--- a/src/test/scala/org/hammerlab/guacamole/reads/UnmappedReadSerializerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/UnmappedReadSerializerSuite.scala
@@ -34,8 +34,8 @@ class UnmappedReadSerializerSuite extends GuacFunSuite {
       isPaired = true
     )
 
-    val serialized = TestUtil.serialize(read)
-    val deserialized = TestUtil.deserialize[UnmappedRead](serialized)
+    val serialized = serialize(read)
+    val deserialized = deserialize[UnmappedRead](serialized)
 
     // We *should* be able to just use MappedRead's equality implementation, since Scala should implement the equals
     // method for case classes. Somehow, something goes wrong though, and this fails:

--- a/src/test/scala/org/hammerlab/guacamole/util/GuacFunSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/GuacFunSuite.scala
@@ -6,7 +6,7 @@ import org.scalatest.{FunSuite, Matchers}
 trait GuacFunSuite extends FunSuite with SharedSparkContext with Matchers with SparkSerializerSuite {
   conf.setAppName("guacamole")
 
-  def registrar = "org.hammerlab.guacamole.kryo.GuacamoleKryoRegistrar"
+  def registrar = "org.hammerlab.guacamole.kryo.Registrar"
 
   val properties: Map[String, String] =
     Map(

--- a/src/test/scala/org/hammerlab/guacamole/util/GuacFunSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/GuacFunSuite.scala
@@ -3,10 +3,10 @@ package org.hammerlab.guacamole.util
 import com.holdenkarau.spark.testing.SharedSparkContext
 import org.scalatest.{FunSuite, Matchers}
 
-trait GuacFunSuite extends FunSuite with SharedSparkContext with Matchers {
+trait GuacFunSuite extends FunSuite with SharedSparkContext with Matchers with SparkSerializerSuite {
   conf.setAppName("guacamole")
 
-  def registrar = "org.hammerlab.guacamole.util.KryoTestRegistrar"
+  def registrar = "org.hammerlab.guacamole.kryo.GuacamoleKryoRegistrar"
 
   val properties: Map[String, String] =
     Map(

--- a/src/test/scala/org/hammerlab/guacamole/util/GuacFunSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/GuacFunSuite.scala
@@ -6,10 +6,12 @@ import org.scalatest.{FunSuite, Matchers}
 trait GuacFunSuite extends FunSuite with SharedSparkContext with Matchers {
   conf.setAppName("guacamole")
 
+  def registrar = "org.hammerlab.guacamole.util.KryoTestRegistrar"
+
   val properties: Map[String, String] =
     Map(
       "spark.serializer" -> "org.apache.spark.serializer.KryoSerializer",
-      "spark.kryo.registrator" -> "org.hammerlab.guacamole.kryo.GuacamoleKryoRegistrar",
+      "spark.kryo.registrator" -> registrar,
       "spark.kryoserializer.buffer" -> "4",
       "spark.kryo.registrationRequired" -> "true",
       "spark.kryo.referenceTracking" -> "true",

--- a/src/test/scala/org/hammerlab/guacamole/util/KryoTestRegistrar.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/KryoTestRegistrar.scala
@@ -4,9 +4,9 @@ import com.esotericsoftware.kryo.Kryo
 import org.apache.spark.serializer.KryoRegistrator
 import org.hammerlab.guacamole.kryo.GuacamoleKryoRegistrar
 
-class KryoTestRegistrar extends KryoRegistrator {
+trait KryoTestRegistrar extends KryoRegistrator {
 
-  def registerTestClasses(kryo: Kryo): Unit = {}
+  def registerTestClasses(kryo: Kryo): Unit
 
   override def registerClasses(kryo: Kryo): Unit = {
     new GuacamoleKryoRegistrar().registerClasses(kryo)

--- a/src/test/scala/org/hammerlab/guacamole/util/KryoTestRegistrar.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/KryoTestRegistrar.scala
@@ -2,14 +2,14 @@ package org.hammerlab.guacamole.util
 
 import com.esotericsoftware.kryo.Kryo
 import org.apache.spark.serializer.KryoRegistrator
-import org.hammerlab.guacamole.kryo.GuacamoleKryoRegistrar
+import org.hammerlab.guacamole.kryo.Registrar
 
 trait KryoTestRegistrar extends KryoRegistrator {
 
   def registerTestClasses(kryo: Kryo): Unit
 
   override def registerClasses(kryo: Kryo): Unit = {
-    new GuacamoleKryoRegistrar().registerClasses(kryo)
+    new Registrar().registerClasses(kryo)
     registerTestClasses(kryo)
   }
 }

--- a/src/test/scala/org/hammerlab/guacamole/util/KryoTestRegistrar.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/KryoTestRegistrar.scala
@@ -1,0 +1,15 @@
+package org.hammerlab.guacamole.util
+
+import com.esotericsoftware.kryo.Kryo
+import org.apache.spark.serializer.KryoRegistrator
+import org.hammerlab.guacamole.kryo.GuacamoleKryoRegistrar
+
+class KryoTestRegistrar extends KryoRegistrator {
+
+  def registerTestClasses(kryo: Kryo): Unit = {}
+
+  override def registerClasses(kryo: Kryo): Unit = {
+    new GuacamoleKryoRegistrar().registerClasses(kryo)
+    registerTestClasses(kryo)
+  }
+}

--- a/src/test/scala/org/hammerlab/guacamole/util/SparkSerializerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/SparkSerializerSuite.scala
@@ -1,0 +1,16 @@
+package org.hammerlab.guacamole.util
+
+import java.nio.ByteBuffer
+
+import com.holdenkarau.spark.testing.SharedSparkContext
+import org.apache.spark.SparkEnv
+
+trait SparkSerializerSuite {
+  self: SharedSparkContext =>
+
+  def serializer = SparkEnv.get.serializer.newInstance()
+
+  def serialize(item: Any): ByteBuffer = serializer.serialize(item)
+  def deserialize[T](bytes: ByteBuffer): T = serializer.deserialize(bytes)
+  def deserialize[T](bytes: Array[Byte]): T = deserialize(ByteBuffer.wrap(bytes))
+}

--- a/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
@@ -21,19 +21,15 @@ package org.hammerlab.guacamole.util
 import java.io.{File, FileNotFoundException}
 import java.nio.file.Files
 
-import com.esotericsoftware.kryo.Kryo
-import com.twitter.chill.{IKryoRegistrar, KryoInstantiator, KryoPool}
 import htsjdk.samtools.TextCigarCodec
 import org.apache.commons.io.FileUtils
 import org.apache.spark.SparkContext
-import org.hammerlab.guacamole.kryo.GuacamoleKryoRegistrar
+import org.hammerlab.guacamole.ReadSet
 import org.hammerlab.guacamole.loci.set.LociParser
 import org.hammerlab.guacamole.pileup.Pileup
 import org.hammerlab.guacamole.reads.{InputFilters, MappedRead, MateAlignmentProperties, PairedRead, Read, ReadLoadingConfig}
 import org.hammerlab.guacamole.reference.ReferenceBroadcast.MapBackedReferenceSequence
 import org.hammerlab.guacamole.reference.{ContigSequence, ReferenceBroadcast}
-import org.hammerlab.guacamole.ReadSet
-import org.scalatest._
 
 import scala.collection.mutable
 import scala.math._
@@ -47,20 +43,6 @@ object TestUtil {
 
   def tmpPath(suffix: String): String = {
     new File(Files.createTempDirectory("TestUtil").toFile, s"TestUtil$suffix").getAbsolutePath
-  }
-
-  // Serialization helper functions.
-  lazy val kryoPool = {
-    val instantiator = new KryoInstantiator().setRegistrationRequired(true).withRegistrar(new IKryoRegistrar {
-      override def apply(kryo: Kryo): Unit = new GuacamoleKryoRegistrar().registerClasses(kryo)
-    })
-    KryoPool.withByteArrayOutputStream(1, instantiator)
-  }
-  def serialize(item: Any): Array[Byte] = {
-    kryoPool.toBytesWithClass(item)
-  }
-  def deserialize[T](bytes: Array[Byte]): T = {
-    kryoPool.fromBytes(bytes).asInstanceOf[T]
   }
 
   /**

--- a/src/test/scala/org/hammerlab/guacamole/variants/AlleleSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/variants/AlleleSuite.scala
@@ -18,10 +18,19 @@
 
 package org.hammerlab.guacamole.variants
 
-import org.hammerlab.guacamole.util.{Bases, TestUtil}
-import org.scalatest.{FunSuite, Matchers}
+import com.esotericsoftware.kryo.Kryo
+import org.hammerlab.guacamole.util.{Bases, GuacFunSuite, KryoTestRegistrar}
+import org.scalatest.Matchers
 
-class AlleleSuite extends FunSuite with Matchers {
+class AlleleSuiteRegistrar extends KryoTestRegistrar {
+  override def registerTestClasses(kryo: Kryo): Unit = {
+    kryo.register(classOf[Allele], new AlleleSerializer)
+  }
+}
+
+class AlleleSuite extends GuacFunSuite with Matchers {
+
+  override def registrar = "org.hammerlab.guacamole.variants.AlleleSuiteRegistrar"
 
   test("isVariant") {
     val mismatch = Allele(Seq(Bases.T), Seq(Bases.A))
@@ -40,14 +49,15 @@ class AlleleSuite extends FunSuite with Matchers {
 
   test("serializing allele") {
     val a1 = Allele(Seq(Bases.T), Seq(Bases.A))
-    val a1Serialized = TestUtil.serialize(a1)
-    val a1Deserialized = TestUtil.deserialize[Allele](a1Serialized)
+
+    val a1Serialized = serialize(a1)
+    val a1Deserialized = deserialize[Allele](a1Serialized)
 
     assert(a1 === a1Deserialized)
 
     val a2 = Allele(Seq(Bases.T, Bases.T, Bases.C), Seq(Bases.A))
-    val a2Serialized = TestUtil.serialize(a2)
-    val a2Deserialized = TestUtil.deserialize[Allele](a2Serialized)
+    val a2Serialized = serialize(a2)
+    val a2Deserialized = deserialize[Allele](a2Serialized)
 
     assert(a2 === a2Deserialized)
   }


### PR DESCRIPTION
Some follow-on work to #441:

- add hook for declaring test-specific kryo registration
- relegate `Pileup{,Element}` registration to the test that requires it; leave it out of production code.
- factor joint-caller registrations out to separate registrar.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/453)
<!-- Reviewable:end -->
