### PR TITLE
Include spark application id in VCF metadata in joint caller

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/commands/SomaticJointCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/SomaticJointCaller.scala
@@ -114,13 +114,14 @@ object SomaticJoint {
         )
       )
 
+      // User defined additional VCF headers, plus the Spark applicationId.
       val extraHeaderMetadata = args.headerMetadata.map(value => {
         val split = value.split("=")
         if (split.length != 2) {
           throw new RuntimeException(s"Invalid header metadata item $value, expected KEY=VALUE")
         }
         (split(0), split(1))
-      })
+      }) ++ Seq(("applicationId", sc.applicationId))
 
       writeCalls(
         collectedCalls,

--- a/src/test/scala/org/hammerlab/guacamole/jointcaller/SomaticJointCallerEndToEndSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/jointcaller/SomaticJointCallerEndToEndSuite.scala
@@ -12,8 +12,8 @@ class SomaticJointCallerEndToEndSuite extends FunSuite with Matchers with Before
   val cancerWGS1Bams = Vector("normal.tiny.bam", "primary.tiny.bam", "recurrence.tiny.bam").map(
     name => TestUtil.testDataPath("cancer-wgs1/" + name))
 
-  def readFile(path: String): String =
-    scala.io.Source.fromFile(path).getLines().filterNot(_.startsWith("##reference")).mkString("\n")
+  def vcfContentsIgnoringHeaders(path: String): String =
+    scala.io.Source.fromFile(path).getLines().filterNot(_.startsWith("##")).mkString("\n")
 
   val outDirPath = Files.createTempDirectory("TestUtil")
   val outDir = outDirPath.toString
@@ -38,6 +38,6 @@ class SomaticJointCallerEndToEndSuite extends FunSuite with Matchers with Before
       ) ++ cancerWGS1Bams
     )
 
-    readFile(outDir + "/all.vcf") should be(readFile(TestUtil.testDataPath("tiny-sjc-output/all.vcf")))
+    vcfContentsIgnoringHeaders(outDir + "/all.vcf") should be(vcfContentsIgnoringHeaders(TestUtil.testDataPath("tiny-sjc-output/all.vcf")))
   }
 }


### PR DESCRIPTION
Add the spark application ID to the metadata in the VCF in the joint caller. This way it can be included in benchmarking results so we can go back and get logs etc. for a benchmark

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/547)
<!-- Reviewable:end -->
