### PR TITLE
move loci parsing logic from Common into loci pkg

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/Common.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Common.scala
@@ -18,16 +18,10 @@
 
 package org.hammerlab.guacamole
 
-import java.io.{File, InputStreamReader}
-
-import htsjdk.variant.vcf.VCFFileReader
-import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.{Logging, SparkContext}
 import org.hammerlab.guacamole.distributed.LociPartitionUtils
-import org.hammerlab.guacamole.loci.LociArgs
-import org.hammerlab.guacamole.loci.set.{LociParser, LociSet}
 import org.hammerlab.guacamole.logging.DebugLogArgs
 import org.hammerlab.guacamole.reads.{InputFilters, ReadLoadingConfigArgs}
 import org.hammerlab.guacamole.variants.Concordance.ConcordanceArgs
@@ -115,81 +109,6 @@ object Common extends Logging {
     )
 
     (tumor, normal)
-  }
-
-  /**
-   * Return the loci specified by the user as a LociParser.
-   *
-   * @param args parsed arguments
-   */
-  def lociFromArguments(args: LociArgs, default: String = "all"): LociParser = {
-    if (args.loci.nonEmpty && args.lociFromFile.nonEmpty) {
-      throw new IllegalArgumentException("Specify at most one of the 'loci' and 'loci-from-file' arguments")
-    }
-    val lociToParse =
-      if (args.loci.nonEmpty) {
-        args.loci
-      } else if (args.lociFromFile.nonEmpty) {
-        // Load loci from file.
-        val filesystem = FileSystem.get(new Configuration())
-        val path = new Path(args.lociFromFile)
-        IOUtils.toString(new InputStreamReader(filesystem.open(path)))
-      } else {
-        default
-      }
-
-    LociParser(lociToParse)
-  }
-
-  /**
-   * Load a LociSet from the specified file, using the contig lengths from the given ReadSet.
-   *
-   * @param filePath path to file containing loci. If it ends in '.vcf' then it is read as a VCF and the variant sites
-   *                 are the loci. If it ends in '.loci' or '.txt' then it should be a file containing loci as
-   *                 "chrX:5-10,chr12-10-20", etc. Whitespace is ignored.
-   * @param contigLengths contig lengths, by name
-   * @return a LociSet
-   */
-  def lociFromFile(filePath: String, contigLengths: Map[String, Long]): LociSet = {
-    if (filePath.endsWith(".vcf")) {
-      LociSet(
-        new VCFFileReader(new File(filePath), false)
-      )
-    } else if (filePath.endsWith(".loci") || filePath.endsWith(".txt")) {
-      val filesystem = FileSystem.get(new Configuration())
-      val path = new Path(filePath)
-      LociParser(
-        IOUtils.toString(new InputStreamReader(filesystem.open(path)))
-      ).result(contigLengths)
-    } else {
-      throw new IllegalArgumentException(
-        s"Couldn't guess format for file: $filePath. Expected file extensions: '.loci' or '.txt' for loci string format; '.vcf' for VCFs."
-      )
-    }
-  }
-
-  /**
-   * Load loci from a string or a path to a file.
-   *
-   * Specify at most one of loci or lociFromFilePath.
-   *
-   * @param loci loci to load as a string
-   * @param lociFromFilePath path to file containing loci to load
-   * @param contigLengths contig lengths, by name
-   * @return a LociSet
-   */
-  def loadLoci(loci: String, lociFromFilePath: String, contigLengths: Map[String, Long]): LociSet = {
-    if (loci.nonEmpty && lociFromFilePath.nonEmpty) {
-      throw new IllegalArgumentException("Specify at most one of the 'loci' and 'loci-from-file' arguments")
-    }
-    if (loci.nonEmpty) {
-      LociParser(loci).result(contigLengths)
-    } else if (lociFromFilePath.nonEmpty) {
-      lociFromFile(lociFromFilePath, contigLengths)
-    } else {
-      // Default is "all"
-      LociSet.all(contigLengths)
-    }
   }
 }
 

