### PR TITLE
{,Spark}Command refactor

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/Common.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Common.scala
@@ -25,7 +25,7 @@ import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.mapred.FileAlreadyExistsException
-import org.apache.spark.{Logging, SparkConf, SparkContext}
+import org.apache.spark.{Logging, SparkContext}
 import org.hammerlab.guacamole.distributed.LociPartitionUtils
 import org.hammerlab.guacamole.loci.LociArgs
 import org.hammerlab.guacamole.loci.set.{LociParser, LociSet}
@@ -210,46 +210,6 @@ object Common extends Logging {
         }
         a :+ (kvSplit(0), kvSplit(1))
     }
-  }
-
-  /**
-   *
-   * Return a spark context.
-   *
-   * NOTE: Most properties are set through config file
-   *
-   * @param appName
-   * @return
-   */
-  def createSparkContext(appName: String): SparkContext = createSparkContext(Some(appName))
-  def createSparkContext(appName: Option[String] = None): SparkContext = {
-    val config: SparkConf = new SparkConf()
-    appName match {
-      case Some(name) => config.setAppName("guacamole: %s".format(name))
-      case _          => config.setAppName("guacamole")
-    }
-
-    if (config.getOption("spark.master").isEmpty) {
-      config.setMaster("local[%d]".format(Runtime.getRuntime.availableProcessors()))
-    }
-
-    if (config.getOption("spark.serializer").isEmpty) {
-      config.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-    }
-
-    if (config.getOption("spark.kryo.registrator").isEmpty) {
-      config.set("spark.kryo.registrator", "org.hammerlab.guacamole.kryo.GuacamoleKryoRegistrar")
-    }
-
-    if (config.getOption("spark.kryoserializer.buffer").isEmpty) {
-      config.set("spark.kryoserializer.buffer", "4mb")
-    }
-
-    if (config.getOption("spark.kryo.referenceTracking").isEmpty) {
-      config.set("spark.kryo.referenceTracking", "true")
-    }
-
-    new SparkContext(config)
   }
 
   /**

--- a/src/main/scala/org/hammerlab/guacamole/commands/Command.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/Command.scala
@@ -16,10 +16,10 @@
  * limitations under the License.
  */
 
-package org.hammerlab.guacamole
+package org.hammerlab.guacamole.commands
 
