### PR TITLE
ReadSets-args refactoring

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/commands/SomaticJointCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/SomaticJointCaller.scala
@@ -3,16 +3,13 @@ package org.hammerlab.guacamole.commands
 import htsjdk.samtools.SAMSequenceDictionary
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
+import org.hammerlab.guacamole.distributed.PileupFlatMapUtils.pileupFlatMapMultipleRDDs
 import org.hammerlab.guacamole.jointcaller.evidence.{MultiSampleMultiAlleleEvidence, MultiSampleSingleAlleleEvidence}
 import org.hammerlab.guacamole.jointcaller.{Input, InputCollection, Parameters, VCFOutput}
-import org.hammerlab.guacamole.distributed.PileupFlatMapUtils.pileupFlatMapMultipleRDDs
 import org.hammerlab.guacamole.loci.LociArgs
-import org.hammerlab.guacamole.loci.partitioning.LociPartitionerArgs
-import org.hammerlab.guacamole.loci.set.{LociParser, LociSet}
+import org.hammerlab.guacamole.loci.set.LociSet
 import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.pileup.Pileup
-import org.hammerlab.guacamole.readsets.args.NoSequenceDictionaryArgs
-import org.hammerlab.guacamole.readsets.io.InputFilters
 import org.hammerlab.guacamole.readsets.{PerSample, ReadSets}
 import org.hammerlab.guacamole.reference.ReferenceBroadcast
 import org.kohsuke.args4j.spi.StringArrayOptionHandler
