### PR TITLE
LociPartitioningUtils cleanups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,11 @@
       <version>1.2.0</version>
     </dependency>
     <dependency>
+      <groupId>org.spire-math</groupId>
+      <artifactId>spire_2.10</artifactId>
+      <version>0.11.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.version.prefix}</artifactId>
       <version>${spark.version}</version>

--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
@@ -8,10 +8,9 @@ import org.hammerlab.guacamole.Common
 import org.hammerlab.guacamole.Common.GermlineCallerArgs
 import org.hammerlab.guacamole.alignment.AffineGapPenaltyAlignment
 import org.hammerlab.guacamole.assembly.AssemblyUtils
-import org.hammerlab.guacamole.distributed.LociPartitionUtils.partitionLociAccordingToArgs
+import org.hammerlab.guacamole.distributed.LociPartitionUtils.{LociPartitioning, partitionLociAccordingToArgs}
 import org.hammerlab.guacamole.distributed.WindowFlatMapUtils.windowFlatMapWithState
 import org.hammerlab.guacamole.likelihood.Likelihood
-import org.hammerlab.guacamole.loci.map.LociMap
 import org.hammerlab.guacamole.logging.DelayedMessages
 import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.pileup.Pileup
@@ -119,7 +118,7 @@ object GermlineAssemblyCaller {
                                  minOccurrence: Int,
                                  minAreaVaf: Float,
                                  reference: ReferenceBroadcast,
-                                 lociPartitions: LociMap[Long],
+                                 lociPartitions: LociPartitioning,
                                  minAltReads: Int = 2,
                                  minPhredScaledLikelihood: Int = 0,
                                  shortcutAssembly: Boolean = false): RDD[CalledAllele] = {

--- a/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
@@ -99,8 +99,7 @@ object SomaticStandard {
       val lociPartitions = partitionLociAccordingToArgs(
         args,
         loci.result(normalReads.contigLengths),
-        tumorReads.mappedReads,
-        normalReads.mappedReads
+        Vector(tumorReads.mappedReads, normalReads.mappedReads)
       )
 
       var potentialGenotypes: RDD[CalledSomaticAllele] =

--- a/src/main/scala/org/hammerlab/guacamole/commands/VAFHistogram.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/VAFHistogram.scala
@@ -10,9 +10,8 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
 import org.hammerlab.guacamole._
 import org.hammerlab.guacamole.distributed.LociPartitionUtils
-import org.hammerlab.guacamole.distributed.LociPartitionUtils.partitionLociAccordingToArgs
+import org.hammerlab.guacamole.distributed.LociPartitionUtils.{LociPartitioning, partitionLociAccordingToArgs}
 import org.hammerlab.guacamole.distributed.PileupFlatMapUtils.pileupFlatMap
-import org.hammerlab.guacamole.loci.map.LociMap
 import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.pileup.Pileup
 import org.hammerlab.guacamole.reads.{InputFilters, MappedRead, ReadLoadingConfigArgs}
@@ -123,7 +122,7 @@ object VAFHistogram {
       val lociPartitions = partitionLociAccordingToArgs(
         args,
         loci.result(readSets(0).contigLengths),
-        readSets(0).mappedReads // Use the first set of reads as a proxy for read depth
+        readSets(0).mappedReads  // Use the first set of reads as a proxy for read depth
       )
 
       val minReadDepth = args.minReadDepth
@@ -224,7 +223,7 @@ object VAFHistogram {
    */
   def variantLociFromReads(reads: RDD[MappedRead],
                            reference: ReferenceGenome,
-                           lociPartitions: LociMap[Long],
+                           lociPartitions: LociPartitioning,
                            samplePercent: Int = 100,
                            minReadDepth: Int = 0,
                            minVariantAlleleFrequency: Int = 0,

--- a/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCaller.scala
@@ -197,7 +197,7 @@ object SomaticJoint {
       partitionLociAccordingToArgs(
         distributedUtilArguments,
         lociSetMinusOne(loci),
-        readSets.map(_.mappedReads): _*
+        readSets.map(_.mappedReads)
       )
 
     pileupFlatMapMultipleRDDs(

--- a/src/main/scala/org/hammerlab/guacamole/distributed/KeyPartitioner.scala
+++ b/src/main/scala/org/hammerlab/guacamole/distributed/KeyPartitioner.scala
@@ -6,10 +6,9 @@ import org.apache.spark.Partitioner
   * Spark partitioner for keyed RDDs that assigns each unique key its own partition.
   * Used to partition an RDD of (task number: Long, read: MappedRead) pairs, giving each task its own partition.
   *
-  * @param partitions total number of partitions
+  * @param numPartitions total number of partitions
   */
-class KeyPartitioner(partitions: Int) extends Partitioner {
-  def numPartitions = partitions
+case class KeyPartitioner(override val numPartitions: Int) extends Partitioner {
   def getPartition(key: Any): Int = key match {
     case value: Long         => value.toInt
     case value: TaskPosition => value.task

--- a/src/main/scala/org/hammerlab/guacamole/distributed/LociPartitionUtils.scala
+++ b/src/main/scala/org/hammerlab/guacamole/distributed/LociPartitionUtils.scala
@@ -1,6 +1,7 @@
 package org.hammerlab.guacamole.distributed
 
 import org.apache.spark.rdd.RDD
+import org.hammerlab.guacamole.PerSample
 import org.hammerlab.guacamole.loci.LociArgs
 import org.hammerlab.guacamole.loci.map.LociMap
 import org.hammerlab.guacamole.loci.set.LociSet
@@ -8,74 +9,119 @@ import org.hammerlab.guacamole.logging.DebugLogArgs
 import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.reference.ReferenceRegion
 import org.kohsuke.args4j.{Option => Args4jOption}
+import spire.implicits._
+import spire.math.Integral
 
+import scala.collection.Map
 import scala.reflect.ClassTag
 
 object LociPartitionUtils {
 
-  trait Arguments extends DebugLogArgs with LociArgs {
-    @Args4jOption(name = "--parallelism", usage = "Num variant calling tasks. Set to 0 (default) to use the number of Spark partitions.")
-    var parallelism: Int = 0
+  // Convenience types representing "micro-partitions" indices, or numbers of micro-partitions.
+  // Micro-partitions can be as numerous as loci in the genome, so we use Longs to represent them.
+  // Many of them can be combined into individual Spark partitions (which are Ints).
+  type MicroPartitionIndex = Long
+  type NumMicroPartitions = Long
 
-    @Args4jOption(name = "--partition-accuracy",
-      usage = "Num micro partitions to use per task in loci partitioning. Set to 0 to partition loci uniformly. Default: 250.")
-    var partitioningAccuracy: Int = 250
+  // Convenience types representing Spark partition indices, or numbers of Spark partitions.
+  type PartitionIndex = Int
+  type NumPartitions = Int
+
+  type LociPartitioning = LociMap[PartitionIndex]
+
+  trait Arguments extends DebugLogArgs with LociArgs {
+    @Args4jOption(
+      name = "--parallelism",
+      usage = "Number of variant calling partitions. Set to 0 (default) to use the number of Spark partitions."
+    )
+    var parallelism: NumPartitions = 0
+
+    @Args4jOption(
+      name = "--partition-accuracy",
+      usage = "Number of micro-partitions to use, per Spark partition, when partitioning loci (default: 250). Set to 0 to partition loci uniformly"
+    )
+    var partitioningAccuracy: NumMicroPartitions = 250
   }
 
   /**
-    * Partition a LociSet among tasks according to the strategy specified in args.
-    */
+   * Partition a LociSet according to the strategy specified in args.
+   */
   def partitionLociAccordingToArgs[R <: ReferenceRegion: ClassTag](args: Arguments,
                                                                    loci: LociSet,
-                                                                   regionRDDs: RDD[R]*): LociMap[Long] = {
+                                                                   regionRDD: RDD[R]): LociPartitioning =
+    partitionLociAccordingToArgs(args, loci, Vector(regionRDD))
+
+  def partitionLociAccordingToArgs[R <: ReferenceRegion: ClassTag](args: Arguments,
+                                                                   loci: LociSet,
+                                                                   regionRDDs: PerSample[RDD[R]]): LociPartitioning = {
     assume(loci.nonEmpty)
     val sc = regionRDDs.head.sparkContext
-    val tasks = if (args.parallelism > 0) args.parallelism else sc.defaultParallelism
+    val numPartitions: NumPartitions =
+      if (args.parallelism > 0)
+        args.parallelism
+      else
+        sc.defaultParallelism
+
     if (args.partitioningAccuracy == 0) {
-      partitionLociUniformly(tasks, loci)
+      partitionLociUniformly(numPartitions, loci)
     } else {
       partitionLociByApproximateDepth(
-        tasks,
+        numPartitions,
         loci,
         args.partitioningAccuracy,
-        regionRDDs: _*
+        regionRDDs
       )
     }
   }
 
   /**
-    * Assign loci from a LociSet to partitions. Contiguous intervals of loci will tend to get assigned to the same
-    * partition.
-    *
-    * This implementation assigns loci uniformly, i.e. each task gets about the same number of loci. A smarter
-    * implementation would know about the regions (depth of coverage), and try to assign each task loci corresponding to
-    * about the same number of regions.
-    *
-    * @param tasks number of partitions
-    * @param loci loci to partition
-    * @return LociMap of locus -> task assignments
-    */
-  def partitionLociUniformly(tasks: Long, loci: LociSet): LociMap[Long] = {
-    assume(tasks >= 1, "`tasks` (--parallelism) should be >= 1")
-    val lociPerTask = math.max(1, loci.count.toDouble / tasks.toDouble)
-    progress("Splitting loci evenly among %,d tasks = ~%,.0f loci per task".format(tasks, lociPerTask))
-    val builder = LociMap.newBuilder[Long]
+   * Assign loci to partitions. Contiguous intervals of loci will tend to get assigned to the same partition.
+   *
+   * This implementation assigns loci uniformly, i.e. each partition gets about the same number of loci. A smarter
+   * implementation, partitionLociByApproximateDepth, can be found below; it considers the depth of coverage at each
+   * locus and assigns each partition loci corresponding to approximately the same number of regions.
+   *
+   * @param numPartitions Number of partitions; these needn't map directly to a number of Spark partitions, since e.g.
+   *                      partitionLociByApproximateDepth does post-processing on a large number of "micro-partitions"
+   *                      computed here, combining them to generate partitions that are passed to Spark.
+   * @param loci Loci to partition
+   * @tparam N Long or Int; partitionLociByApproximateDepth calls this to assign a (Long) number of micro-partitions;
+   *           elsewhere (partitionLociAccordingToArgs) an (Int) number of Spark partitions is computed directly.
+   * @return LociMap of locus -> partition assignments
+   */
+  def partitionLociUniformly[N: Integral](numPartitions: N, loci: LociSet): LociMap[N] = {
+    assume(numPartitions >= 1, "`numPartitions` (--parallelism) should be >= 1")
+
+    val lociPerPartition = math.max(1, loci.count.toDouble / numPartitions.toDouble())
+
+    progress(
+      "Splitting loci evenly among %,d numPartitions = ~%,.0f loci per partition"
+        .format(numPartitions.toLong(), lociPerPartition)
+    )
+
     var lociAssigned = 0L
-    var task = 0L
-    def remainingForThisTask = math.round(((task + 1) * lociPerTask) - lociAssigned)
-    loci.contigs.foreach(contig => {
-      contig.ranges.foreach(range => {
-        var start = range.start
-        val end = range.end
-        while (start < end) {
-          val length: Long = math.min(remainingForThisTask, end - start)
-          builder.put(contig.name, start, start + length, task)
-          start += length
-          lociAssigned += length
-          if (remainingForThisTask == 0) task += 1
-        }
-      })
-    })
+
+    var partition = Integral[N].zero
+
+    def remainingForThisPartition = math.round(((partition + 1).toDouble * lociPerPartition) - lociAssigned)
+
+    val builder = LociMap.newBuilder[N]
+
+    for {
+      contig <- loci.contigs
+      range <- contig.ranges
+    } {
+      var start = range.start
+      val end = range.end
+      while (start < end) {
+        val length: Long = math.min(remainingForThisPartition, end - start)
+        builder.put(contig.name, start, start + length, partition)
+        start += length
+        lociAssigned += length
+        if (remainingForThisPartition == 0) partition += 1
+      }
+    }
+
     val result = builder.result
     assert(lociAssigned == loci.count)
     assert(result.count == loci.count)
@@ -83,123 +129,162 @@ object LociPartitionUtils {
   }
 
   /**
-    * Assign loci from a LociSet to partitions, where each partition overlaps about the same number of regions.
-    *
-    * The approach we take is:
-    *
-    *  (1) chop up the loci uniformly into many genomic "micro partitions."
-    *
-    *  (2) for each micro partition, calculate the number of regions that overlap it.
-    *
-    *  (3) using these counts, assign loci to real ("macro") partitions, making the approximation of uniform depth within
-    *      each micro partition.
-    *
-    *  Some advantages of this approach are:
-    *
-    *  - Stages (1) and (3), which are done locally by the Spark master, are constant time with respect to the number
-    *    of regions.
-    *
-    *  - Stage (2), where runtime does depend on the number of regions, is done in parallel with Spark.
-    *
-    *  - We can tune the accuracy vs. performance trade off by setting `microTasks`.
-    *
-    *  - Does not require a distributed sort.
-    *
-    * @param tasks number of partitions
-    * @param loci loci to partition
-    * @param accuracy integer >= 1. Higher values of this will result in a more exact but also more expensive computation.
-    *                 Specifically, this is the number of micro partitions to use per task to estimate the region depth.
-    *                 In the extreme case, setting this to greater than the number of loci per task will result in an
-    *                 exact calculation.
-    * @param regionRDDs: region RDD 1, region RDD 2, ...
-    *                Any number RDD[Region] arguments giving the regions to base the partitioning on.
-    * @return LociMap of locus -> task assignments.
-    */
-  def partitionLociByApproximateDepth[R <: ReferenceRegion: ClassTag](tasks: Int,
-                                                                      loci: LociSet,
-                                                                      accuracy: Int,
-                                                                      regionRDDs: RDD[R]*): LociMap[Long] = {
-    val sc = regionRDDs(0).sparkContext
+   * Assign loci from a LociSet to partitions, where each partition overlaps approximately the same number of "regions"
+   * (reads mapped to a reference genome).
+   *
+   * The approach we take is:
+   *
+   *  (1) chop up the loci uniformly into many genomic "micro partitions."
+   *
+   *  (2) for each micro partition, calculate the number of regions that overlap it.
+   *
+   *  (3) using these counts, assign loci to real (Spark) partitions, assuming approximately uniform depth within each
+   *      micro partition.
+   *
+   *  Some advantages of this approach are:
+   *
+   *  - Stages (1) and (3), which are done locally by the Spark master, are constant time with respect to the number
+   *    of regions (though linear in the number of micro-partitions).
+   *
+   *  - Stage (2), where runtime does depend on the number of regions, is done in parallel with Spark.
+   *
+   *  - Accuracy vs. performance can be tuned by setting `accuracy`.
+   *
+   *  - Does not require a distributed sort.
+   *
+   * @param numPartitions Number of partitions to split reads into.
+   * @param loci Only consider reads overlapping these loci.
+   * @param microPartitionsPerPartition Long >= 1. Number of micro-partitions generated for each of the `numPartitions`
+   *                                    Spark partitions that will be computed. Higher values of this will result in a
+   *                                    more exact but more expensive computation.
+   *                                    In the extreme, setting this to greater than the number of loci (per partition)
+   *                                    will result in an exact calculation.
+   * @param regionRDDs: region RDD 1, region RDD 2, ...
+   *                    Any number RDD[ReferenceRegion] arguments giving the regions to base the partitioning on.
+   * @return LociMap of locus -> partition assignments.
+   */
+  def partitionLociByApproximateDepth[R <: ReferenceRegion: ClassTag](
+    numPartitions: PartitionIndex,
+    loci: LociSet,
+    microPartitionsPerPartition: NumMicroPartitions,
+    regionRDDs: PerSample[RDD[R]]): LociPartitioning = {
 
-    // Step (1). Split loci uniformly into micro partitions.
-    assume(tasks >= 1)
+    assume(numPartitions >= 1)
     assume(loci.count > 0)
     assume(regionRDDs.nonEmpty)
-    val numMicroPartitions: Int = if (accuracy * tasks < loci.count) accuracy * tasks else loci.count.toInt
-    progress("Splitting loci by region depth among %,d tasks using %,d micro partitions.".format(tasks, numMicroPartitions))
-    val microPartitions = partitionLociUniformly(numMicroPartitions, loci)
+
+    val sc = regionRDDs(0).sparkContext
+
+    // Step 1: split loci uniformly into micro partitions.
+    val numMicroPartitions: NumMicroPartitions =
+      if (microPartitionsPerPartition * numPartitions < loci.count)
+        microPartitionsPerPartition * numPartitions
+      else
+        loci.count
+
+    progress(
+      "Splitting loci by region depth among %,d Spark partitions using %,d micro partitions."
+        .format(numPartitions, numMicroPartitions)
+    )
+
+    val lociToMicroPartitionMap = partitionLociUniformly(numMicroPartitions, loci)
+    val microPartitionToLociMap = lociToMicroPartitionMap.inverse
+
     progress("Done calculating micro partitions.")
-    val broadcastMicroPartitions = sc.broadcast(microPartitions)
 
-    // Step (2)
-    // Total up regions overlapping each micro partition. We keep the totals as an array of Longs.
-    var num = 1
-    val regionCounts = regionRDDs.map(regions => {
-      progress("Collecting region counts for RDD %d of %d.".format(num, regionRDDs.length))
-      val result = regions.flatMap(region =>
-        broadcastMicroPartitions.value.onContig(region.referenceContig).getAll(region.start, region.end)
-      ).countByValue()
-      progress("RDD %d: %,d regions".format(num, result.values.sum))
-      num += 1
-      result
-    })
+    val broadcastMicroPartitions = sc.broadcast(lociToMicroPartitionMap)
 
-    val counts: Seq[Long] = (0 until numMicroPartitions).map(i => regionCounts.map(_.getOrElse(i, 0L)).sum)
+    // Step 2: total up regions overlapping each micro partition. We keep the totals as an array of Longs.
+    var sampleNum = 1
+    val regionCounts: PerSample[Map[MicroPartitionIndex, Long]] =
+      regionRDDs.map(regions => {
+        progress(s"Collecting region counts for RDD $sampleNum of ${regionRDDs.length}")
 
-    // Step (3)
-    // Assign loci to tasks, taking into account region depth in each micro partition.
+        val result =
+          regions
+            .flatMap(region =>
+              broadcastMicroPartitions.value
+                .onContig(region.referenceContig)
+                .getAll(region.start, region.end)
+            )
+            .countByValue()
+
+        progress("RDD %d: %,d regions".format(sampleNum, result.values.sum))
+
+        sampleNum += 1
+        result
+      })
+
+    val counts: Seq[Long] = (0L until numMicroPartitions).map(i => regionCounts.map(_.getOrElse(i, 0L)).sum)
+
+    // Step 3: assign loci to partitions, taking into account region depth in each micro partition.
     val totalRegions = counts.sum
-    val regionsPerTask = math.max(1, totalRegions.toDouble / tasks.toDouble)
-    progress("Done collecting region counts. Total regions with micro partition overlaps: %,d = ~%,.0f regions per task."
-             .format(totalRegions, regionsPerTask))
+    val regionsPerPartition = math.max(1, totalRegions / numPartitions.toDouble)
+
+    progress(
+      "Done collecting region counts. Total regions with micro partition overlaps: %,d = ~%,.0f regions per partition."
+        .format(totalRegions, regionsPerPartition)
+    )
 
     val maxIndex = counts.view.zipWithIndex.maxBy(_._1)._2
-    progress("Regions per micro partition: min=%,d mean=%,.0f max=%,d at %s.".format(
-      counts.min, counts.sum.toDouble / counts.length, counts(maxIndex), microPartitions.inverse(maxIndex)))
 
-    val builder = LociMap.newBuilder[Long]
-    var regionsAssigned = 0.0
-    var task = 0L
-    def regionsRemainingForThisTask = math.round(((task + 1) * regionsPerTask) - regionsAssigned)
-    var microTask = 0
-    while (microTask < numMicroPartitions) {
-      var set = microPartitions.inverse(microTask)
-      var regionsInSet = counts(microTask)
+    progress(
+      "Regions per micro partition: min=%,d mean=%,.0f max=%,d at %s.".format(
+        counts.min,
+        counts.sum.toDouble / counts.length,
+        counts(maxIndex),
+        microPartitionToLociMap(maxIndex)
+      )
+    )
+
+    var totalRegionsAssigned = 0.0
+    var partition = 0
+    def regionsRemainingForThisPartition() = math.round(((partition + 1) * regionsPerPartition) - totalRegionsAssigned)
+
+    val builder = LociMap.newBuilder[PartitionIndex]
+
+    var microPartition = 0
+    while (microPartition < numMicroPartitions) {
+      var set = microPartitionToLociMap(microPartition)
+      var regionsInSet = counts(microPartition)
       while (!set.isEmpty) {
         if (regionsInSet == 0) {
           // Take the whole set if there are no regions assigned to it.
-          builder.put(set, task)
+          builder.put(set, partition)
           set = LociSet()
         } else {
-          // If we've allocated all regions for this task, move on to the next task.
-          if (regionsRemainingForThisTask == 0)
-            task += 1
-          assert(regionsRemainingForThisTask > 0)
-          assert(task < tasks)
+          // If we've allocated all regions for this partition, move on to the next partition.
+          if (regionsRemainingForThisPartition() == 0)
+            partition += 1
+          assert(regionsRemainingForThisPartition() > 0)
+          assert(partition < numPartitions)
 
           // Making the approximation of uniform depth within each micro partition, we assign a proportional number of
-          // loci and regions to the current task. The proportion of loci we assign is the ratio of how many regions we have
-          // remaining to allocate for the current task vs. how many regions are remaining in the current micro partition.
+          // loci and regions to the current partition. The proportion of loci we assign is the ratio of how many
+          // regions we have remaining to allocate for the current partition vs. how many regions are remaining in the
+          // current micro partition.
 
-          // Here we calculate the fraction of the current micro partition we are going to assign to the current task.
+          // Here we calculate the fraction of the current micro partition we are going to assign to the current
+          // partition.
+          //
           // May be 1.0, in which case all loci (and therefore regions) for this micro partition will be assigned to the
-          // current task.
-          val fractionToTake = math.min(1.0, regionsRemainingForThisTask.toDouble / regionsInSet.toDouble)
+          // current partition.
+          val fractionToTake = math.min(1.0, regionsRemainingForThisPartition().toDouble / regionsInSet.toDouble)
 
           // Based on fractionToTake, we set the number of loci and regions to assign.
           // We always take at least 1 locus to ensure we continue to make progress.
           val lociToTake = math.max(1, (fractionToTake * set.count).toLong)
           val regionsToTake = (fractionToTake * regionsInSet).toLong
 
-          // Add the new task assignment to the builder, and update bookkeeping info.
+          // Add the new partition assignment to the builder, and update bookkeeping info.
           val (currentSet, remainingSet) = set.take(lociToTake)
-          builder.put(currentSet, task)
-          regionsAssigned += math.round(regionsToTake).toLong
+          builder.put(currentSet, partition)
+          totalRegionsAssigned += math.round(regionsToTake).toLong
           regionsInSet -= math.round(regionsToTake).toLong
           set = remainingSet
         }
       }
-      microTask += 1
+      microPartition += 1
     }
     val result = builder.result
     assert(result.count == loci.count, s"Expected ${loci.count} loci, got ${result.count}")

--- a/src/main/scala/org/hammerlab/guacamole/distributed/PileupFlatmapUtils.scala
+++ b/src/main/scala/org/hammerlab/guacamole/distributed/PileupFlatmapUtils.scala
@@ -2,12 +2,12 @@ package org.hammerlab.guacamole.distributed
 
 import org.apache.spark.rdd.RDD
 import org.hammerlab.guacamole._
+import org.hammerlab.guacamole.distributed.LociPartitionUtils.LociPartitioning
+import org.hammerlab.guacamole.distributed.WindowFlatMapUtils.windowFlatMapWithState
 import org.hammerlab.guacamole.pileup.Pileup
 import org.hammerlab.guacamole.reads.MappedRead
 import org.hammerlab.guacamole.reference.{ReferenceGenome, _}
 import org.hammerlab.guacamole.windowing.SlidingWindow
-import WindowFlatMapUtils.windowFlatMapWithState
-import org.hammerlab.guacamole.loci.map.LociMap
 
 import scala.reflect.ClassTag
 
@@ -41,7 +41,7 @@ object PileupFlatMapUtils {
    *
    */
   def pileupFlatMap[T: ClassTag](reads: RDD[MappedRead],
-                                 lociPartitions: LociMap[Long],
+                                 lociPartitions: LociPartitioning,
                                  skipEmpty: Boolean,
                                  function: Pileup => Iterator[T],
                                  reference: ReferenceGenome): RDD[T] = {
@@ -68,7 +68,7 @@ object PileupFlatMapUtils {
    */
   def pileupFlatMapTwoRDDs[T: ClassTag](reads1: RDD[MappedRead],
                                         reads2: RDD[MappedRead],
-                                        lociPartitions: LociMap[Long],
+                                        lociPartitions: LociPartitioning,
                                         skipEmpty: Boolean,
                                         function: (Pileup, Pileup) => Iterator[T],
                                         reference: ReferenceGenome): RDD[T] = {
@@ -93,7 +93,7 @@ object PileupFlatMapUtils {
    * @see the windowTaskFlatMapMultipleRDDs function for other argument descriptions.
    */
   def pileupFlatMapMultipleRDDs[T: ClassTag](readsRDDs: PerSample[RDD[MappedRead]],
-                                             lociPartitions: LociMap[Long],
+                                             lociPartitions: LociPartitioning,
                                              skipEmpty: Boolean,
                                              function: PerSample[Pileup] => Iterator[T],
                                              reference: ReferenceGenome): RDD[T] = {

--- a/src/main/scala/org/hammerlab/guacamole/kryo/Registrar.scala
+++ b/src/main/scala/org/hammerlab/guacamole/kryo/Registrar.scala
@@ -23,6 +23,7 @@ import org.apache.spark.serializer.KryoRegistrator
 import org.bdgenomics.adam.models.{SequenceDictionary, SequenceRecord}
 import org.bdgenomics.adam.serialization.ADAMKryoRegistrator
 import org.hammerlab.guacamole.commands.jointcaller.kryo.{Registrar => JointCallerRegistrar}
+import org.hammerlab.guacamole.distributed.LociPartitionUtils.{LociPartitioning, MicroPartitionIndex, PartitionIndex}
 import org.hammerlab.guacamole.distributed.TaskPosition
 import org.hammerlab.guacamole.loci.map.{LociMap, Contig => LociMapContig, ContigSerializer => LociMapContigSerializer, Serializer => LociMapSerializer}
 import org.hammerlab.guacamole.loci.set.{LociSet, Contig => LociSetContig, ContigSerializer => LociSetContigSerializer, Serializer => LociSetSerializer}
@@ -61,8 +62,9 @@ class Registrar extends KryoRegistrator {
     kryo.register(classOf[Array[LociSetContig]])
 
     // LociMap is serialized when broadcast in LociPartitionUtils.partitionLociByApproximateDepth.
-    kryo.register(classOf[LociMap[Long]], new LociMapSerializer)
-    kryo.register(classOf[LociMapContig[Long]], new LociMapContigSerializer[Long])
+    kryo.register(classOf[LociPartitioning], new LociMapSerializer[PartitionIndex])
+    kryo.register(classOf[LociMapContig[PartitionIndex]], new LociMapContigSerializer[PartitionIndex])
+    kryo.register(classOf[LociMapContig[MicroPartitionIndex]], new LociMapContigSerializer[MicroPartitionIndex])
 
     // Serialized in WindowFlatMapUtils.
     kryo.register(classOf[TaskPosition])

--- a/src/test/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCallerSuite.scala
@@ -57,7 +57,7 @@ class GermlineAssemblyCallerSuite extends GuacFunSuite with BeforeAndAfterAll {
 
     val lociPartitions =
       LociPartitionUtils.partitionLociUniformly(
-        tasks = args.parallelism,
+        numPartitions = args.parallelism,
         loci = lociParser.result(readSet.contigLengths)
       )
 

--- a/src/test/scala/org/hammerlab/guacamole/commands/jointcaller/AlleleAtLocusSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/jointcaller/AlleleAtLocusSuite.scala
@@ -1,4 +1,5 @@
 package org.hammerlab.guacamole.commands.jointcaller
+
 import org.hammerlab.guacamole.reference.ReferenceBroadcast
 import org.hammerlab.guacamole.util.{GuacFunSuite, TestUtil}
 import org.scalatest.Matchers


### PR DESCRIPTION
- be clear about where we are using `Long`s (micro-partitions) vs. `Int`s
  (Spark partitions)
- documentation touch-ups
- PerSample-ify RDDs
- use "partition" instead of "task"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/460)
<!-- Reviewable:end -->
