### PR TITLE
VAFHistogram/VariantSupport: handle multiple samples in one RDD pipeline

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/commands/VAFHistogram.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/VAFHistogram.scala
@@ -124,8 +124,6 @@ object VAFHistogram {
 
       val ReadSets(_, _, contigLengths) = readsets
 
-      val mappedReadsRDDs = readsets.mappedReadsRDDs
-
       val partitionedReads =
         PartitionedRegions(
           readsets.mappedReadsRDDs,
@@ -189,7 +187,11 @@ object VAFHistogram {
       }
 
       if (args.cluster) {
-        val variantsPerSample = variantLoci.keyBy(_.sampleId).splitByKey(numVariantsPerSample)
+        val variantsPerSample =
+          variantLoci
+            .keyBy(_.sampleId)
+            .splitByKey(numVariantsPerSample)
+
         for {
           (sampleId, variants) <- variantsPerSample
         } {
@@ -202,9 +204,10 @@ object VAFHistogram {
   /**
    * Generates a count of loci in each variant allele frequency bins
    *
-   * @param variantAlleleFrequencies RDD of loci with variant allele frequency > 0
-   * @param bins Number of bins to group the VAFs into
-   * @return Map of rounded variant allele frequency to number of loci with that value
+   * @param variantAlleleFrequencies RDD of loci with variant allele frequency > 0.
+   * @param bins Number of bins to group the VAFs into.
+   * @return Map from sample name to per-sample sorted [[Vector]] of tuples containing a [rounded variant allele
+   *         frequency] and [the number of loci with that VAF].
    */
   def generateVAFHistograms(variantAlleleFrequencies: RDD[VariantLocus],
                             bins: Int): Map[SampleId, Vector[(Int, Long)]] = {

--- a/src/main/scala/org/hammerlab/guacamole/reads/MappedRead.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/MappedRead.scala
@@ -49,7 +49,6 @@ case class MappedRead(
     isPositiveStrand: Boolean,
     isPaired: Boolean)
   extends Read
-
     with ReferenceRegion {
 
   assert(baseQualities.length == sequence.length,

--- a/src/test/scala/org/hammerlab/guacamole/commands/VariantSupportSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/VariantSupportSuite.scala
@@ -40,10 +40,11 @@ class VariantSupportSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     val computedAlleleCounts =
       (for {
         AlleleCount(_, _, _, ref, alternate, count) <- VariantSupport.Caller.pileupsToAlleleCounts(Vector(pileup))
-      } yield (ref, alternate, count)
+      } yield
+        (ref, alternate, count)
       )
-        .toArray
-        .sortBy(x => x)
+      .toArray
+      .sortBy(x => x)
 
     computedAlleleCounts should be(alleleCounts.sortBy(x => x))
   }


### PR DESCRIPTION
Previously these commands were processing N RDDs basically in sequence. Where possible, it's good to multiplex a given sequence of RDD operations, processing all the samples at once, keeping their elements distinguishable from one another's using some field as a key, to improve efficiency, allowing executors to flexibly perform tasks from any sample, etc.

I've done that here to VariantSupport and to some of the VAFHistogram pipeline.

However, VAFHistogram's mixture-model-building step uses an mllib API that doesn't allow for this sort of multiplexing, meaning it will necessarily process samples sequentially.

In such a case it makes more sense to handle processing multiple samples elsewhere in a pipeline than within one Spark app, which can only process them in serial; cf. discussion [here](https://github.com/bigdatagenomics/adam/issues/833).

So, this PR makes VAFHIstogram only create one model in a run. Previously this would have corresponded to only processing one sample per run, but I've also added functionality that allows it to process multiple samples at once and build a model across all of them, just to round out the distinctions about what kind of multi-sample processing makes sense where.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/502)
<!-- Reviewable:end -->
