### PR TITLE
pom profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,18 +27,41 @@ inspiration from the [Avocado][] project.
 
 For hacking Guacamole, see our [code docs][].
 
-# Running Guacamole on a Single Node
+## Building
 
-Guacamole requires [Apache Maven][maven] (version 3.0.4 or higher).
+Building Guacamole requires [Apache Maven][maven] (version 3.0.4 or higher).
 
-Build:
+You'll generally want two JARs to be on your classpath when you run Guacamole:
+
+- the main Guacamole JAR, and
+- a shaded JAR with all of Guacamole's transitive dependencies.
+
+The former can be built in any of the following ways:
 
 ```
 mvn package
+mvn package -DskipTests  # don't run tests, just package the JAR.
+mvn package -Pguac       # this is the default Maven profile, but can be useful for combining with other profiles as examples below demonstrate.
 ```
 
-This will build a guacamole JAR file in the `target` directory. You can use the
-`guacamole` script to run locally:
+The latter can be built using the `deps` profile:
+
+```
+mvn package -Pdeps
+mvn package -Pdeps -DskipTests
+```
+
+You can also build both at once:
+
+```
+mvn package -Pguac,deps
+mvn package -Pguac,deps -DskipTests
+```
+
+## Running
+
+### Running Locally
+`scripts/guacamole` makes it easy to run locally:
 
 ```
 scripts/guacamole somatic-joint \
@@ -67,26 +90,26 @@ scripts/guacamole <caller> -h
 ```
 for help on a particular variant caller.
 
-# Running Guacamole on a Hadoop Cluster
+### Running on a Hadoop Cluster
 
