### PR TITLE
add load/save capability to PartitionedRegions

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/loci/partitioning/LociPartitioner.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/partitioning/LociPartitioner.scala
@@ -3,6 +3,7 @@ package org.hammerlab.guacamole.loci.partitioning
 import org.apache.spark.rdd.RDD
 import org.hammerlab.guacamole.loci.LociArgs
 import org.hammerlab.guacamole.loci.set.LociSet
+import org.hammerlab.guacamole.readsets.rdd.PartitionedRegionsArgs
 import org.hammerlab.guacamole.reference.ReferenceRegion
 import org.hammerlab.magic.args4j.StringOptionHandler
 import org.kohsuke.args4j.spi.BooleanOptionHandler
@@ -18,10 +19,16 @@ trait LociPartitionerArgs
 
   @Args4JOption(
     name = "--loci-partitioning",
-    usage = "If set: load a LociPartitioning from this path if it exists; write a computed partitioning to this path if it doesn't.",
+    usage = "Load a LociPartitioning from this path if it exists; else write a computed partitioning to this path.",
     handler = classOf[StringOptionHandler]
   )
-  var lociPartitioningPathOpt: Option[String] = None
+  protected var _lociPartitioningPathOpt: Option[String] = None
+
+  /**
+   * Simple getter interface here supports overriding behavior here to support different resolution logic, cf.
+   * [[PartitionedRegionsArgs]].
+   */
+  def lociPartitioningPathOpt: Option[String] = _lociPartitioningPathOpt
 
   @Args4JOption(
     name = "--loci-partitioner",

--- a/src/main/scala/org/hammerlab/guacamole/readsets/args/Base.scala
+++ b/src/main/scala/org/hammerlab/guacamole/readsets/args/Base.scala
@@ -1,11 +1,11 @@
 package org.hammerlab.guacamole.readsets.args
 
-import org.hammerlab.guacamole.loci.partitioning.LociPartitionerArgs
 import org.hammerlab.guacamole.readsets.PerSample
 import org.hammerlab.guacamole.readsets.io.{Input, ReadLoadingConfigArgs}
+import org.hammerlab.guacamole.readsets.rdd.PartitionedRegionsArgs
 
 trait Base
-  extends LociPartitionerArgs
+  extends PartitionedRegionsArgs
     with NoSequenceDictionaryArgs
     with ReadLoadingConfigArgs {
 

--- a/src/main/scala/org/hammerlab/guacamole/readsets/rdd/PartitionedRegionsArgs.scala
+++ b/src/main/scala/org/hammerlab/guacamole/readsets/rdd/PartitionedRegionsArgs.scala
@@ -1,0 +1,65 @@
+package org.hammerlab.guacamole.readsets.rdd
+
+import org.apache.hadoop.fs.Path
+import org.apache.spark.rdd.RDD
+import org.hammerlab.guacamole.loci.partitioning.{LociPartitionerArgs, LociPartitioning}
+import org.hammerlab.magic.args4j.StringOptionHandler
+import org.kohsuke.args4j.spi.BooleanOptionHandler
+import org.kohsuke.args4j.{Option => Args4JOption}
+
+/**
+ * Command-line arguments related to partitioning regions according to a [[LociPartitioning]].
+ *
+ * Allows for configuring how/whether to persist the computed [[PartitionedRegions]] (its [[RDD]] of regions and/or its
+ * [[LociPartitioning]]).
+ *
+ * The `--partitioning-dir`, if present, specifies a location that both read- and loci- partitionings will be saved to;
+ * each one can also be set individually via `--partitioning-dir` and `--loci-partitioning`.
+ */
+trait PartitionedRegionsArgs extends LociPartitionerArgs {
+  @Args4JOption(
+    name = "--partitioning-dir",
+    usage =
+      "Directory from which to read an existing partition-reads RDD (and accompanying LociPartitioning), if the " +
+        "directory exists; otherwise, save them here. If set, precludes use of --partitioned-reads and " +
+        "--loci-partitioning",
+    forbids = Array("--partitioned-reads-path", "--loci-partitioning-path"),
+    handler = classOf[StringOptionHandler]
+  )
+  private var partitioningDirOpt: Option[String] = None
+
+  @Args4JOption(
+    name = "--partitioned-reads",
+    usage = "Directory from which to read an existing partition-reads RDD, if it exists; otherwise, save it here.",
+    forbids = Array("--partitioning-dir"),
+    handler = classOf[StringOptionHandler]
+  )
+  private var _partitionedReadsPathOpt: Option[String] = None
+
+  // Default to `partitioningDirOpt` if it is set.
+  def partitionedReadsPathOpt: Option[String] =
+    _partitionedReadsPathOpt
+    .orElse(
+      partitioningDirOpt
+      .map(
+        new Path(_, "reads").toString
+      )
+    )
+
+  // Override the loci-partitioning-path lookup to default to `partitioningDirOpt` if the latter is set.
+  override def lociPartitioningPathOpt: Option[String] =
+    _lociPartitioningPathOpt
+      .orElse(
+        partitioningDirOpt
+        .map(
+          new Path(_, "partitioning").toString
+        )
+      )
+
+  @Args4JOption(
+    name = "--compress",
+    usage = "Whether to compress the output partitioned reads (default: false).",
+    handler = classOf[BooleanOptionHandler]
+  )
+  var compressReadPartitions: Boolean = false
+}

--- a/src/test/scala/org/hammerlab/guacamole/readsets/rdd/PartitionedRegionsUtil.scala
+++ b/src/test/scala/org/hammerlab/guacamole/readsets/rdd/PartitionedRegionsUtil.scala
@@ -15,6 +15,8 @@ trait PartitionedRegionsUtil {
       readsRDDs,
       lociPartitioning,
       halfWindowSize = 0,
+      partitionedRegionsPathOpt = None,
+      compress = false,
       printStats = false
     )
   }


### PR DESCRIPTION
one step toward allowing the pileup-creation pipeline to save duplicate work during iteration on downstream logic, e.g. pileup-creation or variant-calling

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/549)
<!-- Reviewable:end -->