-import org.apache.spark.{ SparkContext, Logging }
-import org.bdgenomics.utils.cli.{ Args4j, Args4jBase }
+import org.apache.spark.Logging
+import org.bdgenomics.utils.cli.{Args4j, Args4jBase}
 
 /**
  * Interface for running a command from command line arguments.
@@ -46,17 +46,4 @@ abstract class Command[T <% Args4jBase: Manifest] extends Serializable with Logg
   def run(args: Array[String]): Unit = run(Args4j[T](args))
 
   def run(args: T): Unit
-}
-
-abstract class SparkCommand[T <% Args4jBase: Manifest] extends Command[T] {
-  override def run(args: T): Unit = {
-    val sc = Common.createSparkContext(appName = name)
-    try {
-      run(args, sc)
-    } finally {
-      sc.stop()
-    }
-  }
-
-  def run(args: T, sc: SparkContext): Unit
 }

--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
@@ -5,6 +5,7 @@ import breeze.stats.{mean, median}
 import htsjdk.samtools.CigarOperator
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
+import org.hammerlab.guacamole.Common
 import org.hammerlab.guacamole.Common.GermlineCallerArgs
 import org.hammerlab.guacamole.alignment.AffineGapPenaltyAlignment
 import org.hammerlab.guacamole.assembly.DeBruijnGraph
@@ -20,7 +21,7 @@ import org.hammerlab.guacamole.reference.{ReferenceBroadcast, ReferenceGenome}
 import org.hammerlab.guacamole.util.CigarUtils
 import org.hammerlab.guacamole.variants.{Allele, AlleleConversions, AlleleEvidence, CalledAllele, VariantUtils}
 import org.hammerlab.guacamole.windowing.SlidingWindow
-import org.hammerlab.guacamole.{Common, SparkCommand}
+import org.hammerlab.guacamole.Common
 import org.kohsuke.args4j.{Option => Args4jOption}
 
 import scala.collection.JavaConversions._

--- a/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
@@ -22,6 +22,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.rdd.ADAMContext
 import org.bdgenomics.formats.avro.DatabaseVariantAnnotation
+import org.hammerlab.guacamole.Common
 import org.hammerlab.guacamole.Common.SomaticCallerArgs
 import org.hammerlab.guacamole.distributed.LociPartitionUtils.partitionLociAccordingToArgs
 import org.hammerlab.guacamole.distributed.PileupFlatMapUtils.pileupFlatMapTwoRDDs
@@ -35,7 +36,6 @@ import org.hammerlab.guacamole.pileup.Pileup
 import org.hammerlab.guacamole.reads.InputFilters
 import org.hammerlab.guacamole.reference.ReferenceBroadcast
 import org.hammerlab.guacamole.variants.{Allele, AlleleConversions, AlleleEvidence, CalledSomaticAllele, VariantUtils}
-import org.hammerlab.guacamole.{Common, SparkCommand}
 import org.kohsuke.args4j.{Option => Args4jOption}
 
 /**

--- a/src/main/scala/org/hammerlab/guacamole/commands/SparkCommand.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/SparkCommand.scala
@@ -1,0 +1,57 @@
+package org.hammerlab.guacamole.commands
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.bdgenomics.utils.cli.Args4jBase
+
+abstract class SparkCommand[T <% Args4jBase: Manifest] extends Command[T] {
+  override def run(args: T): Unit = {
+    val sc = createSparkContext(appName = name)
+    try {
+      run(args, sc)
+    } finally {
+      sc.stop()
+    }
+  }
+
+  def run(args: T, sc: SparkContext): Unit
+
+  /**
+   *
+   * Return a spark context.
+   *
+   * NOTE: Most properties are set through config file
+   *
+   * @param appName
+   * @return
+   */
+  def createSparkContext(appName: String): SparkContext = createSparkContext(Some(appName))
+  def createSparkContext(appName: Option[String] = None): SparkContext = {
+    val config: SparkConf = new SparkConf()
+    appName match {
+      case Some(name) => config.setAppName("guacamole: %s".format(name))
+      case _          => config.setAppName("guacamole")
+    }
+
+    if (config.getOption("spark.master").isEmpty) {
+      config.setMaster("local[%d]".format(Runtime.getRuntime.availableProcessors()))
+    }
+
+    if (config.getOption("spark.serializer").isEmpty) {
+      config.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+    }
+
+    if (config.getOption("spark.kryo.registrator").isEmpty) {
+      config.set("spark.kryo.registrator", "org.hammerlab.guacamole.kryo.GuacamoleKryoRegistrar")
+    }
+
+    if (config.getOption("spark.kryoserializer.buffer").isEmpty) {
+      config.set("spark.kryoserializer.buffer", "4mb")
+    }
+
+    if (config.getOption("spark.kryo.referenceTracking").isEmpty) {
+      config.set("spark.kryo.referenceTracking", "true")
+    }
+
+    new SparkContext(config)
+  }
+}

--- a/src/main/scala/org/hammerlab/guacamole/commands/VariantSupport.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/VariantSupport.scala
@@ -22,6 +22,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.rdd.ADAMContext
 import org.bdgenomics.formats.avro.Variant
+import org.hammerlab.guacamole.ReadSet
 import org.hammerlab.guacamole.distributed.LociPartitionUtils
 import org.hammerlab.guacamole.distributed.LociPartitionUtils.partitionLociUniformly
 import org.hammerlab.guacamole.distributed.PileupFlatMapUtils.pileupFlatMap
@@ -30,7 +31,6 @@ import org.hammerlab.guacamole.pileup.Pileup
 import org.hammerlab.guacamole.reads.{InputFilters, MappedRead, ReadLoadingConfigArgs}
 import org.hammerlab.guacamole.reference.ReferenceBroadcast
 import org.hammerlab.guacamole.util.Bases
