### PR TITLE
rm pileup overlapsLocus check

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/pileup/Pileup.scala
+++ b/src/main/scala/org/hammerlab/guacamole/pileup/Pileup.scala
@@ -128,7 +128,7 @@ object Pileup {
   /**
    * Given reads and a locus, returns a [[Pileup]] at the specified locus.
    *
-   * @param reads Sequence of reads, in any order, that may or may not overlap the locus.
+   * @param reads Sequence of reads, in any order, that must overlap the locus.
    * @param contigName The contig these reads lie on.
    * @param locus The locus to return a [[Pileup]] at.
    * @param contigSequence The reference for this pileup's contig
@@ -138,8 +138,7 @@ object Pileup {
             contigName: ContigName,
             locus: Locus,
             contigSequence: ContigSequence): Pileup = {
-    //TODO: Is this call to overlaps locus necessary?
-    val elements = reads.filter(_.overlapsLocus(locus)).map(PileupElement(_, locus, contigSequence))
+    val elements = reads.map(PileupElement(_, locus, contigSequence))
     Pileup(contigName, locus, contigSequence, elements.toIndexedSeq)
   }
 }

--- a/src/test/scala/org/hammerlab/guacamole/jointcaller/PileupStatsSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/jointcaller/PileupStatsSuite.scala
@@ -26,9 +26,10 @@ class PileupStatsSuite extends GuacFunSuite {
       TestUtil.makeRead("TCGCTCGA", "8M", 1, qualityScores = Some(Seq.fill(8)(50))),
       TestUtil.makeRead("TCGCTCGA", "8M", 1, qualityScores = Some(Seq.fill(8)(50))),
       TestUtil.makeRead("TCGACCCTCGA", "4M3I4M", 1, qualityScores = Some(Seq.fill(11)(30))))
-    val pileups = (0 until refString.length).map(locus => Pileup(reads, "chr1", locus, contigSequence))
 
-    val stats1 = PileupStats.apply(pileups(2).elements, Bases.stringToBases("G"))
+    val pileups = (1 until refString.length).map(locus => Pileup(reads, "chr1", locus, contigSequence))
+
+    val stats1 = PileupStats.apply(pileups(1).elements, Bases.stringToBases("G"))
     stats1.totalDepthIncludingReadsContributingNoAlleles should equal(6)
     stats1.allelicDepths should equal(Map("G" -> 6))
     stats1.nonRefAlleles should equal(Seq.empty)
@@ -36,7 +37,7 @@ class PileupStatsSuite extends GuacFunSuite {
     assert(stats1.logLikelihoodPileup(Map("G" -> 1.0)) > stats1.logLikelihoodPileup(Map("G" -> .99, "C" -> .01)))
     assert(stats1.logLikelihoodPileup(Map("T" -> 1.0)) < stats1.logLikelihoodPileup(Map("G" -> .99, "C" -> .01)))
 
-    val stats2 = PileupStats.apply(pileups(3).elements, Bases.stringToBases("A"))
+    val stats2 = PileupStats.apply(pileups(2).elements, Bases.stringToBases("A"))
     stats2.allelicDepths should equal(Map("A" -> 2, "C" -> 3, "ACCC" -> 1))
     stats2.nonRefAlleles should equal(Seq("C", "ACCC"))
     assert(stats2.logLikelihoodPileup(Map("A" -> 0.5, "C" -> 0.5)) > stats2.logLikelihoodPileup(Map("A" -> 1.0)))
@@ -44,7 +45,7 @@ class PileupStatsSuite extends GuacFunSuite {
     // True because of the higher base qualities on the C allele:
     assert(stats2.logLikelihoodPileup(Map("C" -> 1.0)) > stats2.logLikelihoodPileup(Map("A" -> 1.0)))
 
-    val stats3 = PileupStats.apply(pileups(4).elements, Bases.stringToBases("T"))
+    val stats3 = PileupStats.apply(pileups(3).elements, Bases.stringToBases("T"))
     stats3.totalDepthIncludingReadsContributingNoAlleles should equal(6)
     stats3.allelicDepths should equal(Map("T" -> 2)) // reads with an SNV at position 4 don't count
   }

--- a/src/test/scala/org/hammerlab/guacamole/pileup/PileupSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/pileup/PileupSuite.scala
@@ -211,6 +211,7 @@ class PileupSuite extends GuacFunSuite with TableDrivenPropertyChecks {
   test("Loci 10-19 deleted from half of the reads") {
     val pileup = loadPileup(sc, "same_start_reads.sam", locus = 0, reference = reference)
     val deletionPileup = pileup.atGreaterLocus(9, Seq.empty.iterator)
+
     deletionPileup.elements.map(_.alignment).count {
       case Deletion(bases, _) => {
         Bases.basesToString(bases) should equal("AAAAAAAAAAA")
@@ -218,6 +219,7 @@ class PileupSuite extends GuacFunSuite with TableDrivenPropertyChecks {
       }
       case _ => false
     } should be(5)
+
     for (i <- 10 to 19) {
       val nextPileup = pileup.atGreaterLocus(i, Seq.empty.iterator)
       nextPileup.elements.count(_.isMidDeletion) should be(5)
@@ -229,6 +231,22 @@ class PileupSuite extends GuacFunSuite with TableDrivenPropertyChecks {
     for (i <- 60 to 69) {
       val nextPileup = pileup.atGreaterLocus(i, Seq.empty.iterator)
       nextPileup.elements.length should be(5)
+    }
+  }
+
+  test("Pileup.apply throws on non-overlapping reads") {
+    val read = TestUtil.makeRead("AATTGAATTG", "5M1D5M", 1, "chr4")
+
+    intercept[AssertionError] {
+      Pileup(Seq(read), "chr4", 0, reference.getContig("chr4"))
+    }
+
+    intercept[AssertionError] {
+      Pileup(Seq(read), "chr4", 12, reference.getContig("chr4"))
+    }
+
+    intercept[AssertionError] {
+      Pileup(Seq(read), "chr5", 1, reference.getContig("chr4"))
     }
   }
 

--- a/src/test/scala/org/hammerlab/guacamole/pileup/PileupSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/pileup/PileupSuite.scala
@@ -49,9 +49,6 @@ class PileupSuite extends GuacFunSuite with TableDrivenPropertyChecks {
       TestUtil.makeRead("TCGATCGA", "8M", 1),
       TestUtil.makeRead("TCGACCCTCGA", "4M3I4M", 1))
 
-    val noPileup = Pileup(reads, "chr1", 0, reference.getContig("chr1")).elements
-    assert(noPileup.size === 0)
-
     val firstPileup = Pileup(reads, "chr1", 1, reference.getContig("chr1"))
     firstPileup.elements.forall(_.isMatch) should be(true)
     firstPileup.elements.forall(_.qualityScore == 31) should be(true)
@@ -89,9 +86,6 @@ class PileupSuite extends GuacFunSuite with TableDrivenPropertyChecks {
       TestUtil.makeRead("TCGATCGA", "8M", 1, "chr1", Some(Seq(10, 15, 20, 25, 10, 15, 20, 25))),
       TestUtil.makeRead("TCGACCCTCGA", "4M3I4M", 1, "chr1", Some(Seq(10, 15, 20, 25, 5, 5, 5, 10, 15, 20, 25)))
     )
-
-    val noPileup = Pileup(reads, "chr1", 0, reference.getContig("chr1")).elements
-    noPileup.size should be(0)
 
     val pastInsertPileup = Pileup(reads, "chr1", 5, reference.getContig("chr1"))
     pastInsertPileup.elements.foreach(_.isMatch should be(true))

--- a/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
@@ -220,8 +220,10 @@ object TestUtil {
                             reference: ReferenceBroadcast): (Pileup, Pileup) = {
     val contig = tumorReads(0).contigName
     assume(normalReads(0).contigName == contig)
-    (Pileup(tumorReads, contig, locus, reference.getContig(contig)),
-      Pileup(normalReads, contig, locus, reference.getContig(contig)))
+    (
+      Pileup(tumorReads.filter(_.overlapsLocus(locus)), contig, locus, reference.getContig(contig)),
+      Pileup(normalReads.filter(_.overlapsLocus(locus)), contig, locus, reference.getContig(contig))
+    )
   }
 
   def loadPileup(sc: SparkContext,


### PR DESCRIPTION
I could be wrong, but I can't see why we need the check in `Pileup.apply`, likewise the couple test cases that verify that non-overlapping reads aren't included in Pileups.

Let me know what you think!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/504)
<!-- Reviewable:end -->
