### PR TITLE
rm unused Pileup.bySample

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/pileup/Pileup.scala
+++ b/src/main/scala/org/hammerlab/guacamole/pileup/Pileup.scala
@@ -57,16 +57,6 @@ case class Pileup(contigName: ContigName,
   lazy val sampleName = elements.head.read.sampleName
 
   /**
-   * Split this [[Pileup]] by sample name. Returns a map from sample name to [[Pileup]] instances that use only reads
-   * from that sample.
-   */
-  lazy val bySample: Map[String, Pileup] = {
-    elements.groupBy(element => Option(element.read.sampleName).map(_.toString).getOrElse("default")).map({
-      case (sample, newElements) => (sample, Pileup(contigName, locus, contigSequence, newElements))
-    })
-  }
-
-  /**
    * Depth of pileup - number of reads at locus
    */
   lazy val depth: Int = elements.length


### PR DESCRIPTION
doesn't make sense for it to coexist with Pileup.sampleName, which
assumes a Pileup contains reads from only one sample, which is what
all callers in guacamole currently do.

this is a step towards clarifying that contract.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/517)
<!-- Reviewable:end -->
