### PR TITLE
Fix varlens test deletion parsing

### DIFF
--- a/src/test/scala/org/hammerlab/guacamole/VariantComparisonUtils.scala
+++ b/src/test/scala/org/hammerlab/guacamole/VariantComparisonUtils.scala
@@ -29,10 +29,10 @@ case class VariantFromVarlensCSV(
       (interbaseStart, ref, alt)
     } else {
       // Deletion.
-      val refSeqeunce = Bases.basesToString(
+      val refSequence = Bases.basesToString(
         reference.getReferenceSequence(
-          uncanonicalizedContig, interbaseStart.toInt - 1, interbaseStart.toInt + 1)).toUpperCase
-      (interbaseStart - 1, refSeqeunce, refSeqeunce(0) + alt)
+          uncanonicalizedContig, interbaseStart.toInt - 1, interbaseEnd.toInt)).toUpperCase
+      (interbaseStart - 1, refSequence, refSequence(0) + alt)
     }
 
     val alleles = Seq(adjustedRef, adjustedAlt).distinct


### PR DESCRIPTION
I think there was an issue with the CSV parsing in the tests here. I'd again advocate to store the data in a  canonical format (VCF or with standard coordinates) rather than relying on custom test code to load it.

@timodonnell Is this right here? I'm not sure which side of the interbase coordinates are inclusive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/455)
<!-- Reviewable:end -->