-See Guacamole's [pom.xml](/pom.xml) file for the versions of Hadoop and Spark
-that Guacamole expects to find on your cluster.
+Guacamole currently builds against Spark 1.6.1 and Hadoop 2.7.0, though it will likely run fine with versions close to those.
 
 Here is an example command to get started using Guacamole in Spark's yarn
 cluster mode. You'll probably have to modify it for your environment. 
 
 ```
+version=0.0.1-SNAPSHOT
 spark-submit \
 	--master yarn \
 	--deploy-mode cluster \
-	--driver-java-options -Dlog4j.configuration=/path/to/guacamole/scripts/log4j.properties \
 	--executor-memory 4g \
 	--driver-memory 10g \
 	--num-executors 1000 \
 	--executor-cores 1 \
 	--class org.hammerlab.guacamole.Main \
+	--jars target/guacamole-deps-only-$version.jar \
 	--verbose \
-	/path/to/target/guacamole-with-dependencies-<x.y.z>.jar \
+	target/guacamole-$version.jar \
 	somatic-joint \
     		/hdfs/path/to/normal.bam \
     		/hdfs/path/to/tumor.bam \

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <hadoop.version>2.7.0</hadoop.version>
     <spark.version>1.6.1</spark.version>
     <maven.release.plugin.version>2.4.1</maven.release.plugin.version>
+    <shade.plugin.version>2.1</shade.plugin.version>
   </properties>
 
   <licenses>
@@ -48,19 +49,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.1</version>
+        <version>${shade.plugin.version}</version>
         <configuration>
           <transformers>
             <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
               <mainClass>org.hammerlab.guacamole.Main</mainClass>
             </transformer>
-            <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-              <resource>reference.conf</resource>
-            </transformer>
-            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
           </transformers>
-          <shadedArtifactAttached>true</shadedArtifactAttached>
-          <finalName>guacamole-with-dependencies-${project.version}</finalName>
           <filters>
             <filter>
               <artifact>*:*</artifact>
@@ -80,24 +75,7 @@
               <exclude>org.apache.maven:lib:tests</exclude>
             </excludes>
           </artifactSet>
-          <relocations>
-            <relocation>
-              <pattern>com.google.common</pattern>
-              <shadedPattern>org.bdgenomics.guavarelocated</shadedPattern>
-              <includes>
-                <include>com.google.common.**</include>
-              </includes>
-            </relocation>
-          </relocations>
         </configuration>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>net.alchim31.maven</groupId>
@@ -359,6 +337,49 @@
   </dependencies>
 
   <profiles>
+    <profile>
+      <!-- Default profile: build Guacamole jar with shaded Guava. -->
+      <id>guac</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>default</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <configuration>
+                  <finalName>guacamole-${project.version}</finalName>
+                  <relocations>
+                    <relocation>
+                      <pattern>com.google.common</pattern>
+                      <shadedPattern>org.hammerlab.guavarelocated</shadedPattern>
+                      <includes>
+                        <include>com.google.common.**</include>
+                      </includes>
+                    </relocation>
+                  </relocations>
+                  <artifactSet>
+                    <includes>
+                      <include>org.hammerlab.guacamole:*</include>
+                      <include>com.google.guava:*</include>
+                    </includes>
+                  </artifactSet>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <!-- Only build coverage in when we want to run coverage -->
     <profile>
       <id>coverage</id>
@@ -395,7 +416,6 @@
         </plugins>
       </build>
     </profile>
-
     <profile>
       <id>cluster</id>
       <dependencies>
@@ -455,6 +475,68 @@
                 <goals>
                   <goal>sign</goal>
                 </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!-- "uber" profile: build a JAR with Guacamole and all transitive dependencies shaded, and Guava relocated. -->
+      <id>uber</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>deps</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <configuration>
+                  <finalName>guacamole-with-deps-${project.version}</finalName>
+                  <relocations>
+                    <relocation>
+                      <pattern>com.google.common</pattern>
+                      <shadedPattern>org.hammerlab.guavarelocated</shadedPattern>
+                      <includes>
+                        <include>com.google.common.**</include>
+                      </includes>
+                    </relocation>
+                  </relocations>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!-- "deps" profile: build a JAR with just Guacamole's transitive dependencies. -->
+      <id>deps</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>deps</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <configuration>
+                  <finalName>guacamole-deps-only-${project.version}</finalName>
+                  <artifactSet>
+                    <excludes>
+                      <exclude>org.hammerlab.guacamole:*</exclude>
+                    </excludes>
+                  </artifactSet>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/scripts/guacamole
+++ b/scripts/guacamole
@@ -6,8 +6,8 @@
 echo "$@" >> ~/.guacamole.invocations.log
 
 if [ -z "${GUACAMOLE_JAR}" ]; then
-    jar="$(ls -tc target/guacamole-with-dependencies-*.jar | head -n 1)"
-    if [ -z "$jar" ]; then
+    GUACAMOLE_JAR="$(ls -tc target/guacamole-*.jar | grep -v deps | head -n 1)"
+    if [ -z "$GUACAMOLE_JAR" ]; then
         cat 1>&2 << EOF
 Couldn't find a Guacamole jar in the target/ directory.
 Are you in the root directory of the Guacamole repo, and have you built Guacamole?
@@ -16,11 +16,25 @@ To build, run:
 EOF
         exit 1
     fi
-    echo "Using most recently modified jar: $jar"
+    echo "Found guac jar: $GUACAMOLE_JAR"
 else
-    jar="${GUACAMOLE_JAR}"
-    echo "Using GUACAMOLE_JAR=$jar"
+    echo "Using GUACAMOLE_JAR=$GUACAMOLE_JAR"
 fi
 
-exec time java -Xmx4g -XX:MaxPermSize=512m "-Dspark.master=local[1]" -cp "$jar" org.hammerlab.guacamole.Main "$@"
+if [ -z "$GUACAMOLE_DEPS_JAR" ]; then
+  GUACAMOLE_DEPS_JAR="$(ls -tc target/guacamole-deps-only-*.jar | head -n 1)"
+  if [ -z "$GUACAMOLE_DEPS_JAR" ]; then
+        cat 1>&2 << EOF
+Couldn't find a Guacamole deps jar in the target/ directory.
+Are you in the root directory of the Guacamole repo, and have you built Guacamole?
+To build, run:
+    mvn package -DskipTests=true"
+EOF
+        exit 1
+  fi
+else
+  echo "Using GUACAMOLE_DEPS_JAR=$GUACAMOLE_DEPS_JAR"
+fi
+
+exec time java -Xmx4g -XX:MaxPermSize=512m "-Dspark.master=local[1]" -cp "$GUACAMOLE_JAR:$GUACAMOLE_DEPS_JAR" org.hammerlab.guacamole.Main "$@"
 


### PR DESCRIPTION
New Maven profiles:
- default (`-Pguac`): build a guac jar with relocated guava classes shaded.
- `-Pdeps`: build a shaded jar of all deps, but not including guac or relocated guava.
- `-Puber`: build a JAR that is all of the above (current default).

This solves two problems:
- when iteratively building guac, jars have to be repackaged for every trivial change.
  - the uber jar takes >70s locally when not even responding to any compilation changes.
  - the new default guac jar takes ~20s locally.
- the `guacamole-<version>.jar` JAR that Maven will pick up by anything depending on `org.hammerlab.guacamole:guacamole:<version>` will now have shaded+relocated guava in it; the previous lack of it made the JAR basically unusable via this route, afaict.

Suggested workflow:
```
alias mvp="mvn package -DskipTests"
mvp -Pdeps  # once, or only when dependencies change
mvp         # while developing
version=0.0.1-SNAPSHOT
main=org.hammerlab.guacamole.Main
guac_jar=target/guacamole-$version.jar
guac_deps_jar=target/guacamole-deps-only-$version.jar
spark-submit <spark confs> --class $main $guac_jar --jars $guac_deps_jar <guac args>
```

To build both the "guac" and "deps" JARs in one cmd:

```
mvp -Pguac,deps
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/482)
<!-- Reviewable:end -->
