### PR TITLE
Consistently align scaladocs

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/distributed/HashMapAccumulatorParam.scala
+++ b/src/main/scala/org/hammerlab/guacamole/distributed/HashMapAccumulatorParam.scala
@@ -6,21 +6,21 @@ import org.apache.spark.{AccumulatorParam, SparkConf}
 import scala.collection.mutable.{HashMap => MutableHashMap}
 
 /**
-  * Allows a mutable HashMap[String, Long] to be used as an accumulator in Spark.
-  *
-  * When we put (k, v2) into an accumulator that already contains (k, v1), the result will be a HashMap containing
-  * (k, v1 + v2).
-  *
-  */
+ * Allows a mutable HashMap[String, Long] to be used as an accumulator in Spark.
+ *
+ * When we put (k, v2) into an accumulator that already contains (k, v1), the result will be a HashMap containing
+ * (k, v1 + v2).
+ *
+ */
 class HashMapAccumulatorParam extends AccumulatorParam[MutableHashMap[String, Long]] {
   /**
-    * Combine two accumulators. Adds the values in each hash map.
-    *
-    * This method is allowed to modify and return the first value for efficiency.
-    *
-    * @see org.apache.spark.GrowableAccumulableParam.addInPlace(r1: R, r2: R): R
-    *
-    */
+   * Combine two accumulators. Adds the values in each hash map.
+   *
+   * This method is allowed to modify and return the first value for efficiency.
+   *
+   * @see org.apache.spark.GrowableAccumulableParam.addInPlace(r1: R, r2: R): R
+   *
+   */
   def addInPlace(first: MutableHashMap[String, Long], second: MutableHashMap[String, Long]): MutableHashMap[String, Long] = {
     second.foreach(pair => {
       if (!first.contains(pair._1))
@@ -32,11 +32,11 @@ class HashMapAccumulatorParam extends AccumulatorParam[MutableHashMap[String, Lo
   }
 
   /**
-    * Zero value for the accumulator: the empty hash map.
-    *
-    * @see org.apache.spark.GrowableAccumulableParam.zero(initialValue: R): R
-    *
-    */
+   * Zero value for the accumulator: the empty hash map.
+   *
+   * @see org.apache.spark.GrowableAccumulableParam.zero(initialValue: R): R
+   *
+   */
   def zero(initialValue: MutableHashMap[String, Long]): MutableHashMap[String, Long] = {
     val ser = new JavaSerializer(new SparkConf(false)).newInstance()
     val copy = ser.deserialize[MutableHashMap[String, Long]](ser.serialize(initialValue))

--- a/src/main/scala/org/hammerlab/guacamole/distributed/KeyPartitioner.scala
+++ b/src/main/scala/org/hammerlab/guacamole/distributed/KeyPartitioner.scala
@@ -3,11 +3,11 @@ package org.hammerlab.guacamole.distributed
 import org.apache.spark.Partitioner
 
 /**
-  * Spark partitioner for keyed RDDs that assigns each unique key its own partition.
-  * Used to partition an RDD of (task number: Long, read: MappedRead) pairs, giving each task its own partition.
-  *
-  * @param numPartitions total number of partitions
-  */
+ * Spark partitioner for keyed RDDs that assigns each unique key its own partition.
+ * Used to partition an RDD of (task number: Long, read: MappedRead) pairs, giving each task its own partition.
+ *
+ * @param numPartitions total number of partitions
+ */
 case class KeyPartitioner(override val numPartitions: Int) extends Partitioner {
   def getPartition(key: Any): Int = key match {
     case value: Long         => value.toInt

--- a/src/main/scala/org/hammerlab/guacamole/distributed/PileupFlatmapUtils.scala
+++ b/src/main/scala/org/hammerlab/guacamole/distributed/PileupFlatmapUtils.scala
@@ -13,11 +13,11 @@ import scala.reflect.ClassTag
 
 object PileupFlatMapUtils {
   /**
-    * Helper function. Given optionally an existing Pileup, and a sliding read window return a new Pileup at the given
-    * locus. If an existing Pileup is given as input, then the result will share elements with that Pileup for efficiency.
-    *
-    *  If an existing Pileup is provided, then its locus must be <= the new locus.
-    */
+   * Helper function. Given optionally an existing Pileup, and a sliding read window return a new Pileup at the given
+   * locus. If an existing Pileup is given as input, then the result will share elements with that Pileup for efficiency.
+   *
+   *  If an existing Pileup is provided, then its locus must be <= the new locus.
+   */
   private def initOrMovePileup(existing: Option[Pileup],
                                window: SlidingWindow[MappedRead],
                                referenceContigSequence: ContigSequence): Pileup = {
@@ -58,6 +58,7 @@ object PileupFlatMapUtils {
       }
     )
   }
+
   /**
    * Flatmap across loci on two RDDs of MappedReads. At each locus the provided function is passed two Pileup instances,
    * giving the pileup for the reads in each RDD at that locus.

--- a/src/main/scala/org/hammerlab/guacamole/distributed/RegionsByContig.scala
+++ b/src/main/scala/org/hammerlab/guacamole/distributed/RegionsByContig.scala
@@ -3,22 +3,22 @@ package org.hammerlab.guacamole.distributed
 import org.hammerlab.guacamole.reference.ReferenceRegion
 
 /**
-  * Using an iterator of regions sorted by (contig, start locus), this class exposes a way to get separate iterators
-  * over the regions in each contig.
-  *
-  * For example, given these regions (written as contig:start locus):
-  *    chr20:1000,chr20:1500,chr21:200
-  *
-  * Calling next("chr20") will return an iterator of two regions (chr20:1000 and chr20:1500). After that, calling
-  * next("chr21") will give an iterator of one region (chr21:200).
-  *
-  * Note that you must call next("chr20") before calling next("chr21") in this example. That is, this class does not
-  * buffer anything -- it just walks forward in the regions using the iterator you gave it.
-  *
-  * Also note that after calling next("chr21"), the iterator returned by our previous call to next() is invalidated.
-  *
-  * @param regionIterator regions, sorted by contig and start locus.
-  */
+ * Using an iterator of regions sorted by (contig, start locus), this class exposes a way to get separate iterators
+ * over the regions in each contig.
+ *
+ * For example, given these regions (written as contig:start locus):
+ *    chr20:1000,chr20:1500,chr21:200
+ *
+ * Calling next("chr20") will return an iterator of two regions (chr20:1000 and chr20:1500). After that, calling
+ * next("chr21") will give an iterator of one region (chr21:200).
+ *
+ * Note that you must call next("chr20") before calling next("chr21") in this example. That is, this class does not
+ * buffer anything -- it just walks forward in the regions using the iterator you gave it.
+ *
+ * Also note that after calling next("chr21"), the iterator returned by our previous call to next() is invalidated.
+ *
+ * @param regionIterator regions, sorted by contig and start locus.
+ */
 class RegionsByContig[R <: ReferenceRegion](regionIterator: Iterator[R]) {
   private val buffered = regionIterator.buffered
   private var seenContigs = List.empty[String]

--- a/src/main/scala/org/hammerlab/guacamole/distributed/SingleContigRegionIterator.scala
+++ b/src/main/scala/org/hammerlab/guacamole/distributed/SingleContigRegionIterator.scala
@@ -3,9 +3,9 @@ package org.hammerlab.guacamole.distributed
 import org.hammerlab.guacamole.reference.ReferenceRegion
 
 /**
-  * Wraps an iterator of regions sorted by contig name. Implements an iterator that gives regions only for the specified
-  * contig name, then stops.
-  */
+ * Wraps an iterator of regions sorted by contig name. Implements an iterator that gives regions only for the specified
+ * contig name, then stops.
+ */
 class SingleContigRegionIterator[R <: ReferenceRegion](contig: String, iterator: BufferedIterator[R]) extends Iterator[R] {
 
   def hasNext = iterator.hasNext && iterator.head.referenceContig == contig

--- a/src/main/scala/org/hammerlab/guacamole/distributed/TaskPosition.scala
+++ b/src/main/scala/org/hammerlab/guacamole/distributed/TaskPosition.scala
@@ -1,13 +1,13 @@
 package org.hammerlab.guacamole.distributed
 
 /**
-  * TaskPosition represents the task a read is assigned to and the start position on the reference genome of the read
-  * Each read is assigned to a task and the reads are sorted by (referenceContig, locus) when they are processed
-  *
-  * @param task Task ID
-  * @param referenceContig Reference or chromosome name for reads
-  * @param locus The position in the reference contig at which the read starts
-  */
+ * TaskPosition represents the task a read is assigned to and the start position on the reference genome of the read
+ * Each read is assigned to a task and the reads are sorted by (referenceContig, locus) when they are processed
+ *
+ * @param task Task ID
+ * @param referenceContig Reference or chromosome name for reads
+ * @param locus The position in the reference contig at which the read starts
+ */
 case class TaskPosition(task: Int, referenceContig: String, locus: Long) extends Ordered[TaskPosition] {
 
   // Sorting is performed by first sorting on task, secondly on contig and lastly on the start locus

--- a/src/main/scala/org/hammerlab/guacamole/distributed/WindowFlatMapUtils.scala
+++ b/src/main/scala/org/hammerlab/guacamole/distributed/WindowFlatMapUtils.scala
@@ -112,31 +112,31 @@ object WindowFlatMapUtils {
   }
 
   /**
-    * FlatMap across sets of regions (e.g. reads) overlapping genomic partitions, on multiple RDDs.
-    *
-    * This function works as follows:
-    *
-    *  (1) Assign regions to partitions. A region may overlap multiple partitions, and therefore be assigned to multiple
-    *      partitions.
-    *
-    *  (2) For each partition, call the provided function. The arguments to this function are the task number, the loci
-    *      assigned to this task, and a sequence of iterators giving the regions overlapping those loci (within the
-    *      specified halfWindowSize) from each corresponding input RDD. The loci assigned to this task are always unique
-    *      to this task, but the same regions may be provided to multiple tasks, since regions may overlap loci partition
-    *      boundaries.
-    *
-    *  (3) The results of the provided function are concatenated into an RDD, which is returned.
-    *
-    * @param regionRDDs RDDs of reads, one per sample.
-    * @param lociPartitions map from locus -> task number. This argument specifies both the loci to be considered and how
-    *                       they should be split among tasks. regions that don't overlap these loci are discarded.
-    * @param halfWindowSize if a region overlaps a region of halfWindowSize to either side of a locus under consideration,
-    *                       then it is included.
-    * @param function function to flatMap: (task number, loci, iterators of regions that overlap a window around these
-    *                 loci (one region-iterator per sample)) -> T
-    * @tparam T type of value returned by function
-    * @return flatMap results, RDD[T]
-    */
+   * FlatMap across sets of regions (e.g. reads) overlapping genomic partitions, on multiple RDDs.
+   *
+   * This function works as follows:
+   *
+   *  (1) Assign regions to partitions. A region may overlap multiple partitions, and therefore be assigned to multiple
+   *      partitions.
+   *
+   *  (2) For each partition, call the provided function. The arguments to this function are the task number, the loci
+   *      assigned to this task, and a sequence of iterators giving the regions overlapping those loci (within the
+   *      specified halfWindowSize) from each corresponding input RDD. The loci assigned to this task are always unique
+   *      to this task, but the same regions may be provided to multiple tasks, since regions may overlap loci partition
+   *      boundaries.
+   *
+   *  (3) The results of the provided function are concatenated into an RDD, which is returned.
+   *
+   * @param regionRDDs RDDs of reads, one per sample.
+   * @param lociPartitions map from locus -> task number. This argument specifies both the loci to be considered and how
+   *                       they should be split among tasks. regions that don't overlap these loci are discarded.
+   * @param halfWindowSize if a region overlaps a region of halfWindowSize to either side of a locus under
+   *                       consideration, then it is included.
+   * @param function function to flatMap: (task number, loci, iterators of regions that overlap a window around these
+   *                 loci (one region-iterator per sample)) -> T
+   * @tparam T type of value returned by function
+   * @return flatMap results, RDD[T]
+   */
   private[distributed] def windowTaskFlatMapMultipleRDDs[R <: ReferenceRegion: ClassTag, T: ClassTag](
     regionRDDs: PerSample[RDD[R]],
     lociPartitions: LociPartitioning,
@@ -215,17 +215,17 @@ object WindowFlatMapUtils {
   }
 
   /**
-    *
-    * Generates a sequence of results from each task (using the `generateFromWindows` function)
-    * and collects them into a single iterator
-    *
-    * @param taskRegionsPerSample for each sample, elements of type M to process for this task
-    * @param taskLoci Set of loci to process for this task
-    * @param halfWindowSize A window centered at locus = l will contain regions overlapping l +/- halfWindowSize
-    * @param generateFromWindows Function that maps windows to result type
-    * @tparam T result data type
-    * @return Iterator[T] collected from each contig
-    */
+   *
+   * Generates a sequence of results from each task (using the `generateFromWindows` function)
+   * and collects them into a single iterator
+   *
+   * @param taskRegionsPerSample for each sample, elements of type M to process for this task
+   * @param taskLoci Set of loci to process for this task
+   * @param halfWindowSize A window centered at locus = l will contain regions overlapping l +/- halfWindowSize
+   * @param generateFromWindows Function that maps windows to result type
+   * @tparam T result data type
+   * @return Iterator[T] collected from each contig
+   */
   def collectByContig[R <: ReferenceRegion: ClassTag, T: ClassTag](
     taskRegionsPerSample: PerSample[Iterator[R]],
     taskLoci: LociSet,

--- a/src/main/scala/org/hammerlab/guacamole/loci/map/Contig.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/map/Contig.scala
@@ -48,8 +48,8 @@ case class Contig[T](name: String, private val rangeMap: RangeMap[JLong, T]) ext
   }
 
   /**
-    * Map from each value found in this Contig to a LociSet Contig representing the loci that map to that value.
-    */
+   * Map from each value found in this Contig to a LociSet Contig representing the loci that map to that value.
+   */
   lazy val inverse: Map[T, LociSetContig] = {
     val map = mutable.HashMap[T, ArrayBuffer[JRange[JLong]]]()
     for {

--- a/src/main/scala/org/hammerlab/guacamole/loci/map/ContigSerializer.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/map/ContigSerializer.scala
@@ -4,8 +4,8 @@ import com.esotericsoftware.kryo.io.{Input, Output}
 import com.esotericsoftware.kryo.{Kryo, Serializer => KryoSerializer}
 
 /**
-  * We serialize a Contig as its name, the number of ranges, and the ranges themselves (two longs and a value each).
-  */
+ * We serialize a Contig as its name, the number of ranges, and the ranges themselves (two longs and a value each).
+ */
 class ContigSerializer[T] extends KryoSerializer[Contig[T]] {
   def write(kryo: Kryo, output: Output, obj: Contig[T]) = {
     output.writeString(obj.name)

--- a/src/main/scala/org/hammerlab/guacamole/loci/map/Serializer.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/map/Serializer.scala
@@ -6,8 +6,8 @@ import com.esotericsoftware.kryo.{Kryo, Serializer => KryoSerializer}
 import scala.collection.immutable.TreeMap
 
 /**
-  * We serialize a LociMap simply by writing out all of its Contigs.
-  */
+ * We serialize a LociMap simply by writing out all of its Contigs.
+ */
 class Serializer[T] extends KryoSerializer[LociMap[T]] {
   def write(kryo: Kryo, output: Output, obj: LociMap[T]) = {
     output.writeLong(obj.contigs.size)

--- a/src/main/scala/org/hammerlab/guacamole/loci/set/Builder.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/set/Builder.scala
@@ -3,8 +3,8 @@ package org.hammerlab.guacamole.loci.set
 import scala.collection.SortedMap
 
 /**
-  * Build a LociSet out of Contigs.
-  */
+ * Build a LociSet out of Contigs.
+ */
 private[loci] class Builder {
   private val map = SortedMap.newBuilder[String, Contig]
 

--- a/src/main/scala/org/hammerlab/guacamole/loci/set/Contig.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/set/Contig.scala
@@ -11,8 +11,8 @@ import scala.collection.JavaConversions._
 import scala.collection.mutable.ArrayBuffer
 
 /**
-  * A set of loci on a contig, stored/manipulated as loci ranges.
-  */
+ * A set of loci on a contig, stored/manipulated as loci ranges.
+ */
 case class Contig(name: String, private val rangeSet: RangeSet[JLong]) extends TruncatedToString {
 
   /** Is the given locus contained in this set? */
@@ -40,10 +40,10 @@ case class Contig(name: String, private val rangeSet: RangeSet[JLong]) extends T
   def intersects(start: Long, end: Long): Boolean = !rangeSet.subRangeSet(JRange.closedOpen(start, end)).isEmpty
 
   /**
-    * Make two new Contigs: one with the first @numToTake loci from this Contig, and the second with the rest.
-    *
-    * Used by LociSet.take.
-    */
+   * Make two new Contigs: one with the first @numToTake loci from this Contig, and the second with the rest.
+   *
+   * Used by LociSet.take.
+   */
   private[set] def take(numToTake: Long): (Contig, Contig) = {
     val firstRanges = ArrayBuffer[JRange[JLong]]()
     val secondRanges = ArrayBuffer[JRange[JLong]]()
@@ -69,9 +69,9 @@ case class Contig(name: String, private val rangeSet: RangeSet[JLong]) extends T
   }
 
   /**
-    * Iterator over string representations of each range in the map, used to assemble (possibly truncated) .toString()
-    * output.
-    */
+   * Iterator over string representations of each range in the map, used to assemble (possibly truncated) .toString()
+   * output.
+   */
   def stringPieces = {
     ranges.iterator.map(pair =>
       "%s:%d-%d".format(name, pair.start, pair.end)

--- a/src/main/scala/org/hammerlab/guacamole/loci/set/LociSet.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/set/LociSet.scala
@@ -118,10 +118,10 @@ object LociSet {
   def apply(loci: String): LociSet = LociParser(loci).result
 
   /**
-    * These constructors build a LociSet directly from Contigs.
-    *
-    * They operate on an Iterator so that transformations to the data happen in one pass.
-    */
+   * These constructors build a LociSet directly from Contigs.
+   *
+   * They operate on an Iterator so that transformations to the data happen in one pass.
+   */
   private[set] def fromContigs(contigs: Iterable[Contig]): LociSet = fromContigs(contigs.iterator)
   private[set] def fromContigs(contigs: Iterator[Contig]): LociSet =
     LociSet(

--- a/src/main/scala/org/hammerlab/guacamole/reference/ReferenceGenome.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reference/ReferenceGenome.scala
@@ -7,11 +7,11 @@ import org.hammerlab.guacamole.util.Bases
 trait ReferenceGenome {
 
   /**
-    * Path where this reference was loaded from, or other description of its provenance (optional).
-    *
-    * For provenance tracking only. Not guaranteed to be a valid path or on a filesystem that is currently accessible.
-    *
-    */
+   * Path where this reference was loaded from, or other description of its provenance (optional).
+   *
+   * For provenance tracking only. Not guaranteed to be a valid path or on a filesystem that is currently accessible.
+   *
+   */
   val source: Option[String]
 
   /**

--- a/src/main/scala/org/hammerlab/guacamole/strings/TruncatedToString.scala
+++ b/src/main/scala/org/hammerlab/guacamole/strings/TruncatedToString.scala
@@ -9,18 +9,18 @@ trait TruncatedToString {
   }
 
   /**
-    * Iterator over string representations of
-    */
+   * Iterator over string representations of
+   */
   def stringPieces: Iterator[String]
 }
 
 object TruncatedToString {
   /**
-    * Like Scala's List.mkString method, but supports truncation.
-    *
-    * Return the concatenation of an iterator over strings, separated by separator, truncated to at most maxLength
-    * characters. If truncation occurs, the string is terminated with ellipses.
-    */
+   * Like Scala's List.mkString method, but supports truncation.
+   *
+   * Return the concatenation of an iterator over strings, separated by separator, truncated to at most maxLength
+   * characters. If truncation occurs, the string is terminated with ellipses.
+   */
   def apply(pieces: Iterator[String],
             maxLength: Int,
             separator: String = ",",


### PR DESCRIPTION
Per discussion on #467, we align to the first asterisk of the opening `/**` of a scaladoc most of the time:

```
$ gfs '.scala' | p "po -hM ' *\/\*\*.*?\n *\*' {}" | cls | tts | subtract | hist
  26 2
 299 1
```

That's 26 blocks aligned to the 2nd asterisk, 299 aligned to the 1st.

On the other hand, apparently [the official scala edict](http://docs.scala-lang.org/style/scaladoc.html) puts them under the 2nd one.

I am fine to make it either way; this PR currently puts them all under the first one. Let's decide on one and use this PR to make it so and then never think about it again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/469)
<!-- Reviewable:end -->
