### PR TITLE
rm redundant commons-io dep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -318,11 +318,6 @@
       <version>1.9.1</version>
     </dependency>
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.4</version>
-    </dependency>
-    <dependency>
       <groupId>org.hammerlab</groupId>
       <artifactId>magic-rdds</artifactId>
       <version>1.0.0-20160801.033044-3</version>


### PR DESCRIPTION
newer version is included later in the POM as a test dep, which is what we actually want

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/519)
<!-- Reviewable:end -->
