### PR TITLE
optionally error/warn on repeat contigs in coverage-depth computation

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/loci/map/Builder.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/map/Builder.scala
@@ -35,6 +35,6 @@ private[loci] class Builder[T] {
   }
 
   /** Build the result. */
-  def result(): LociMap[T] = LociMap(data.map(Contig(_)))
+  def result(): LociMap[T] = LociMap.fromContigs(data.map(Contig(_)))
 }
 

--- a/src/main/scala/org/hammerlab/guacamole/loci/map/LociMap.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/map/LociMap.scala
@@ -18,13 +18,11 @@
 
 package org.hammerlab.guacamole.loci.map
 
-import java.io.{InputStream, OutputStream, PrintStream}
+import java.io.{OutputStream, PrintStream}
 
-import org.hammerlab.guacamole.loci.partitioning.LociPartitioner.PartitionIndex
 import org.hammerlab.guacamole.loci.set.{LociSet, Builder => LociSetBuilder}
 import org.hammerlab.guacamole.reference.{ContigName, ReferenceRegion}
 import org.hammerlab.guacamole.strings.TruncatedToString
-import org.hammerlab.magic.iterator.LinesIterator
 
 import scala.collection.immutable.TreeMap
 import scala.collection.{SortedMap, mutable}
@@ -97,34 +95,6 @@ object LociMap {
   /** Construct an empty LociMap. */
   def apply[T](): LociMap[T] = LociMap(TreeMap[ContigName, Contig[T]]())
 
-  /**
-   * Load a LociMap output by [[LociMap.prettyPrint]].
-   * @param is [[InputStream]] reading from e.g. a file.
-   */
-  def load(is: InputStream): LociMap[PartitionIndex] = {
-    fromLines(LinesIterator(is))
-  }
-
-  /**
-   * Read in a [[LociMap]] of partition indices from some strings, each one representing a genomic range.
-   * @param lines string representations of genomic ranges.
-   */
-  def fromLines(lines: TraversableOnce[String]): LociMap[PartitionIndex] = {
-    val builder = newBuilder[PartitionIndex]
-    val re = """([^:]+):(\d+)-(\d+)=(\d+)""".r
-    for {
-      line <- lines
-      m <- re.findFirstMatchIn(line)
-      contig = m.group(1)
-      start = m.group(2).toLong
-      end = m.group(3).toLong
-      partition = m.group(4).toInt
-    } {
-      builder.put(contig, start, end, partition)
-    }
-    builder.result()
-  }
-
   /** The following convenience constructors are only called by Builder. */
   private[map] def apply[T](contigs: (String, Long, Long, T)*): LociMap[T] = {
     val builder = new Builder[T]
@@ -136,7 +106,7 @@ object LociMap {
     builder.result()
   }
 
-  private[map] def apply[T](contigs: Iterable[Contig[T]]): LociMap[T] =
+  private[map] def fromContigs[T](contigs: Iterable[Contig[T]]): LociMap[T] =
     LociMap(
       TreeMap(
         contigs.map(contig => contig.name -> contig).toSeq: _*

--- a/src/main/scala/org/hammerlab/guacamole/loci/map/Serializer.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/map/Serializer.scala
@@ -20,7 +20,7 @@ class Serializer[T] extends KryoSerializer[LociMap[T]] {
     val contigs = (0L until count).map(i => {
       kryo.readObject(input, classOf[Contig[T]])
     })
-    LociMap[T](contigs)
+    LociMap.fromContigs(contigs)
   }
 }
 

--- a/src/main/scala/org/hammerlab/guacamole/loci/partitioning/LociPartitioner.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/partitioning/LociPartitioner.scala
@@ -31,6 +31,7 @@ trait LociPartitionerArgs
 
   def getPartitioner[R <: ReferenceRegion: ClassTag](regions: RDD[R], halfWindowSize: Int = 0): LociPartitioner = {
     val sc = regions.sparkContext
+
     val numPartitions =
       if (parallelism == 0)
         sc.defaultParallelism
@@ -39,7 +40,12 @@ trait LociPartitionerArgs
 
     lociPartitionerName match {
       case "exact" =>
-        new CappedRegionsPartitioner(regions, halfWindowSize, maxReadsPerPartition, printStats = !quiet)
+        new CappedRegionsPartitioner(
+          regions,
+          halfWindowSize,
+          maxReadsPerPartition,
+          printStats = !quiet
+        )
       case "approximate" =>
         new MicroRegionPartitioner(regions, halfWindowSize, numPartitions, partitioningAccuracy)
       case "uniform" =>

--- a/src/main/scala/org/hammerlab/guacamole/loci/set/TakeLociIterator.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/set/TakeLociIterator.scala
@@ -148,7 +148,7 @@ class TakeLociIterator(it: BufferedIterator[(Position, Coverage)],
 
       if (curNumRegions + newRegions > numRegions) {
         // If the current locus pushed us over the maximum allowed `numRegions`, add the current in-progress Interval.
-        maybeAddInterval
+        maybeAddInterval()
 
         if (newRegions > dropAbove)
           // If this locus exceeds the `dropAbove` threshold, no LociSet will be able to incorporate it, so we just skip
@@ -169,12 +169,12 @@ class TakeLociIterator(it: BufferedIterator[(Position, Coverage)],
         curIntervalOpt =
           curIntervalOpt match {
             // Extend the current interval, if possible.
-            case Some((start, end)) if (locus == end) =>
+            case Some((start, end)) if locus == end =>
               Some(start -> (locus + 1))
 
             // Otherwise, commit the current interval if it exists, and start a new one.
             case _ =>
-              maybeAddInterval
+              maybeAddInterval()
               Some(locus -> (locus + 1))
           }
         it.next()
@@ -183,7 +183,7 @@ class TakeLociIterator(it: BufferedIterator[(Position, Coverage)],
 
     // We end up here if we ran out of loci on this contig before we reached the maximum allowed number of regions. In
     // this case, commit any in-progress interval, build the Contig, and return.
-    maybeAddInterval
+    maybeAddInterval()
     result
   }
 }

--- a/src/main/scala/org/hammerlab/guacamole/readsets/iterator/ContigCoverageIterator.scala
+++ b/src/main/scala/org/hammerlab/guacamole/readsets/iterator/ContigCoverageIterator.scala
@@ -1,16 +1,27 @@
 package org.hammerlab.guacamole.readsets.iterator
 
 import org.hammerlab.guacamole.loci.Coverage
-import org.hammerlab.guacamole.loci.iterator.SkippableLocusKeyedIterator
-import org.hammerlab.guacamole.reference.{ContigIterator, Locus, ReferenceRegion}
+import org.hammerlab.guacamole.loci.iterator.{SkippableLociIterator, SkippableLocusKeyedIterator}
+import org.hammerlab.guacamole.reference.{ContigIterator, Interval, Locus}
 
 import scala.collection.mutable
 
+/**
+ * [[SkippableLociIterator]] that consumes reference regions (sorted by start-position, and all on the same contig) and
+ * emits a [[Coverage]] at each covered locus, indicating how many reads overlap (and start at) that locus. Overlaps
+ * are given a grace-margin of `halfWindowSize`.
+ *
+ * @param intervals Single-contig-restricted, start-position-sorted [[Iterator]] of [[Interval]]s.
+ */
 case class ContigCoverageIterator(halfWindowSize: Int,
-                                  regions: ContigIterator[ReferenceRegion])
+                                  intervals: ContigIterator[Interval])
   extends SkippableLocusKeyedIterator[Coverage] {
 
+  // Queue of intervals that overlap the current locus, ordered by ascending `end`.
   private val ends = mutable.PriorityQueue[Long]()(implicitly[Ordering[Long]].reverse)
+
+  // Record the last-seen interval-start, to verify that the intervals are sorted by `start`.
+  private var lastStart: Locus = 0
 
   override def _advance: Option[(Locus, Coverage)] = {
     var lowerLimit = math.max(0, locus - halfWindowSize)
@@ -21,10 +32,10 @@ case class ContigCoverageIterator(halfWindowSize: Int,
     }
 
     if (ends.isEmpty) {
-      if (regions.isEmpty)
+      if (intervals.isEmpty)
         return None
 
-      val nextReadWindowStart = regions.head.start - halfWindowSize
+      val nextReadWindowStart = intervals.head.start - halfWindowSize
       if (nextReadWindowStart > locus) {
         skipTo(nextReadWindowStart)
         upperLimit = locus + halfWindowSize
@@ -32,11 +43,22 @@ case class ContigCoverageIterator(halfWindowSize: Int,
     }
 
     var numAdded = 0
-    while (regions.nonEmpty && regions.head.start <= upperLimit) {
-      ends.enqueue(regions.next().end)
+    while (intervals.nonEmpty && intervals.head.start <= upperLimit) {
+      val Interval(start, end) = intervals.next()
+
+      if (start < lastStart)
+        throw RegionsNotSortedException(
+          s"Consecutive regions rewinding from $lastStart to $start on contig ${intervals.contigName}"
+        )
+      else
+        lastStart = start
+
+      ends.enqueue(end)
       numAdded += 1
     }
 
     Some(locus -> Coverage(ends.size, numAdded))
   }
 }
+
+case class RegionsNotSortedException(msg: String) extends Exception

--- a/src/main/scala/org/hammerlab/guacamole/reference/ReferenceRegion.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reference/ReferenceRegion.scala
@@ -22,7 +22,9 @@ package org.hammerlab.guacamole.reference
  * Trait for objects that are associated with an interval on the genome. The most prominent example is a
  * [[org.hammerlab.guacamole.reads.MappedRead]], but there's also [[org.hammerlab.guacamole.variants.ReferenceVariant]].
  */
-trait ReferenceRegion extends HasContig with Interval {
+trait ReferenceRegion
+  extends HasContig
+    with Interval {
 
   /** Name of the reference contig */
   def contigName: ContigName
@@ -61,4 +63,11 @@ object ReferenceRegion {
         x.contigName == y.contigName && x.start <= y.start
       }
     }
+
+  def unapply(region: ReferenceRegion): Option[(ContigName, Locus, Locus)] =
+    Some(
+      region.contigName,
+      region.start,
+      region.end
+    )
 }

--- a/src/test/scala/org/hammerlab/guacamole/readsets/iterator/ContigCoverageIteratorSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/readsets/iterator/ContigCoverageIteratorSuite.scala
@@ -6,26 +6,25 @@ import org.hammerlab.guacamole.readsets.{ContigLengths, ContigLengthsUtil}
 import org.hammerlab.guacamole.reference.ContigIterator
 import org.scalatest.{FunSuite, Matchers}
 
-class ContigCoverageIteratorSuite extends FunSuite with Matchers with ContigLengthsUtil {
+class ContigCoverageIteratorSuite
+  extends FunSuite
+    with Matchers {
 
-  def check(contig: String,
-            halfWindowSize: Int,
+  def check(halfWindowSize: Int,
             intervals: (Int, Int)*)(
-    expectedStrs: ((String, Int), (Int, Int))*
+    expectedStrs: (Int, (Int, Int))*
   ): Unit = {
 
     val reads =
       (for {
         (start, end) <- intervals
       } yield
-        TestRegion(contig, start, end)
+        TestRegion("foo", start, end)
       ).iterator.buffered
-
-    val contigLengths: ContigLengths = makeContigLengths("chr1" -> 100, "chr2" -> 200)
 
     val expected =
       for {
-        ((contig, locus), (depth, starts)) <- expectedStrs
+        (locus, (depth, starts)) <- expectedStrs
       } yield
         locus -> Coverage(depth, starts)
 
@@ -34,20 +33,41 @@ class ContigCoverageIteratorSuite extends FunSuite with Matchers with ContigLeng
 
   test("simple") {
     check(
-      "chr1",
       halfWindowSize = 0,
       (10, 20)
     )(
-      ("chr1", 10) -> (1, 1),
-      ("chr1", 11) -> (1, 0),
-      ("chr1", 12) -> (1, 0),
-      ("chr1", 13) -> (1, 0),
-      ("chr1", 14) -> (1, 0),
-      ("chr1", 15) -> (1, 0),
-      ("chr1", 16) -> (1, 0),
-      ("chr1", 17) -> (1, 0),
-      ("chr1", 18) -> (1, 0),
-      ("chr1", 19) -> (1, 0)
+      10 -> (1, 1),
+      11 -> (1, 0),
+      12 -> (1, 0),
+      13 -> (1, 0),
+      14 -> (1, 0),
+      15 -> (1, 0),
+      16 -> (1, 0),
+      17 -> (1, 0),
+      18 -> (1, 0),
+      19 -> (1, 0)
+    )
+  }
+
+  test("contained reads") {
+    check(
+      halfWindowSize = 0,
+      (0, 10),
+      (1,  9),
+      (2,  8),
+      (3, 11)
+    )(
+       0 -> (1, 1),
+       1 -> (2, 1),
+       2 -> (3, 1),
+       3 -> (4, 1),
+       4 -> (4, 0),
+       5 -> (4, 0),
+       6 -> (4, 0),
+       7 -> (4, 0),
+       8 -> (3, 0),
+       9 -> (2, 0),
+      10 -> (1, 0)
     )
   }
 
@@ -78,5 +98,24 @@ class ContigCoverageIteratorSuite extends FunSuite with Matchers with ContigLeng
     it.next() should be(39 -> Coverage(1, 0))
     it.skipTo(45)
     it.hasNext should be(false)
+  }
+
+  test("throw on unsorted regions") {
+    val reads =
+      ContigIterator(
+        Iterator(
+          TestRegion("chr1",  0, 10),
+          TestRegion("chr1",  1,  9),
+          TestRegion("chr1",  2, 21),
+          TestRegion("chr1",  1, 31)
+        ).buffered
+      )
+
+    val it = ContigCoverageIterator(halfWindowSize = 0, reads)
+    it.next() should be( 0 -> Coverage(1, 1))
+    it.next() should be( 1 -> Coverage(2, 1))
+    intercept[RegionsNotSortedException] {
+      it.next()
+    }
   }
 }

--- a/src/test/scala/org/hammerlab/guacamole/readsets/iterator/ContigsIteratorSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/readsets/iterator/ContigsIteratorSuite.scala
@@ -51,4 +51,17 @@ class ContigsIteratorSuite extends FunSuite with Matchers with ReadsUtil {
     chr2Name should be("chr2")
     chr2.toList should be(List(TestRegion("chr2", 50, 60)))
   }
+
+  test("throw on repeat contigs") {
+    intercept[RepeatedContigException] {
+      ContigsIterator(
+        Iterator[TestRegion](
+          ("chr1", 10, 20),
+          ("chr1", 30, 40),
+          ("chr2", 50, 60),
+          ("chr1", 70, 80)
+        ).buffered
+      ).toList
+    }
+  }
 }


### PR DESCRIPTION
- `RegionRDD` → `CoverageRDD`, also removed `implicit` creation since it now takes in `requireRegionsGroupedByContig` bool

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/546)
<!-- Reviewable:end -->
