### PR TITLE
improve LociMap/Set serde

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/loci/map/LociMap.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/map/LociMap.scala
@@ -34,16 +34,17 @@ import scala.collection.{SortedMap, mutable}
  *
  * @param map Map from contig names to [[Contig]] instances giving the regions and values on that contig.
  */
-case class LociMap[T](private val map: SortedMap[ContigName, Contig[T]]) extends TruncatedToString {
+case class LociMap[T](@transient private val map: SortedMap[ContigName, Contig[T]])
+  extends TruncatedToString {
 
   /** The contigs included in this LociMap with a nonempty set of loci. */
-  lazy val contigs = map.values.toSeq
+  @transient lazy val contigs = map.values.toSeq
 
   /** The number of loci in this LociMap. */
-  lazy val count: Long = contigs.map(_.count).sum
+  @transient lazy val count: Long = contigs.map(_.count).sum
 
   /** The "inverse map", i.e. a T -> LociSet map that gives the loci that map to each value. */
-  lazy val inverse: Map[T, LociSet] = {
+  @transient lazy val inverse: Map[T, LociSet] = {
     val mapOfBuilders = new mutable.HashMap[T, LociSetBuilder]()
     for {
       contig <- contigs

--- a/src/main/scala/org/hammerlab/guacamole/loci/map/Serializer.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/map/Serializer.scala
@@ -19,11 +19,10 @@ class Serializer[T] extends KryoSerializer[LociMap[T]] {
 
   def read(kryo: Kryo, input: Input, klass: Class[LociMap[T]]): LociMap[T] = {
     val count: Long = input.readLong()
-    val pairs = (0L until count).map(i => {
-      val obj = kryo.readObject(input, classOf[Contig[T]])
-      obj.name -> obj
+    val contigs = (0L until count).map(i => {
+      kryo.readObject(input, classOf[Contig[T]])
     })
-    LociMap[T](TreeMap[String, Contig[T]](pairs: _*))
+    LociMap[T](contigs)
   }
 }
 

--- a/src/main/scala/org/hammerlab/guacamole/loci/set/LociSet.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/set/LociSet.scala
@@ -49,10 +49,10 @@ import scala.collection.immutable.TreeMap
 case class LociSet(private val map: SortedMap[ContigName, Contig]) extends TruncatedToString {
 
   /** The contigs included in this LociSet with a nonempty set of loci. */
-  lazy val contigs = map.values.toArray
+  @transient lazy val contigs = map.values.toArray
 
   /** The number of loci in this LociSet. */
-  lazy val count: NumLoci = contigs.map(_.count).sum
+  @transient lazy val count: NumLoci = contigs.map(_.count).sum
 
   def isEmpty = map.isEmpty
   def nonEmpty = map.nonEmpty

--- a/src/test/scala/org/hammerlab/guacamole/loci/set/SerializerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/loci/set/SerializerSuite.scala
@@ -1,5 +1,7 @@
 package org.hammerlab.guacamole.loci.set
 
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
+
 import com.esotericsoftware.kryo.Kryo
 import org.hammerlab.guacamole.util.{GuacFunSuite, KryoTestRegistrar}
 
@@ -63,5 +65,23 @@ class SerializerSuite extends GuacFunSuite {
     val rdd = sc.parallelize(0L until 1000L)
     val result = rdd.filter(i => setBC.value.onContig("chr21").contains(i)).collect
     result should equal(100L until 200)
+  }
+
+  test("java serialization") {
+    val loci = LociSet("chr21:100-200,chr20:0-10,chr20:8-15,chr20:100-120,empty:10-10")
+
+    val baos = new ByteArrayOutputStream()
+    val oos = new ObjectOutputStream(baos)
+
+    oos.writeObject(loci)
+    oos.close()
+
+    val bytes = baos.toByteArray
+    val bais = new ByteArrayInputStream(bytes)
+    val ois = new ObjectInputStream(bais)
+
+    val loci2 = ois.readObject().asInstanceOf[LociSet]
+
+    loci2 should be(loci)
   }
 }


### PR DESCRIPTION
in the course of broadcasting LociMaps and LociSets in a spark repl,
they can be java serialized, which was throwing errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/495)
<!-- Reviewable:end -->