--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
@@ -194,7 +194,7 @@ object GermlineAssemblyCaller {
 
     override def run(args: Arguments, sc: SparkContext): Unit = {
       val reference = ReferenceBroadcast(args.referenceFastaPath, sc)
-      val loci = Common.lociFromArguments(args)
+      val loci = args.parseLoci()
       val readSet = Common.loadReadsFromArguments(
         args,
         sc,

--- a/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
@@ -69,7 +69,7 @@ object SomaticStandard {
 
     override def run(args: Arguments, sc: SparkContext): Unit = {
       VariantUtils.validateArguments(args)
-      val loci = Common.lociFromArguments(args)
+      val loci = args.parseLoci()
       val filters =
         InputFilters(
           overlapsLoci = loci,

--- a/src/main/scala/org/hammerlab/guacamole/commands/VAFHistogram.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/VAFHistogram.scala
@@ -99,7 +99,7 @@ object VAFHistogram {
     override def run(args: Arguments, sc: SparkContext): Unit = {
       val reference = ReferenceBroadcast(args.referenceFastaPath, sc)
 
-      val loci = Common.lociFromArguments(args)
+      val loci = args.parseLoci()
       val filters =
         InputFilters(
           overlapsLoci = loci,

--- a/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCaller.scala
@@ -91,7 +91,7 @@ object SomaticJoint {
 
       val reference = ReferenceBroadcast(args.referenceFastaPath, sc, partialFasta = args.referenceFastaIsPartial)
 
-      val loci = Common.lociFromArguments(args)
+      val loci = args.parseLoci()
 
       val readSets = inputsToReadSets(sc, inputs, loci, !args.noSequenceDictionary)
 
@@ -102,7 +102,7 @@ object SomaticJoint {
 
       val forceCallLoci =
         if (args.forceCallLoci.nonEmpty || args.forceCallLociFromFile.nonEmpty) {
-          Common.loadLoci(args.forceCallLoci, args.forceCallLociFromFile, readSets(0).contigLengths)
+          LociSet.load(args.forceCallLoci, args.forceCallLociFromFile, readSets(0).contigLengths)
         } else {
           LociSet()
         }

--- a/src/main/scala/org/hammerlab/guacamole/loci/LociArgs.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/LociArgs.scala
@@ -1,5 +1,11 @@
 package org.hammerlab.guacamole.loci
 
+import java.io.InputStreamReader
+
+import org.apache.commons.io.IOUtils
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.hammerlab.guacamole.loci.set.LociParser
 import org.hammerlab.guacamole.logging.DebugLogArgs
 import org.kohsuke.args4j.{Option => Args4jOption}
 
@@ -18,5 +24,33 @@ trait LociArgs extends DebugLogArgs {
     forbids = Array("--loci")
   )
   var lociFromFile: String = ""
+
+  /**
+   * Parse string representations of loci ranges, either from the "--loci" cmdline parameter or a file specified by the
+   * "--loci-from-file" parameter, and return a LociParser encapsulating the result. The latter can then be converted
+   * into a LociSet when contig-lengths are available / have been parsed from read-sets.
+   *
+   * @param fallback If neither "--loci" nor "--loci-from-file" were provided, fall back to this string representation
+   *                 of the loci that should be considered.
+   * @return a LociParser wrapping the appropriate loci ranges.
+   */
+  def parseLoci(fallback: String = "all"): LociParser = {
+    if (loci.nonEmpty && lociFromFile.nonEmpty) {
+      throw new IllegalArgumentException("Specify at most one of the 'loci' and 'loci-from-file' arguments")
+    }
+    val lociToParse =
+      if (loci.nonEmpty) {
+        loci
+      } else if (lociFromFile.nonEmpty) {
+        // Load loci from file.
+        val filesystem = FileSystem.get(new Configuration())
+        val path = new Path(lociFromFile)
+        IOUtils.toString(new InputStreamReader(filesystem.open(path)))
+      } else {
+        fallback
+      }
+
+    LociParser(lociToParse)
+  }
 }
 

--- a/src/test/scala/org/hammerlab/guacamole/loci/set/LociSetSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/loci/set/LociSetSuite.scala
@@ -120,7 +120,7 @@ class LociSetSuite extends GuacFunSuite {
     // Test -loci argument
     val args1 = new TestArgs()
     args1.loci = "20:100-200"
-    Common.lociFromArguments(args1).result should equal(LociSet("20:100-200"))
+    args1.parseLoci().result should equal(LociSet("20:100-200"))
 
     // Test -loci-from-file argument. The test file gives a loci set equal to 20:100-200.
     val args2 = new TestArgs()

--- a/src/test/scala/org/hammerlab/guacamole/main/GeneratePartialFasta.scala
+++ b/src/test/scala/org/hammerlab/guacamole/main/GeneratePartialFasta.scala
@@ -62,7 +62,7 @@ object GeneratePartialFasta extends SparkCommand[GeneratePartialFastaArguments] 
   override def run(args: GeneratePartialFastaArguments, sc: SparkContext): Unit = {
 
     val reference = ReferenceBroadcast(args.referenceFastaPath, sc)
-    val lociBuilder = Common.lociFromArguments(args, default = "none")
+    val parsedLoci = args.parseLoci(fallback = "none")
     val readSets = args.bams.zipWithIndex.map(fileAndIndex =>
       ReadSet(
         sc,
@@ -77,10 +77,10 @@ object GeneratePartialFasta extends SparkCommand[GeneratePartialFastaArguments] 
 
     val regions = reads.map(read => (read.referenceContig, read.start, read.end))
     regions.collect.foreach(triple => {
-      lociBuilder.put(triple._1, triple._2, triple._3)
+      parsedLoci.put(triple._1, triple._2, triple._3)
     })
 
-    val loci = lociBuilder.result
+    val loci = parsedLoci.result
 
     val fd = new File(args.output)
     val writer = new BufferedWriter(new FileWriter(fd))


### PR DESCRIPTION
- I decided to put put the `LociArgs` → `LociParser` logic into `LociArgs.parse` instead of a `LociParser` constructor to keep `LociArgs` out of `LociParser.scala`, because the latter feels further down the stack than the former

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/459)
<!-- Reviewable:end -->