@@ -21,8 +18,6 @@ import org.kohsuke.args4j.{Option => Args4jOption}
 object SomaticJoint {
   class Arguments
     extends Parameters.CommandlineArguments
-      with LociPartitionerArgs
-      with NoSequenceDictionaryArgs
       with InputCollection.Arguments {
 
     @Args4jOption(name = "--out", usage = "Output path for all variants in VCF. Default: no output")
@@ -58,21 +53,6 @@ object SomaticJoint {
     var headerMetadata: Array[String] = Array.empty
   }
 
-  /**
-   * Load ReadSet instances from user-specified BAMs (specified as an InputCollection).
-   */
-  def inputsToReadSets(sc: SparkContext,
-                       inputs: InputCollection,
-                       loci: LociParser,
-                       contigLengthsFromDictionary: Boolean = true): ReadSets = {
-    ReadSets(
-      sc,
-      inputs.items.map(_.path),
-      InputFilters(overlapsLoci = loci),
-      contigLengthsFromDictionary = contigLengthsFromDictionary
-    )
-  }
-
   object Caller extends SparkCommand[Arguments] {
     override val name = "somatic-joint"
     override val description = "call germline and somatic variants based on any number of samples from the same patient"
@@ -80,18 +60,12 @@ object SomaticJoint {
     override def run(args: Arguments, sc: SparkContext): Unit = {
       val inputs = InputCollection(args)
 
+      val (readsets, loci) = ReadSets(sc, args)
+
       if (!args.quiet) {
-        println("Running on %d inputs:".format(inputs.items.length))
-        inputs.items.foreach(input => println(input))
+        println(s"Running on ${inputs.items.length} inputs:")
+        inputs.items.foreach(println)
       }
-
-      val reference = ReferenceBroadcast(args.referenceFastaPath, sc, partialFasta = args.referenceFastaIsPartial)
-
-      val loci = args.parseLoci(sc.hadoopConfiguration)
-
-      val readsets = inputsToReadSets(sc, inputs, loci, !args.noSequenceDictionary)
-
-      val contigLengths = readsets.contigLengths
 
       val forceCallLoci =
         LociArgs.parseLoci(
@@ -99,7 +73,7 @@ object SomaticJoint {
           args.forceCallLociFile,
           sc.hadoopConfiguration,
           fallback = ""
-        ).result(contigLengths)
+        ).result(readsets.contigLengths)
 
       if (forceCallLoci.nonEmpty) {
         progress(
@@ -113,13 +87,15 @@ object SomaticJoint {
 
       val parameters = Parameters(args)
 
+      val reference = ReferenceBroadcast(args.referenceFastaPath, sc, partialFasta = args.referenceFastaIsPartial)
+
       val calls = makeCalls(
         sc,
         inputs,
         readsets,
         parameters,
         reference,
-        loci.result(contigLengths),
+        loci,
         forceCallLoci,
         args.onlySomatic,
         args.includeFiltered,
@@ -182,7 +158,7 @@ object SomaticJoint {
                 forceCallLoci: LociSet = LociSet(),
                 onlySomatic: Boolean = false,
                 includeFiltered: Boolean = false,
-                args: LociPartitionerArgs = new LociPartitionerArgs {}): RDD[MultiSampleMultiAlleleEvidence] = {
+                args: Arguments = new Arguments {}): RDD[MultiSampleMultiAlleleEvidence] = {
 
     assume(loci.nonEmpty)
 
@@ -214,7 +190,7 @@ object SomaticJoint {
     }
 
     pileupFlatMapMultipleRDDs(
-      readsets.mappedReads,
+      readsets.mappedReadsRDDs,
       lociPartitions,
       skipEmpty = true,  // TODO: shouldn't skip empty positions if we might force call them. Need an efficient way to handle this.
       callPileups,

--- a/src/main/scala/org/hammerlab/guacamole/jointcaller/Input.scala
+++ b/src/main/scala/org/hammerlab/guacamole/jointcaller/Input.scala
@@ -1,6 +1,7 @@
 package org.hammerlab.guacamole.jointcaller
 
 import org.hammerlab.guacamole.jointcaller.Input.{Analyte, TissueType}
+import org.hammerlab.guacamole.readsets.io.{Input => RSInput}
 import org.hammerlab.guacamole.readsets.{SampleId, SampleName}
 
 /**
@@ -16,10 +17,11 @@ import org.hammerlab.guacamole.readsets.{SampleId, SampleName}
  * @param analyte rna or dna
  */
 case class Input(index: SampleId,
-                 sampleName: SampleName,
-                 path: String,
+                 override val sampleName: SampleName,
+                 override val path: String,
                  tissueType: TissueType.Value,
-                 analyte: Analyte.Value) {
+                 analyte: Analyte.Value)
+  extends RSInput(sampleName, path) {
 
   override def toString: String = {
     "<Input #%d '%s' of %s %s at %s >".format(index, sampleName, tissueType, analyte, path)

--- a/src/main/scala/org/hammerlab/guacamole/jointcaller/InputCollection.scala
+++ b/src/main/scala/org/hammerlab/guacamole/jointcaller/InputCollection.scala
@@ -2,8 +2,9 @@ package org.hammerlab.guacamole.jointcaller
 
 import org.hammerlab.guacamole.jointcaller.Input.{Analyte, TissueType}
 import org.hammerlab.guacamole.readsets.{PerSample, SampleName}
+import org.hammerlab.guacamole.readsets.args.{Arguments => ReadSetsArguments}
 import org.kohsuke.args4j.spi.StringArrayOptionHandler
-import org.kohsuke.args4j.{Argument, Option => Args4jOption}
+import org.kohsuke.args4j.{Option => Args4jOption}
 
 /**
  * Convenience container for zero or more Input instances.
@@ -16,11 +17,7 @@ case class InputCollection(items: PerSample[Input]) {
 }
 
 object InputCollection {
-  trait Arguments {
-    @Argument(required = true, multiValued = true,
-      usage = "FILE1 FILE2 FILE3")
-    var paths: Array[String] = Array.empty
-
+  trait Arguments extends ReadSetsArguments {
     @Args4jOption(name = "--tissue-types", handler = classOf[StringArrayOptionHandler],
       usage = "[normal|tumor] ... [normal|tumor]")
     var tissueTypes: Array[String] = Array.empty
@@ -28,10 +25,6 @@ object InputCollection {
     @Args4jOption(name = "--analytes", handler = classOf[StringArrayOptionHandler],
       usage = "[dna|rna] ... [dna|rna]")
     var analytes: Array[String] = Array.empty
-
-    @Args4jOption(name = "--sample-names", handler = classOf[StringArrayOptionHandler],
-      usage = "name1 ... nameN")
-    var sampleNames: Array[String] = Array.empty
   }
 
   /**

--- a/src/main/scala/org/hammerlab/guacamole/readsets/args/Arguments.scala
+++ b/src/main/scala/org/hammerlab/guacamole/readsets/args/Arguments.scala
@@ -1,0 +1,17 @@
+package org.hammerlab.guacamole.readsets.args
+
+import org.kohsuke.args4j.{Argument, Option => Args4JOption}
+import org.kohsuke.args4j.spi.StringArrayOptionHandler
+
+/**
+ * Common command-line arguments for loading in one or more sets of reads, and associating a sample-name with each.
+ */
+trait Arguments extends Base {
+
+  @Argument(required = true, multiValued = true, usage = "FILE1 FILE2 FILE3")
+  var paths: Array[String] = Array()
+
+  @Args4JOption(name = "--sample-names", handler = classOf[StringArrayOptionHandler], usage = "name1 ... nameN")
+  var sampleNames: Array[String] = Array()
+}
+

--- a/src/main/scala/org/hammerlab/guacamole/readsets/args/Base.scala
+++ b/src/main/scala/org/hammerlab/guacamole/readsets/args/Base.scala
@@ -1,0 +1,26 @@
+package org.hammerlab.guacamole.readsets.args
+
+import org.hammerlab.guacamole.loci.partitioning.LociPartitionerArgs
+import org.hammerlab.guacamole.readsets.PerSample
+import org.hammerlab.guacamole.readsets.io.{Input, ReadLoadingConfigArgs}
+
+trait Base
+  extends LociPartitionerArgs
+    with NoSequenceDictionaryArgs
+    with ReadLoadingConfigArgs {
+
+  def paths: Array[String]
+  def sampleNames: Array[String]
+
+  lazy val inputs: PerSample[Input] = {
+    paths.indices.map(i =>
+      Input(
+        if (i < sampleNames.length)
+          sampleNames(i)
+        else
+          paths(i),
+        paths(i)
+      )
+    )
+  }
+}

--- a/src/main/scala/org/hammerlab/guacamole/readsets/args/GermlineCallerArgs.scala
+++ b/src/main/scala/org/hammerlab/guacamole/readsets/args/GermlineCallerArgs.scala
@@ -8,4 +8,3 @@ trait GermlineCallerArgs
   extends GenotypeOutputArgs
     with SingleSampleArgs
     with ConcordanceArgs
-    with LociPartitionerArgs

--- a/src/main/scala/org/hammerlab/guacamole/readsets/args/NoSequenceDictionaryArgs.scala
+++ b/src/main/scala/org/hammerlab/guacamole/readsets/args/NoSequenceDictionaryArgs.scala
@@ -4,7 +4,7 @@ import org.hammerlab.guacamole.logging.DebugLogArgs
 import org.kohsuke.args4j.{Option => Args4jOption}
 
 /** Argument for using / not using sequence dictionaries to get contigs and lengths. */
-trait NoSequenceDictionaryArgs extends DebugLogArgs {
+trait NoSequenceDictionaryArgs {
   @Args4jOption(name = "--no-sequence-dictionary",
     usage = "If set, get contigs and lengths directly from reads instead of from sequence dictionary.")
   var noSequenceDictionary: Boolean = false

--- a/src/main/scala/org/hammerlab/guacamole/readsets/args/SingleSampleArgs.scala
+++ b/src/main/scala/org/hammerlab/guacamole/readsets/args/SingleSampleArgs.scala
@@ -1,12 +1,16 @@
 package org.hammerlab.guacamole.readsets.args
 
-import org.hammerlab.guacamole.logging.DebugLogArgs
-import org.hammerlab.guacamole.readsets.io.ReadLoadingConfigArgs
 import org.kohsuke.args4j.{Option => Args4jOption}
 
 /** Argument for accepting a single set of reads (for non-somatic variant calling). */
-trait SingleSampleArgs extends DebugLogArgs with NoSequenceDictionaryArgs with ReadLoadingConfigArgs {
+trait SingleSampleArgs extends Base {
   @Args4jOption(name = "--reads", metaVar = "X", required = true, usage = "Aligned reads")
   var reads: String = ""
+
+  override def paths = Array(reads)
+
+  def sampleName = "reads"
+
+  override def sampleNames = Array(sampleName)
 }
 

--- a/src/main/scala/org/hammerlab/guacamole/readsets/args/SomaticCallerArgs.scala
+++ b/src/main/scala/org/hammerlab/guacamole/readsets/args/SomaticCallerArgs.scala
@@ -6,4 +6,3 @@ import org.hammerlab.guacamole.variants.GenotypeOutputArgs
 trait SomaticCallerArgs
   extends GenotypeOutputArgs
     with TumorNormalReadsArgs
-    with LociPartitionerArgs

--- a/src/main/scala/org/hammerlab/guacamole/readsets/args/TumorNormalReadsArgs.scala
+++ b/src/main/scala/org/hammerlab/guacamole/readsets/args/TumorNormalReadsArgs.scala
@@ -1,15 +1,17 @@
 package org.hammerlab.guacamole.readsets.args
 
-import org.hammerlab.guacamole.logging.DebugLogArgs
-import org.hammerlab.guacamole.readsets.io.ReadLoadingConfigArgs
 import org.kohsuke.args4j.{Option => Args4jOption}
 
 /** Arguments for accepting two sets of reads (tumor + normal). */
-trait TumorNormalReadsArgs extends DebugLogArgs with NoSequenceDictionaryArgs with ReadLoadingConfigArgs {
+trait TumorNormalReadsArgs extends Base {
+
   @Args4jOption(name = "--normal-reads", metaVar = "X", required = true, usage = "Aligned reads: normal")
   var normalReads: String = ""
 
   @Args4jOption(name = "--tumor-reads", metaVar = "X", required = true, usage = "Aligned reads: tumor")
   var tumorReads: String = ""
-}
 
+  override def paths = Array(normalReads, tumorReads)
+
+  override def sampleNames = Array("normal", "tumor")
+}

--- a/src/main/scala/org/hammerlab/guacamole/readsets/io/Input.scala
+++ b/src/main/scala/org/hammerlab/guacamole/readsets/io/Input.scala
@@ -1,0 +1,10 @@
+package org.hammerlab.guacamole.readsets.io
+
+import org.hammerlab.guacamole.readsets.SampleName
+
+class Input(val sampleName: SampleName, val path: String) extends Serializable
+
+object Input {
+  def apply(sampleName: SampleName, path: String): Input = new Input(sampleName, path)
+  def unapply(input: Input): Option[(SampleName, String)] = Some((input.sampleName, input.path))
+}

--- a/src/main/scala/org/hammerlab/guacamole/readsets/rdd/ReadsRDD.scala
+++ b/src/main/scala/org/hammerlab/guacamole/readsets/rdd/ReadsRDD.scala
@@ -4,13 +4,14 @@ import java.io.File
 
 import org.apache.spark.rdd.RDD
 import org.hammerlab.guacamole.reads.{MappedRead, PairedRead, Read}
+import org.hammerlab.guacamole.readsets.io.Input
 
 /**
  * A thin wrapper around an RDD[Read], with helpers to filter to mapped and paired-mapped reads.
  */
-case class ReadsRDD(reads: RDD[Read], sourceFile: String) {
+case class ReadsRDD(reads: RDD[Read], input: Input) {
 
-  val basename = new File(sourceFile).getName
+  val basename = new File(input.path).getName
   val shortName = basename.substring(0, math.min(100, basename.length))
 
   lazy val mappedReads =
@@ -25,8 +26,4 @@ case class ReadsRDD(reads: RDD[Read], sourceFile: String) {
       case rp: PairedRead[_] if rp.isMapped => Some(rp.asInstanceOf[PairedRead[MappedRead]])
       case _                                => None
     }).setName(s"Mapped reads: $shortName")
-}
-
-object ReadsRDD {
-  def apply(pair: (RDD[Read], String)): ReadsRDD = ReadsRDD(pair._1, pair._2)
 }

--- a/src/test/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCallerSuite.scala
@@ -61,6 +61,7 @@ class GermlineAssemblyCallerSuite extends GuacFunSuite with BeforeAndAfterAll {
     val variants =
       GermlineAssemblyCaller.Caller.discoverGermlineVariants(
         mappedReads,
+        args.sampleName,
         kmerSize = kmerSize,
         assemblyWindowRange = assemblyWindowRange,
         minOccurrence = minOccurrence,

--- a/src/test/scala/org/hammerlab/guacamole/commands/VAFHistogramSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/VAFHistogramSuite.scala
@@ -2,7 +2,6 @@ package org.hammerlab.guacamole.commands
 
 import com.esotericsoftware.kryo.Kryo
 import org.hammerlab.guacamole.util.{GuacFunSuite, KryoTestRegistrar}
-import org.scalatest.Matchers
 
 class VAFHistogramSuiteRegistrar extends KryoTestRegistrar {
   override def registerTestClasses(kryo: Kryo): Unit = {

--- a/src/test/scala/org/hammerlab/guacamole/jointcaller/SomaticJointCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/jointcaller/SomaticJointCallerSuite.scala
@@ -2,11 +2,13 @@ package org.hammerlab.guacamole.jointcaller
 
 import org.hammerlab.guacamole.commands.SomaticJoint
 import org.hammerlab.guacamole.loci.set.{LociParser, LociSet}
+import org.hammerlab.guacamole.readsets.rdd.ReadsRDDUtil
 import org.hammerlab.guacamole.reference.ReferenceBroadcast
 import org.hammerlab.guacamole.reference.ReferenceBroadcast.MapBackedReferenceSequence
 import org.hammerlab.guacamole.util.{GuacFunSuite, TestUtil}
 
-class SomaticJointCallerSuite extends GuacFunSuite {
+class SomaticJointCallerSuite extends GuacFunSuite with ReadsRDDUtil {
+
   val cancerWGS1Bams = Vector("normal.bam", "primary.bam", "recurrence.bam").map(
     name => TestUtil.testDataPath("cancer-wgs1/" + name))
 
@@ -26,7 +28,7 @@ class SomaticJointCallerSuite extends GuacFunSuite {
   test("force-call a non-variant locus") {
     val inputs = InputCollection(cancerWGS1Bams)
     val loci = LociParser("chr12:65857040")
-    val readSets = SomaticJoint.inputsToReadSets(sc, inputs, loci)
+    val readSets = makeReadSets(inputs, loci)
     val calls = SomaticJoint.makeCalls(
       sc, inputs, readSets, Parameters.defaults, hg19PartialReference, loci.result, loci.result).collect
 
@@ -43,7 +45,7 @@ class SomaticJointCallerSuite extends GuacFunSuite {
   test("call a somatic deletion") {
     val inputs = InputCollection(cancerWGS1Bams)
     val loci = LociParser("chr5:82649006-82649009")
-    val readSets = SomaticJoint.inputsToReadSets(sc, inputs, loci)
+    val readSets = makeReadSets(inputs, loci)
     val calls = SomaticJoint.makeCalls(
       sc,
       inputs,
@@ -63,7 +65,7 @@ class SomaticJointCallerSuite extends GuacFunSuite {
   test("call germline variants") {
     val inputs = InputCollection(cancerWGS1Bams.take(1), tissueTypes = Vector("normal"))
     val loci = LociParser("chr1,chr2,chr3")
-    val readSets = SomaticJoint.inputsToReadSets(sc, inputs, loci)
+    val readSets = makeReadSets(inputs, loci)
     val calls =
       SomaticJoint.makeCalls(
         sc,
@@ -104,7 +106,7 @@ class SomaticJointCallerSuite extends GuacFunSuite {
   test("don't call variants with N as the reference base") {
     val inputs = InputCollection(cancerWGS1Bams)
     val loci = LociParser("chr12:65857030-65857080")
-    val readSets = SomaticJoint.inputsToReadSets(sc, inputs, loci)
+    val readSets = makeReadSets(inputs, loci)
     val emptyPartialReference = ReferenceBroadcast(
       Map("chr12" -> MapBackedReferenceSequence(500000000, sc.broadcast(Map.empty))))
     val calls = SomaticJoint.makeCalls(
@@ -122,7 +124,7 @@ class SomaticJointCallerSuite extends GuacFunSuite {
       SomaticJoint.makeCalls(
         sc,
         inputsWithRNA,
-        SomaticJoint.inputsToReadSets(sc, inputsWithRNA, loci),
+        makeReadSets(inputsWithRNA, loci),
         parameters,
         b37Chromosome22Reference,
         loci.result
@@ -134,7 +136,7 @@ class SomaticJointCallerSuite extends GuacFunSuite {
     val callsWithoutRNA = SomaticJoint.makeCalls(
       sc,
       inputsWithoutRNA,
-      SomaticJoint.inputsToReadSets(sc, inputsWithoutRNA, loci),
+      makeReadSets(inputsWithoutRNA, loci),
       parameters,
       b37Chromosome22Reference,
       loci.result).collect.filter(_.bestAllele.isCall)

--- a/src/test/scala/org/hammerlab/guacamole/readsets/ReadSetsSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/readsets/ReadSetsSuite.scala
@@ -23,8 +23,8 @@ import org.bdgenomics.adam.models.{SequenceDictionary, SequenceRecord}
 import org.bdgenomics.adam.rdd.read.AlignmentRecordRDDFunctions
 import org.bdgenomics.adam.rdd.{ADAMContext, ADAMSaveAnyArgs}
 import org.hammerlab.guacamole.loci.set.LociParser
-import org.hammerlab.guacamole.reads.{MappedRead, Read}
-import org.hammerlab.guacamole.readsets.io.{BamReaderAPI, InputFilters, ReadLoadingConfig}
+import org.hammerlab.guacamole.reads.MappedRead
+import org.hammerlab.guacamole.readsets.io.{BamReaderAPI, Input, InputFilters, ReadLoadingConfig}
 import org.hammerlab.guacamole.util.{GuacFunSuite, TestUtil}
 
 class ReadSetsSuite extends GuacFunSuite {
@@ -167,10 +167,16 @@ class ReadSetsSuite extends GuacFunSuite {
       }
     )
 
+  val inputs =
+    List(
+      Input("f1", "1"),
+      Input("f2", "2")
+    )
+
   test("merge identical seqdicts") {
     val dict1 = sequenceDictionary(("1", 111, "aaa"), ("2", 222, "bbb"))
     val dict2 = sequenceDictionary(("1", 111, "aaa"), ("2", 222, "bbb"))
-    val merged = ReadSets.mergeSequenceDictionaries(List("f1", "f2"), List(dict1, dict2))
+    val merged = ReadSets.mergeSequenceDictionaries(inputs, List(dict1, dict2))
     merged should be(dict1)
     merged should be(dict2)
   }
@@ -179,7 +185,7 @@ class ReadSetsSuite extends GuacFunSuite {
     val dict1 = sequenceDictionary(("1", 111, "aaa"), ("2", 222, "bbb"))
     val dict2 = sequenceDictionary(("1", 111, "aaa"), ("3", 333, "ccc"))
 
-    val merged = ReadSets.mergeSequenceDictionaries(List("f1", "f2"), List(dict1, dict2))
+    val merged = ReadSets.mergeSequenceDictionaries(inputs, List(dict1, dict2))
 
     val expected = sequenceDictionary(("1", 111, "aaa"), ("2", 222, "bbb"), ("3", 333, "ccc"))
 
@@ -190,8 +196,8 @@ class ReadSetsSuite extends GuacFunSuite {
     val dict1 = sequenceDictionary(("1", 111, "aaa"), ("2", 222, "bbb"))
     val dict2 = sequenceDictionary(("1", 111, "aaa"), ("2", 333, "ccc"))
 
-    (intercept[IllegalArgumentException] {
-      ReadSets.mergeSequenceDictionaries(List("f1", "f2"), List(dict1, dict2))
-    }).getMessage should startWith("Conflicting sequence records for 2")
+    intercept[IllegalArgumentException] {
+      ReadSets.mergeSequenceDictionaries(inputs, List(dict1, dict2))
+    }.getMessage should startWith("Conflicting sequence records for 2")
   }
 }

--- a/src/test/scala/org/hammerlab/guacamole/readsets/rdd/ReadsRDDUtil.scala
+++ b/src/test/scala/org/hammerlab/guacamole/readsets/rdd/ReadsRDDUtil.scala
@@ -2,7 +2,11 @@ package org.hammerlab.guacamole.readsets.rdd
 
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
+import org.hammerlab.guacamole.jointcaller.InputCollection
+import org.hammerlab.guacamole.loci.set.LociParser
 import org.hammerlab.guacamole.reads.{ReadsUtil, TestRegion}
+import org.hammerlab.guacamole.readsets.ReadSets
+import org.hammerlab.guacamole.readsets.io.InputFilters
 
 trait ReadsRDDUtil extends ReadsUtil {
 
@@ -10,4 +14,7 @@ trait ReadsRDDUtil extends ReadsUtil {
 
   def makeReadsRDD(numPartitions: Int, reads: (String, Int, Int, Int)*): RDD[TestRegion] =
     sc.parallelize(makeReads(reads).toSeq, numPartitions)
+
+  def makeReadSets(inputs: InputCollection, loci: LociParser): ReadSets =
+    ReadSets(sc, inputs.items, filters = InputFilters(overlapsLoci = loci))
 }


### PR DESCRIPTION
Share sample-loading, filename/sample infra across all commands.

ReadSets now keeps sample names/paths around explicitly in a way that is tied to the corresponding RDD[Read]s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/516)
<!-- Reviewable:end -->
