### PR TITLE
Use shared spark context in tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,19 +306,6 @@
       <version>3.0</version>
     </dependency>
     <dependency>
-      <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_${scala.version.prefix}</artifactId>
-      <version>2.2.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.bdgenomics.bdg-utils</groupId>
-      <artifactId>bdg-utils-misc</artifactId>
-      <version>0.1.1</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
       <version>${hadoop.version}</version>
@@ -342,6 +329,27 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.4</version>
+    </dependency>
+
+    <!-- Test deps -->
+    <dependency>
+      <groupId>com.holdenkarau</groupId>
+      <artifactId>spark-testing-base_2.10</artifactId>
+      <version>${spark.version}_0.3.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest_${scala.version.prefix}</artifactId>
+      <version>2.2.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.bdgenomics.bdg-utils</groupId>
+      <artifactId>bdg-utils-misc</artifactId>
+      <version>0.1.1</version>
+      <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/test/scala/org/hammerlab/guacamole/assembly/DeBrujinGraphSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/assembly/DeBrujinGraphSuite.scala
@@ -367,7 +367,7 @@ class DeBruijnGraphSuite extends GuacFunSuite {
 
   }
 
-  sparkTest("real reads data test") {
+  test("real reads data test") {
     val kmerSize = 55
 
     val referenceString = "GAGGATCTGCCATGGCCGGGCGAGCTGGAGGAGGAGGAGGAGGAGGAGGAGGAGGAGGAGGAGGAAGAGGAGGAGGCTGCAGCGGCGGCGGCGGCGAACGTGGACGACGTAGTGGTCGTGGAGGAGGTGGAGGAAGAGGCGGGGCG"

--- a/src/test/scala/org/hammerlab/guacamole/commands/SomaticStandardCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/SomaticStandardCallerSuite.scala
@@ -94,7 +94,7 @@ class SomaticStandardCallerSuite extends GuacFunSuite with TableDrivenPropertyCh
     }
   }
 