-import org.hammerlab.guacamole.{ReadSet, SparkCommand}
 import org.kohsuke.args4j.{Argument, Option => Args4jOption}
 
 object VariantSupport {

--- a/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/jointcaller/SomaticJointCaller.scala
@@ -5,6 +5,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.hammerlab.guacamole.Common.NoSequenceDictionaryArgs
 import org.hammerlab.guacamole._
+import org.hammerlab.guacamole.commands.SparkCommand
 import org.hammerlab.guacamole.commands.jointcaller.evidence.{MultiSampleMultiAlleleEvidence, MultiSampleSingleAlleleEvidence}
 import org.hammerlab.guacamole.distributed.LociPartitionUtils
 import org.hammerlab.guacamole.distributed.LociPartitionUtils.partitionLociAccordingToArgs

--- a/src/main/scala/org/hammerlab/guacamole/kryo/GuacamoleKryoRegistrar.scala
+++ b/src/main/scala/org/hammerlab/guacamole/kryo/GuacamoleKryoRegistrar.scala
@@ -107,6 +107,11 @@ class GuacamoleKryoRegistrar extends KryoRegistrator {
     kryo.register(classOf[Genotype], new GenotypeSerializer)
     kryo.register(classOf[TaskPosition])
 
+    // Germline-assembly caller flatmaps some CalledAlleles.
+    kryo.register(classOf[Array[CalledAllele]])
+    kryo.register(classOf[CalledAllele])
+    kryo.register(classOf[AlleleEvidence])
+
     kryo.register(classOf[Array[LociSet]])
     kryo.register(classOf[Map[_, _]])
     kryo.register(Map.empty.getClass)

--- a/src/test/scala/org/hammerlab/guacamole/main/GermlineAssemblyIntegrationTests.scala
+++ b/src/test/scala/org/hammerlab/guacamole/main/GermlineAssemblyIntegrationTests.scala
@@ -1,9 +1,11 @@
 package org.hammerlab.guacamole.main
 
-import org.hammerlab.guacamole.VariantComparisonUtils.compareToVCF
-import org.hammerlab.guacamole.commands.GermlineAssemblyCaller
+import org.apache.spark.SparkContext
+import org.hammerlab.guacamole.NA12878TestUtils
+import org.hammerlab.guacamole.commands.GermlineAssemblyCaller.Arguments
+import org.hammerlab.guacamole.commands.{GermlineAssemblyCaller, SparkCommand}
 import org.hammerlab.guacamole.util.TestUtil
-import org.hammerlab.guacamole.{Common, NA12878TestUtils}
+import org.hammerlab.guacamole.variants.VariantComparisonTest
 
 /**
  * Germline assembly caller integration "tests" that output various statistics to stdout.
@@ -16,11 +18,14 @@ import org.hammerlab.guacamole.{Common, NA12878TestUtils}
  *     -cp target/guacamole-with-dependencies-0.0.1-SNAPSHOT.jar:target/scala-2.10.5/test-classes \
  *     org.hammerlab.guacamole.main.GermlineAssemblyIntegrationTests
  */
-object GermlineAssemblyIntegrationTests {
+object GermlineAssemblyIntegrationTests extends SparkCommand[Arguments] with VariantComparisonTest {
 
-  def main(args: Array[String]): Unit = {
+  override val name: String = "germline-assembly-integration-test"
+  override val description: String = "output various statistics to stdout"
 
-    val sc = Common.createSparkContext("GermlineAssemblyIntegrationTest")
+  def main(args: Array[String]): Unit = run(args)
+
+  override def run(args: Arguments, sc: SparkContext): Unit = {
 
     println("Germline assembly calling on subset of illumina platinum NA12878")
     val args = new GermlineAssemblyCaller.Arguments()

--- a/src/test/scala/org/hammerlab/guacamole/main/SomaticJointCallerIntegrationTests.scala
+++ b/src/test/scala/org/hammerlab/guacamole/main/SomaticJointCallerIntegrationTests.scala
@@ -1,10 +1,13 @@
 package org.hammerlab.guacamole.main
 
-import org.hammerlab.guacamole.VariantComparisonUtils.{compareToCSV, compareToVCF, csvRecords}
+import org.apache.spark.SparkContext
+import org.hammerlab.guacamole.commands.SparkCommand
 import org.hammerlab.guacamole.commands.jointcaller.SomaticJoint
+import org.hammerlab.guacamole.commands.jointcaller.SomaticJoint.Arguments
 import org.hammerlab.guacamole.loci.set.LociSet
 import org.hammerlab.guacamole.util.TestUtil
-import org.hammerlab.guacamole.{CancerWGSTestUtils, Common, NA12878TestUtils}
+import org.hammerlab.guacamole.variants.VariantComparisonTest
+import org.hammerlab.guacamole.{CancerWGSTestUtils, NA12878TestUtils}
 
 /**
  * Somatic joint-caller integration "tests" that output various statistics to stdout.
@@ -17,7 +20,7 @@ import org.hammerlab.guacamole.{CancerWGSTestUtils, Common, NA12878TestUtils}
  *     -cp target/guacamole-with-dependencies-0.0.1-SNAPSHOT.jar:target/scala-2.10.5/test-classes \
  *     org.hammerlab.guacamole.main.SomaticJointCallerIntegrationTests
  */
-object SomaticJointCallerIntegrationTests {
+object SomaticJointCallerIntegrationTests extends SparkCommand[Arguments] with VariantComparisonTest {
 
   var tempFileNum = 0
 
@@ -26,16 +29,19 @@ object SomaticJointCallerIntegrationTests {
     "/tmp/test-somatic-joint-caller-%d.vcf".format(tempFileNum)
   }
 
-  def main(args: Array[String]): Unit = {
+  override val name: String = "germline-assembly-integration-test"
+  override val description: String = "output various statistics to stdout"
 
-    val sc = Common.createSparkContext("SomaticJointCallerIntegrationTest")
+  def main(args: Array[String]): Unit = run(args)
+
+  override def run(args: Arguments, sc: SparkContext): Unit = {
 
     println("somatic calling on subset of 3-sample cancer patient 1")
     val outDir = "/tmp/guacamole-somatic-joint-test"
 
     if (true) {
       if (true) {
-        val args = new SomaticJoint.Arguments()
+        val args = new Arguments()
         args.outDir = outDir
         args.referenceFastaPath = CancerWGSTestUtils.referenceFastaPath
         args.referenceFastaIsPartial = true

--- a/src/test/scala/org/hammerlab/guacamole/variants/VariantComparisonTest.scala
+++ b/src/test/scala/org/hammerlab/guacamole/variants/VariantComparisonTest.scala
@@ -1,8 +1,8 @@
-package org.hammerlab.guacamole
+package org.hammerlab.guacamole.variants
 
 import java.io.File
 
-import htsjdk.variant.variantcontext.{Allele, GenotypeBuilder, VariantContext, VariantContextBuilder}
+import htsjdk.variant.variantcontext.{GenotypeBuilder, VariantContext, VariantContextBuilder, Allele => HTSJDKAllele}
 import htsjdk.variant.vcf.VCFFileReader
 import org.hammerlab.guacamole.reference.ReferenceBroadcast
 import org.hammerlab.guacamole.util.{Bases, VCFComparison}
@@ -37,7 +37,7 @@ case class VariantFromVarlensCSV(
 
     val alleles = Seq(adjustedRef, adjustedAlt).distinct
 
-    def makeHtsjdkAllele(allele: String): Allele = Allele.create(allele, allele == adjustedRef)
+    def makeHtsjdkAllele(allele: String): HTSJDKAllele = HTSJDKAllele.create(allele, allele == adjustedRef)
 
     val genotype = new GenotypeBuilder(tumor)
       .alleles(JavaConversions.seqAsJavaList(Seq(adjustedRef, adjustedAlt).map(makeHtsjdkAllele _)))
@@ -53,7 +53,7 @@ case class VariantFromVarlensCSV(
   }
 }
 
-object VariantComparisonUtils {
+trait VariantComparisonTest {
 
   def printSamplePairs(pairs: Seq[(VariantContext, VariantContext)], num: Int = 20): Unit = {
     val sample = pairs.take(num)
@@ -62,10 +62,10 @@ object VariantComparisonUtils {
       case (pair, num) => {
         println("(%4d) %20s vs %20s \tDETAILS: %20s vs %20s".format(
           num + 1,
-          VCFComparison.variantToString(pair._1, false),
-          VCFComparison.variantToString(pair._2, false),
-          VCFComparison.variantToString(pair._1, true),
-          VCFComparison.variantToString(pair._2, true)))
+          VCFComparison.variantToString(pair._1, verbose = false),
+          VCFComparison.variantToString(pair._2, verbose = false),
+          VCFComparison.variantToString(pair._1, verbose = true),
+          VCFComparison.variantToString(pair._2, verbose = true)))
       }
     })
   }
@@ -77,8 +77,8 @@ object VariantComparisonUtils {
       case (item, num) => {
         println("(%4d) %20s \tDETAILS: %29s".format(
           num + 1,
-          VCFComparison.variantToString(item, false),
-          VCFComparison.variantToString(item, true)))
+          VCFComparison.variantToString(item, verbose = false),
+          VCFComparison.variantToString(item, verbose = true)))
       }
     })
   }


### PR DESCRIPTION
- move Command into commands pkg
- split SparkCommand into own file
- move Common.createSparkContext into SparkCommand
- make "integration tests" SparkCommands
- make GermlineAssemblyCallerSuite a GuacFunSuite
  - reuse common test plumbing
  - it wasn't previously requiring Kryo registration
  - this enabled us to miss that some necessary classes were not being
    registered
- move `VariantComparisonUtils` to `variants.VariantComparisonTest`, make the integration tests mix it in

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/461)
<!-- Reviewable:end -->