-  sparkTest("testing simple positive variants") {
+  test("testing simple positive variants") {
     val (tumorReads, normalReads) =
       TestUtil.loadTumorNormalReads(
         sc,
@@ -131,7 +131,7 @@ class SomaticStandardCallerSuite extends GuacFunSuite with TableDrivenPropertyCh
     testVariants(tumorReads, normalReads, positivePositions, shouldFindVariant = true)
   }
 
-  sparkTest("testing simple negative variants on syn1") {
+  test("testing simple negative variants on syn1") {
     val (tumorReads, normalReads) =
       TestUtil.loadTumorNormalReads(
         sc,
@@ -152,7 +152,7 @@ class SomaticStandardCallerSuite extends GuacFunSuite with TableDrivenPropertyCh
     testVariants(tumorReads, normalReads, negativePositions, shouldFindVariant = false)
   }
 
-  sparkTest("testing complex region negative variants on syn1") {
+  test("testing complex region negative variants on syn1") {
     val (tumorReads, normalReads) =
       TestUtil.loadTumorNormalReads(
         sc,
@@ -172,7 +172,7 @@ class SomaticStandardCallerSuite extends GuacFunSuite with TableDrivenPropertyCh
     testVariants(tumorReads, normalReads, positivePositions, shouldFindVariant = true)
   }
 
-  sparkTest("difficult negative variants") {
+  test("difficult negative variants") {
 
     val (tumorReads, normalReads) =
       TestUtil.loadTumorNormalReads(
@@ -190,7 +190,7 @@ class SomaticStandardCallerSuite extends GuacFunSuite with TableDrivenPropertyCh
     testVariants(tumorReads, normalReads, negativeVariantPositions, shouldFindVariant = false)
   }
 
-  sparkTest("no indels") {
+  test("no indels") {
     val normalReads = Seq(
       TestUtil.makeRead("TCGATCGA", "8M", 0),
       TestUtil.makeRead("TCGATCGA", "8M", 0),
@@ -208,7 +208,7 @@ class SomaticStandardCallerSuite extends GuacFunSuite with TableDrivenPropertyCh
     SomaticStandard.Caller.findPotentialVariantAtLocus(tumorPileup, normalPileup, oddsThreshold = 2).size should be(0)
   }
 
-  sparkTest("single-base deletion") {
+  test("single-base deletion") {
     val normalReads = Seq(
       TestUtil.makeRead("TCGATCGA", "8M", 0),
       TestUtil.makeRead("TCGATCGA", "8M", 0),
@@ -229,7 +229,7 @@ class SomaticStandardCallerSuite extends GuacFunSuite with TableDrivenPropertyCh
     Bases.basesToString(allele.altBases) should be("G")
   }
 
-  sparkTest("multiple-base deletion") {
+  test("multiple-base deletion") {
     val normalReads = Seq(
       TestUtil.makeRead("TCGAAGCTTCGAAGCT", "16M", 0, chr = "chr4"),
       TestUtil.makeRead("TCGAAGCTTCGAAGCT", "16M", 0, chr = "chr4"),
@@ -252,7 +252,7 @@ class SomaticStandardCallerSuite extends GuacFunSuite with TableDrivenPropertyCh
     Bases.basesToString(allele.altBases) should be("A")
   }
 
-  sparkTest("single-base insertion") {
+  test("single-base insertion") {
     val normalReads = Seq(
       TestUtil.makeRead("TCGATCGA", "8M", 0),
       TestUtil.makeRead("TCGATCGA", "8M", 0),
@@ -275,7 +275,7 @@ class SomaticStandardCallerSuite extends GuacFunSuite with TableDrivenPropertyCh
     Bases.basesToString(allele.altBases) should be("AG")
   }
 
-  sparkTest("multiple-base insertion") {
+  test("multiple-base insertion") {
     val normalReads = Seq(
       TestUtil.makeRead("TCGATCGA", "8M", 0),
       TestUtil.makeRead("TCGATCGA", "8M", 0),
@@ -300,7 +300,7 @@ class SomaticStandardCallerSuite extends GuacFunSuite with TableDrivenPropertyCh
     Bases.basesToString(allele.altBases) should be("AGGTC")
   }
 
-  sparkTest("insertions and deletions") {
+  test("insertions and deletions") {
     /*
     idx:  01234  56    7890123456
     ref:  TCGAA  TC    GATCGATCGA

--- a/src/test/scala/org/hammerlab/guacamole/commands/VAFHistogramSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/VAFHistogramSuite.scala
@@ -5,7 +5,7 @@ import org.scalatest.Matchers
 
 class VAFHistogramSuite extends GuacFunSuite {
 
-  sparkTest("generating the histogram") {
+  test("generating the histogram") {
 
     val loci = sc.parallelize(Seq(
       VariantLocus("chr1", 1L, 0.25f),

--- a/src/test/scala/org/hammerlab/guacamole/commands/VariantSupportSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/VariantSupportSuite.scala
@@ -76,23 +76,23 @@ class VariantSupportSuite extends GuacFunSuite with TableDrivenPropertyChecks {
       .collect()
       .sortBy(_.start)
 
-  sparkTest("read evidence for simple snvs") {
+  test("read evidence for simple snvs") {
     val pileup = Pileup(gatkReads("20:10008951-10008952"), "20", 10008951, grch37Reference.getContig("20"))
     assertAlleleCounts(pileup, ("CACACACACACA", "C", 1), ("C", "C", 4))
   }
 
-  sparkTest("read evidence for mid-deletion") {
+  test("read evidence for mid-deletion") {
     val pileup = Pileup(gatkReads("20:10006822-10006823"), "20", 10006822, referenceContigSequence = grch37Reference.getContig("20"))
     assertAlleleCounts(pileup, ("C", "", 6), ("C", "C", 2))
   }
 
-  sparkTest("read evidence for simple snvs 2") {
+  test("read evidence for simple snvs 2") {
     val reads = gatkReads("20:10000624-10000625")
     val pileup = Pileup(reads, "20", 10000624, referenceContigSequence = grch37Reference.getContig("20"))
     assertAlleleCounts(pileup, ("T", "T", 6), ("T", "C", 1))
   }
 
-  sparkTest("read evidence for simple snvs no filters") {
+  test("read evidence for simple snvs no filters") {
     val loci =
       Seq(
         ("20", 9999900, Nil), // empty
@@ -106,7 +106,7 @@ class VariantSupportSuite extends GuacFunSuite with TableDrivenPropertyChecks {
 
   }
 
-  sparkTest("read evidence for simple snvs duplicate filtering") {
+  test("read evidence for simple snvs duplicate filtering") {
     val loci =
       Seq(
         ("20", 9999995, Seq(("A", "ACT", 8))),

--- a/src/test/scala/org/hammerlab/guacamole/commands/jointcaller/AlleleAtLocusSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/jointcaller/AlleleAtLocusSuite.scala
@@ -12,7 +12,7 @@ class AlleleAtLocusSuite extends GuacFunSuite with Matchers {
     ReferenceBroadcast(b37Chromosome22Fasta, sc, partialFasta = false)
   }
 
-  sparkTest("AlleleAtLocus.variantAlleles for low vaf variant allele") {
+  test("AlleleAtLocus.variantAlleles for low vaf variant allele") {
     val inputs = InputCollection(celsr1BAMs, analytes = Vector("dna", "dna", "rna"))
     val pileups = (inputs.normalDNA ++ inputs.tumorDNA).map(input =>
       TestUtil.loadPileup(sc, input.path, b37Chromosome22Reference, 46931060, Some("chr22")))

--- a/src/test/scala/org/hammerlab/guacamole/commands/jointcaller/PileupStatsSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/jointcaller/PileupStatsSuite.scala
@@ -15,7 +15,7 @@ class PileupStatsSuite extends GuacFunSuite {
     ReferenceBroadcast(partialFasta, sc, partialFasta = true)
   }
 
-  sparkTest("pileupstats likelihood computation") {
+  test("pileupstats likelihood computation") {
     val refString = "NTCGATCGA"
     def reference = TestUtil.makeReference(sc, Seq(("chr1", 0, refString)))
     def referenceContigSequence = reference.getContig("chr1")

--- a/src/test/scala/org/hammerlab/guacamole/commands/jointcaller/ReadSubsequenceSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/jointcaller/ReadSubsequenceSuite.scala
@@ -16,7 +16,7 @@ class ReadSubsequenceSuite extends GuacFunSuite {
     ReferenceBroadcast(partialFasta, sc, partialFasta = true)
   }
 
-  sparkTest("ofFixedReferenceLength") {
+  test("ofFixedReferenceLength") {
     val reads = Seq(
       TestUtil.makeRead("TCGATCGA", "8M", 1), // no variant
       TestUtil.makeRead("TCGACCCTCGA", "4M3I4M", 1), // insertion
@@ -31,7 +31,7 @@ class ReadSubsequenceSuite extends GuacFunSuite {
     ReadSubsequence.ofFixedReferenceLength(pileups(3).head, 1).get.sequenceIsAllStandardBases should equal(false)
   }
 
-  sparkTest("ofNextAltAllele") {
+  test("ofNextAltAllele") {
     val reads = Seq(
       TestUtil.makeRead("TCGATCGA", "8M", 1), // no variant
       TestUtil.makeRead("TCGAGCGA", "8M", 1), // snv
@@ -59,7 +59,7 @@ class ReadSubsequenceSuite extends GuacFunSuite {
     ReadSubsequence.ofNextAltAllele(pileups(5).elements(0)).get.sequenceIsAllStandardBases should equal(false)
   }
 
-  sparkTest("gathering possible alleles") {
+  test("gathering possible alleles") {
     val inputs = InputCollection(cancerWGS1Bams)
     val parameters = Parameters.defaults
     val contigLocus = ("chr12", 65857039)

--- a/src/test/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCallerSuite.scala
@@ -22,7 +22,7 @@ class SomaticJointCallerSuite extends GuacFunSuite {
     ReferenceBroadcast(b37Chromosome22Fasta, sc, partialFasta = false)
   }
 
-  sparkTest("call a somatic variant") {
+  test("call a somatic variant") {
     val inputs = InputCollection(cancerWGS1Bams)
     val loci = LociParser("chr12:65857040")
     val readSets = SomaticJoint.inputsToReadSets(sc, inputs, loci)
@@ -34,7 +34,7 @@ class SomaticJointCallerSuite extends GuacFunSuite {
     calls.head.singleAlleleEvidences.map(_.allele.ref) should equal(Seq("G"))
   }
 
-  sparkTest("call a somatic deletion") {
+  test("call a somatic deletion") {
     val inputs = InputCollection(cancerWGS1Bams)
     val loci = LociParser("chr5:82649006-82649009")
     val readSets = SomaticJoint.inputsToReadSets(sc, inputs, loci)
@@ -54,7 +54,7 @@ class SomaticJointCallerSuite extends GuacFunSuite {
     calls.head.singleAlleleEvidences.head.allele.alt should equal("T")
   }
 
-  sparkTest("call germline variants") {
+  test("call germline variants") {
     val inputs = InputCollection(cancerWGS1Bams.take(1), tissueTypes = Vector("normal"))
     val loci = LociParser("chr1,chr2,chr3")
     val readSets = SomaticJoint.inputsToReadSets(sc, inputs, loci)
@@ -87,7 +87,7 @@ class SomaticJointCallerSuite extends GuacFunSuite {
     calls(("chr1", 167190087)).bestAllele.failingFilterNames.contains("STRAND_BIAS") should be(true)
   }
 
-  sparkTest("don't call variants with N as the reference base") {
+  test("don't call variants with N as the reference base") {
     val inputs = InputCollection(cancerWGS1Bams)
     val loci = LociParser("chr12:65857030-65857080")
     val readSets = SomaticJoint.inputsToReadSets(sc, inputs, loci)
@@ -99,7 +99,7 @@ class SomaticJointCallerSuite extends GuacFunSuite {
     calls.collect.length should equal(0)
   }
 
-  sparkTest("call a somatic variant using RNA evidence") {
+  test("call a somatic variant using RNA evidence") {
     val parameters = Parameters.defaults.copy(somaticNegativeLog10VariantPriorWithRnaEvidence = 1)
 
     val loci = LociParser("chr22:46931058-46931079")

--- a/src/test/scala/org/hammerlab/guacamole/distributed/LociPartitionUtilsSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/distributed/LociPartitionUtilsSuite.scala
@@ -138,7 +138,7 @@ class LociPartitionUtilsSuite extends GuacFunSuite {
     LociPartitionUtils.partitionLociUniformly(2000, giantSet).inverse
   }
 
-  sparkTest("partitionLociByApproximateReadDepth") {
+  test("partitionLociByApproximateReadDepth") {
     def makeRead(start: Long, length: Long) = {
       TestUtil.makeRead("A" * length.toInt, "%sM".format(length), start, "chr1")
     }

--- a/src/test/scala/org/hammerlab/guacamole/distributed/PileupFlatMapUtilsSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/distributed/PileupFlatMapUtilsSuite.scala
@@ -25,7 +25,7 @@ import org.hammerlab.guacamole.util.{AssertBases, GuacFunSuite, TestUtil}
 
 class PileupFlatMapUtilsSuite extends GuacFunSuite {
 
-  sparkTest("test pileup flatmap parallelism 0; create pileups") {
+  test("test pileup flatmap parallelism 0; create pileups") {
 
     val reads = sc.parallelize(Seq(
       TestUtil.makeRead("TCGATCGA", "8M", 1),
@@ -53,7 +53,7 @@ class PileupFlatMapUtilsSuite extends GuacFunSuite {
 
   }
 
-  sparkTest("test pileup flatmap parallelism 5; create pileups") {
+  test("test pileup flatmap parallelism 5; create pileups") {
 
     val reads = sc.parallelize(Seq(
       TestUtil.makeRead("TCGATCGA", "8M", 1),
@@ -76,7 +76,7 @@ class PileupFlatMapUtilsSuite extends GuacFunSuite {
     pileups.forall(_.head.isMatch) should be(true)
   }
 
-  sparkTest("test pileup flatmap parallelism 5; skip empty pileups") {
+  test("test pileup flatmap parallelism 5; skip empty pileups") {
     val reads = sc.parallelize(Seq(
       TestUtil.makeRead("TCGATCGA", "8M", 1),
       TestUtil.makeRead("TCGATCGA", "8M", 1),
@@ -93,7 +93,7 @@ class PileupFlatMapUtilsSuite extends GuacFunSuite {
     loci should equal(Array(1, 2, 3, 4, 5, 6, 7, 8))
   }
 
-  sparkTest("test pileup flatmap two rdds; skip empty pileups") {
+  test("test pileup flatmap two rdds; skip empty pileups") {
     val reads1 = sc.parallelize(Seq(
       TestUtil.makeRead("TCGATCGA", "8M", 1),
       TestUtil.makeRead("TCGATCGA", "8M", 1),
@@ -120,7 +120,7 @@ class PileupFlatMapUtilsSuite extends GuacFunSuite {
     loci should equal(Seq(1, 2, 3, 4, 5, 6, 7, 8, 99, 100, 101, 102, 103, 104, 105, 106, 107))
   }
 
-  sparkTest("test pileup flatmap multiple rdds; skip empty pileups") {
+  test("test pileup flatmap multiple rdds; skip empty pileups") {
     val reads1 = sc.parallelize(Seq(
       TestUtil.makeRead("TCGATCGA", "8M", 1),
       TestUtil.makeRead("TCGATCGA", "8M", 1),
@@ -185,7 +185,7 @@ class PileupFlatMapUtilsSuite extends GuacFunSuite {
     resultPlain(10) should equal(Seq(Seq("G", "G", "G"), Seq("X"), Seq("X")))
   }
 
-  sparkTest("test pileup flatmap parallelism 5; create pileup elements") {
+  test("test pileup flatmap parallelism 5; create pileup elements") {
 
     val reads = sc.parallelize(Seq(
       TestUtil.makeRead("TCGATCGA", "8M", 1),
@@ -205,7 +205,7 @@ class PileupFlatMapUtilsSuite extends GuacFunSuite {
     pileups.forall(_.isMatch) should be(true)
   }
 
-  sparkTest("test two-rdd pileup flatmap; create pileup elements") {
+  test("test two-rdd pileup flatmap; create pileup elements") {
     val reads1 = sc.parallelize(Seq(
       TestUtil.makeRead("TCGATCGA", "8M", 1),
       TestUtil.makeRead("TCGATCGA", "8M", 1),
@@ -237,7 +237,7 @@ class PileupFlatMapUtilsSuite extends GuacFunSuite {
     )
   }
 
-  sparkTest("test pileup flatmap parallelism 5; create pileup elements; with indel") {
+  test("test pileup flatmap parallelism 5; create pileup elements; with indel") {
 
     val reads = sc.parallelize(Seq(
       TestUtil.makeRead("TCGATCGA", "8M", 1),

--- a/src/test/scala/org/hammerlab/guacamole/distributed/WindowFlatMapUtilsSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/distributed/WindowFlatMapUtilsSuite.scala
@@ -6,7 +6,7 @@ import org.hammerlab.guacamole.util.{GuacFunSuite, TestUtil}
 import org.hammerlab.guacamole.windowing.SlidingWindow
 
 class WindowFlatMapUtilsSuite extends GuacFunSuite {
-  sparkTest("test window fold parallelism 5; average read depth") {
+  test("test window fold parallelism 5; average read depth") {
 
     // 4 overlapping reads starting at loci = 0
     //     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6

--- a/src/test/scala/org/hammerlab/guacamole/likelihood/LikelihoodSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/likelihood/LikelihoodSuite.scala
@@ -55,7 +55,7 @@ class LikelihoodSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     }
   }
 
-  sparkTest("all reads ref") {
+  test("all reads ref") {
     testGenotypeLikelihoods(
       Seq(refRead(30), refRead(40), refRead(30)),
       ('C', 'C') -> (1 - errorPhred30) * (1 - errorPhred40) * (1 - errorPhred30),
@@ -66,7 +66,7 @@ class LikelihoodSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     )
   }
 
-  sparkTest("two ref, one alt") {
+  test("two ref, one alt") {
     testGenotypeLikelihoods(
       Seq(refRead(30), refRead(40), altRead(30)),
       ('C', 'C') -> (1 - errorPhred30) * (1 - errorPhred40) * errorPhred30,
@@ -78,7 +78,7 @@ class LikelihoodSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     )
   }
 
-  sparkTest("one ref, two alt") {
+  test("one ref, two alt") {
     testGenotypeLikelihoods(
       Seq(refRead(30), altRead(40), altRead(30)),
       ('C', 'C') -> (1 - errorPhred30) * errorPhred40 * errorPhred30,
@@ -90,7 +90,7 @@ class LikelihoodSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     )
   }
 
-  sparkTest("all reads alt") {
+  test("all reads alt") {
     testGenotypeLikelihoods(
       Seq(altRead(30), altRead(40), altRead(30)),
       ('C', 'C') -> errorPhred30 * errorPhred40 * errorPhred30,
@@ -102,7 +102,7 @@ class LikelihoodSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     )
   }
 
-  sparkTest("score genotype for single sample; all bases ref") {
+  test("score genotype for single sample; all bases ref") {
     val referenceContigSequence = referenceBroadcast(sc).getContig("chr1")
 
     val reads = Seq(
@@ -119,7 +119,7 @@ class LikelihoodSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     )
   }
 
-  sparkTest("score genotype for single sample; mix of ref/non-ref bases") {
+  test("score genotype for single sample; mix of ref/non-ref bases") {
     val referenceContigSequence = referenceBroadcast(sc).getContig("chr1")
 
     val reads = Seq(
@@ -138,7 +138,7 @@ class LikelihoodSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     )
   }
 
-  sparkTest("score genotype for single sample; all bases non-ref") {
+  test("score genotype for single sample; all bases non-ref") {
     val referenceContigSequence = referenceBroadcast(sc).getContig("chr1")
 
     val reads = Seq(
@@ -155,7 +155,7 @@ class LikelihoodSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     )
   }
 
-  sparkTest("log score genotype for single sample; all bases ref") {
+  test("log score genotype for single sample; all bases ref") {
     val referenceContigSequence = referenceBroadcast(sc).getContig("chr1")
 
     val reads = Seq(
@@ -175,7 +175,7 @@ class LikelihoodSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     )
   }
 
-  sparkTest("log score genotype for single sample; mix of ref/non-ref bases") {
+  test("log score genotype for single sample; mix of ref/non-ref bases") {
     val referenceContigSequence = referenceBroadcast(sc).getContig("chr1")
 
     val reads = Seq(
@@ -197,7 +197,7 @@ class LikelihoodSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     )
   }
 
-  sparkTest("log score genotype for single sample; all bases non-ref") {
+  test("log score genotype for single sample; all bases non-ref") {
     val referenceContigSequence = referenceBroadcast(sc).getContig("chr1")
 
     val reads = Seq(

--- a/src/test/scala/org/hammerlab/guacamole/loci/map/SerializerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/loci/map/SerializerSuite.scala
@@ -13,7 +13,7 @@ class SerializerSuite extends GuacFunSuite {
     numRanges: Int,
     count: Int
   ) = {
-    sparkTest(name) {
+    test(name) {
       val serializer = SparkEnv.get.serializer.newInstance()
 
       val beforeMap = LociMap[String](ranges: _*)

--- a/src/test/scala/org/hammerlab/guacamole/loci/set/LociSetSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/loci/set/LociSetSuite.scala
@@ -80,7 +80,7 @@ class LociSetSuite extends GuacFunSuite {
     set.onContig("chr1").contains(10001) should be(false)
   }
 
-  sparkTest("loci set invariants") {
+  test("loci set invariants") {
     val sets = List(
       "",
       "empty:20-20,empty2:30-30",
@@ -114,7 +114,7 @@ class LociSetSuite extends GuacFunSuite {
     sets.foreach(checkInvariants)
   }
 
-  sparkTest("loci argument parsing in Common") {
+  test("loci argument parsing in Common") {
     class TestArgs extends DebugLogArgs with LociArgs {}
 
     // Test -loci argument
@@ -198,7 +198,7 @@ class LociSetSuite extends GuacFunSuite {
   }
 
   // We do not provide java serialization for LociSet, instead broadcasting it (which uses Kryo serialization).
-  sparkTest("serialization: a closure that includes a LociSet") {
+  test("serialization: a closure that includes a LociSet") {
     val set = LociSet("chr21:100-200,chr20:0-10,chr20:8-15,chr20:100-120,empty:10-10")
     val setBC = sc.broadcast(set)
     val rdd = sc.parallelize(0L until 1000L)

--- a/src/test/scala/org/hammerlab/guacamole/loci/set/SerializerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/loci/set/SerializerSuite.scala
@@ -3,7 +3,7 @@ package org.hammerlab.guacamole.loci.set
 import org.hammerlab.guacamole.util.GuacFunSuite
 
 class SerializerSuite extends GuacFunSuite {
-  sparkTest("make an RDD[LociSet]") {
+  test("make an RDD[LociSet]") {
     val sets =
       List(
         "",
@@ -20,7 +20,7 @@ class SerializerSuite extends GuacFunSuite {
     result should equal(sets.map(_.toString))
   }
 
-  sparkTest("make an RDD[LociSet], and an RDD[Contig]") {
+  test("make an RDD[LociSet], and an RDD[Contig]") {
     val sets =
       List(
         "",

--- a/src/test/scala/org/hammerlab/guacamole/pileup/PileupSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/pileup/PileupSuite.scala
@@ -43,7 +43,7 @@ class PileupSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     PileupElement(read, locus, reference.getContig(read.referenceContig))
   }
 
-  sparkTest("create pileup from long insert reads") {
+  test("create pileup from long insert reads") {
     val reads = Seq(
       TestUtil.makeRead("TCGATCGA", "8M", 1),
       TestUtil.makeRead("TCGATCGA", "8M", 1),
@@ -65,7 +65,7 @@ class PileupSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     insertPileup.elements(2).alignment should equal(Insertion("ACCC", Seq(31, 31, 31, 31).map(_.toByte)))
   }
 
-  sparkTest("create pileup from long insert reads; different qualities in insertion") {
+  test("create pileup from long insert reads; different qualities in insertion") {
     val reads = Seq(
       TestUtil.makeRead("TCGATCGA", "8M", 1, "chr1", Some(Seq(10, 15, 20, 25, 10, 15, 20, 25))),
       TestUtil.makeRead("TCGATCGA", "8M", 1, "chr1", Some(Seq(10, 15, 20, 25, 10, 15, 20, 25))),
@@ -83,7 +83,7 @@ class PileupSuite extends GuacFunSuite with TableDrivenPropertyChecks {
       })
   }
 
-  sparkTest("create pileup from long insert reads, right after insertion") {
+  test("create pileup from long insert reads, right after insertion") {
     val reads = Seq(
       TestUtil.makeRead("TCGATCGA", "8M", 1, "chr1", Some(Seq(10, 15, 20, 25, 10, 15, 20, 25))),
       TestUtil.makeRead("TCGATCGA", "8M", 1, "chr1", Some(Seq(10, 15, 20, 25, 10, 15, 20, 25))),
@@ -100,7 +100,7 @@ class PileupSuite extends GuacFunSuite with TableDrivenPropertyChecks {
 
   }
 
-  sparkTest("create pileup from long insert reads; after insertion") {
+  test("create pileup from long insert reads; after insertion") {
     val reads = Seq(
       TestUtil.makeRead("TCGATCGA", "8M", 1),
       TestUtil.makeRead("TCGATCGA", "8M", 1),
@@ -110,7 +110,7 @@ class PileupSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     lastPileup.elements.forall(_.isMatch) should be(true)
   }
 
-  sparkTest("create pileup from long insert reads; end of read") {
+  test("create pileup from long insert reads; end of read") {
 
     val reads = Seq(
       TestUtil.makeRead("TCGATCGA", "8M", 1, "chr1", Some(Seq(10, 15, 20, 25, 10, 15, 20, 25))),
@@ -125,12 +125,12 @@ class PileupSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     lastPileup.elements.forall(_.qualityScore == 25) should be(true)
   }
 
-  sparkTest("Load pileup from SAM file") {
+  test("Load pileup from SAM file") {
     val pileup = loadPileup(sc, "same_start_reads.sam", locus = 0, reference = reference)
     pileup.elements.length should be(10)
   }
 
-  sparkTest("First 60 loci should have all 10 reads") {
+  test("First 60 loci should have all 10 reads") {
     val pileup = loadPileup(sc, "same_start_reads.sam", locus = 0, reference = reference)
     for (i <- 1 to 59) {
       val nextPileup = pileup.atGreaterLocus(i, Seq.empty.iterator)
@@ -138,7 +138,7 @@ class PileupSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     }
   }
 
-  sparkTest("test pileup element creation") {
+  test("test pileup element creation") {
     val read = TestUtil.makeRead("AATTG", "5M", 0, "chr2")
     val firstElement = pileupElementFromRead(read, 0)
 
@@ -155,7 +155,7 @@ class PileupSuite extends GuacFunSuite with TableDrivenPropertyChecks {
 
   }
 
-  sparkTest("test pileup element creation with multiple cigar elements") {
+  test("test pileup element creation with multiple cigar elements") {
     val read = TestUtil.makeRead("AAATTT", "3M3M", 0, "chr3")
 
     val secondMatch = pileupElementFromRead(read, 3)
@@ -168,13 +168,13 @@ class PileupSuite extends GuacFunSuite with TableDrivenPropertyChecks {
 
   }
 
-  sparkTest("insertion at contig start includes trailing base") {
+  test("insertion at contig start includes trailing base") {
     val contigStartInsertionRead = TestUtil.makeRead("AAAAAACGT", "5I4M", 0, "chr1")
     val pileup = pileupElementFromRead(contigStartInsertionRead, 0)
     pileup.alignment should equal(Insertion("AAAAAA", List(31, 31, 31, 31, 31, 31)))
   }
 
-  sparkTest("pileup alignment at insertion cigar-element throws") {
+  test("pileup alignment at insertion cigar-element throws") {
     val contigStartInsertionRead = TestUtil.makeRead("AAAAAACGT", "5I4M", 0, "chr1")
     val pileup = PileupElement(
       read = contigStartInsertionRead,
@@ -188,7 +188,7 @@ class PileupSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     the[InvalidCigarElementException] thrownBy pileup.alignment
   }
 
-  sparkTest("test pileup element creation with deletion cigar elements") {
+  test("test pileup element creation with deletion cigar elements") {
     val read = TestUtil.makeRead("AATTGAATTG", "5M1D5M", 0, "chr4")
     val firstElement = pileupElementFromRead(read, 0)
 
@@ -214,7 +214,7 @@ class PileupSuite extends GuacFunSuite with TableDrivenPropertyChecks {
 
   }
 
-  sparkTest("Loci 10-19 deleted from half of the reads") {
+  test("Loci 10-19 deleted from half of the reads") {
     val pileup = loadPileup(sc, "same_start_reads.sam", locus = 0, reference = reference)
     val deletionPileup = pileup.atGreaterLocus(9, Seq.empty.iterator)
     deletionPileup.elements.map(_.alignment).count {
@@ -230,7 +230,7 @@ class PileupSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     }
   }
 
-  sparkTest("Loci 60-69 have 5 reads") {
+  test("Loci 60-69 have 5 reads") {
     val pileup = loadPileup(sc, "same_start_reads.sam", locus = 0, reference = reference)
     for (i <- 60 to 69) {
       val nextPileup = pileup.atGreaterLocus(i, Seq.empty.iterator)
@@ -238,7 +238,7 @@ class PileupSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     }
   }
 
-  sparkTest("Pileup.Element basic test") {
+  test("Pileup.Element basic test") {
     intercept[NullPointerException] {
       val e = pileupElementFromRead(null, 42)
     }
@@ -308,7 +308,7 @@ class PileupSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     AssertBases(read3At15.advanceToLocus(18).sequencedBases, "G")
   }
 
-  sparkTest("Read4 has CIGAR: 10M10I10D40M. It's ACGT repeated 15 times") {
+  test("Read4 has CIGAR: 10M10I10D40M. It's ACGT repeated 15 times") {
     val decadentRead4 = testAdamRecords(3)
     val read4At20 = pileupElementFromRead(decadentRead4, 20)
     assert(read4At20 != null)
@@ -324,7 +324,7 @@ class PileupSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     (read4At30.sequencedBases: String) should equal("CGTACGTACGT")
   }
 
-  sparkTest("Read5: ACGTACGTACGTACG, 5M4=1X5=") {
+  test("Read5: ACGTACGTACGTACG, 5M4=1X5=") {
     // Read5: ACGTACGTACGTACG, 5M4=1X5=, [10; 25[
     //        MMMMM====G=====
     val decadentRead5 = testAdamRecords(4)
@@ -340,7 +340,7 @@ class PileupSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     AssertBases(read5At10.advanceToLocus(24).sequencedBases, "G")
   }
 
-  sparkTest("read6: ACGTACGTACGT 4=1N4=4S") {
+  test("read6: ACGTACGTACGT 4=1N4=4S") {
     // Read6: ACGTACGTACGT 4=1N4=4S
     // one `N` and soft-clipping at the end
     val decadentRead6 = testAdamRecords(5)
@@ -359,7 +359,7 @@ class PileupSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     }
   }
 
-  sparkTest("read7: ACGTACGT 4=1N4=4H, one `N` and hard-clipping at the end") {
+  test("read7: ACGTACGT 4=1N4=4H, one `N` and hard-clipping at the end") {
     val decadentRead7 = testAdamRecords(6)
     val read7At99 = pileupElementFromRead(decadentRead7, 99)
     assert(read7At99 != null)
@@ -375,7 +375,7 @@ class PileupSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     }
   }
 
-  sparkTest("create and advance pileup element from RNA read") {
+  test("create and advance pileup element from RNA read") {
     val reference = TestUtil.makeReference(sc, Seq(("chr1", 229538779, "A" * 1000)), 229538779 + 1000)
 
     val rnaRead = TestUtil.makeRead(
@@ -400,7 +400,7 @@ class PileupSuite extends GuacFunSuite with TableDrivenPropertyChecks {
 
   }
 
-  sparkTest("create pileup from RNA reads") {
+  test("create pileup from RNA reads") {
     val reference = TestUtil.makeReference(sc, Seq(("1", 229538779, "A" * 1000)), 229538779 + 1000)
     val rnaReadsPileup = loadPileup(sc, "testrna.sam", locus = 229580594, reference = reference)
 
@@ -414,7 +414,7 @@ class PileupSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     movedRnaReadsPileup.atGreaterLocus(229580707, Iterator.empty).depth should be(1)
   }
 
-  sparkTest("pileup in the middle of a deletion") {
+  test("pileup in the middle of a deletion") {
     val reads = Seq(
       TestUtil.makeRead("TCGAAAAGCT", "5M6D5M", 0),
       TestUtil.makeRead("TCGAAAAGCT", "5M6D5M", 0),

--- a/src/test/scala/org/hammerlab/guacamole/reads/ReadSetSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/ReadSetSuite.scala
@@ -30,7 +30,7 @@ class ReadSetSuite extends GuacFunSuite {
     override def toString: String = msg()
   }
 
-  sparkTest("using different bam reading APIs on sam/bam files should give identical results") {
+  test("using different bam reading APIs on sam/bam files should give identical results") {
     def check(paths: Seq[String], filter: InputFilters): Unit = {
       withClue("using filter %s: ".format(filter)) {
 
@@ -98,7 +98,7 @@ class ReadSetSuite extends GuacFunSuite {
     })
   }
 
-  sparkTest("load and test filters") {
+  test("load and test filters") {
     val allReads = TestUtil.loadReads(sc, "mdtagissue.sam")
     allReads.reads.count() should be(8)
 
@@ -113,12 +113,12 @@ class ReadSetSuite extends GuacFunSuite {
     nonDuplicateReads.reads.count() should be(3)
   }
 
-  sparkTest("load RNA reads") {
+  test("load RNA reads") {
     val readSet = TestUtil.loadReads(sc, "rna_chr17_41244936.sam")
     readSet.reads.count should be(23)
   }
 
-  sparkTest("load read from ADAM") {
+  test("load read from ADAM") {
     // First load reads from SAM using ADAM and save as ADAM
     val adamContext = new ADAMContext(sc)
     val adamRecords = adamContext.loadBam(TestUtil.testDataPath("mdtagissue.sam"))
@@ -146,7 +146,7 @@ class ReadSetSuite extends GuacFunSuite {
     filteredReads.count() should be(3)
   }
 
-  sparkTest("load and serialize / deserialize reads") {
+  test("load and serialize / deserialize reads") {
     val reads = TestUtil.loadReads(sc, "mdtagissue.sam", InputFilters(mapped = true)).mappedReads.collect()
     val serializedReads = reads.map(TestUtil.serialize)
     val deserializedReads: Seq[MappedRead] = serializedReads.map(TestUtil.deserialize[MappedRead](_))

--- a/src/test/scala/org/hammerlab/guacamole/reference/ReferenceBroadcastSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reference/ReferenceBroadcastSuite.scala
@@ -8,7 +8,7 @@ class ReferenceBroadcastSuite extends GuacFunSuite with Matchers {
 
   val testFastaPath = TestUtil.testDataPath("sample.fasta")
 
-  sparkTest("loading and broadcasting reference") {
+  test("loading and broadcasting reference") {
 
     val reference = ReferenceBroadcast(testFastaPath, sc)
     reference.broadcastedContigs.keys.size should be(2)
@@ -18,7 +18,7 @@ class ReferenceBroadcastSuite extends GuacFunSuite with Matchers {
 
   }
 
-  sparkTest("retrieving reference sequences") {
+  test("retrieving reference sequences") {
     val reference = ReferenceBroadcast(testFastaPath, sc)
 
     reference.getReferenceBase("1", 0) should be(Bases.N)

--- a/src/test/scala/org/hammerlab/guacamole/util/GuacFunSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/GuacFunSuite.scala
@@ -1,11 +1,12 @@
 package org.hammerlab.guacamole.util
 
-import org.bdgenomics.utils.misc.SparkFunSuite
-import org.scalatest.Matchers
+import com.holdenkarau.spark.testing.SharedSparkContext
+import org.scalatest.{FunSuite, Matchers}
 
-trait GuacFunSuite extends SparkFunSuite with Matchers {
-  override val appName: String = "guacamole"
-  override val properties: Map[String, String] =
+trait GuacFunSuite extends FunSuite with SharedSparkContext with Matchers {
+  conf.setAppName("guacamole")
+
+  val properties: Map[String, String] =
     Map(
       "spark.serializer" -> "org.apache.spark.serializer.KryoSerializer",
       "spark.kryo.registrator" -> "org.hammerlab.guacamole.kryo.GuacamoleKryoRegistrar",
@@ -15,5 +16,10 @@ trait GuacFunSuite extends SparkFunSuite with Matchers {
       "spark.driver.host" -> "localhost"
     )
 
+  for {
+    (k, v) <- properties
+  } {
+    conf.set(k, v)
+  }
 }
 

--- a/src/test/scala/org/hammerlab/guacamole/variants/AlleleEvidenceSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/variants/AlleleEvidenceSuite.scala
@@ -9,7 +9,7 @@ class AlleleEvidenceSuite extends GuacFunSuite {
 
   def reference = TestUtil.makeReference(sc, Seq(("chr1", 0, "NTAGATCGA")))
 
-  sparkTest("allele evidence from pileup, all reads support") {
+  test("allele evidence from pileup, all reads support") {
     val reads = Seq(
       TestUtil.makeRead("TCGATCGA", "8M", 1, alignmentQuality = 30),
       TestUtil.makeRead("TCGATCGA", "8M", 1, alignmentQuality = 30),
@@ -27,7 +27,7 @@ class AlleleEvidenceSuite extends GuacFunSuite {
     variantEvidence.medianMismatchesPerRead should be(1)
   }
 
-  sparkTest("allele evidence from pileup, one read supports") {
+  test("allele evidence from pileup, one read supports") {
     val reads = Seq(
       TestUtil.makeRead("TAGATCGA", "8M", 1, alignmentQuality = 30),
       TestUtil.makeRead("TCGATCGA", "8M", 1, alignmentQuality = 60),
@@ -45,7 +45,7 @@ class AlleleEvidenceSuite extends GuacFunSuite {
     variantEvidence.medianMismatchesPerRead should be(1)
   }
 
-  sparkTest("allele evidence from pileup, no read supports") {
+  test("allele evidence from pileup, no read supports") {
     val reads = Seq(
       TestUtil.makeRead("TAGATCGA", "8M", 1, alignmentQuality = 30),
       TestUtil.makeRead("TAGATCGA", "8M", 1, alignmentQuality = 60),


### PR DESCRIPTION
Uses @holdenk's spark-testing-base.

I ran `mvn test` 10 times (after first doing a `mvn test-compile`) with and without this change, to measure the timing difference:

Before:

```
01:47 min
01:47 min
01:46 min
01:47 min
01:47 min
01:47 min
01:49 min
01:52 min
01:53 min
01:43 min
```

After:

```
01:29 min
01:32 min
01:31 min
01:32 min
01:29 min
01:33 min
01:31 min
01:30 min
01:32 min
01:33 min
```

~15% faster!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/458)
<!-- Reviewable:end -->
