### PR TITLE
clarify "quiet" param governing partitioning debug info

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/commands/SomaticJointCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/SomaticJointCaller.scala
@@ -64,10 +64,9 @@ object SomaticJoint {
 
       val (readsets, loci) = ReadSets(sc, args)
 
-      if (!args.quiet) {
-        println(s"Running on ${inputs.items.length} inputs:")
-        inputs.items.foreach(println)
-      }
+      log.info(
+        (s"Running on ${inputs.items.length} inputs:" :: inputs.items.toList).mkString("\n")
+      )
 
       val forceCallLoci =
         LociArgs.parseLoci(

--- a/src/main/scala/org/hammerlab/guacamole/loci/partitioning/CappedRegionsPartitioner.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/partitioning/CappedRegionsPartitioner.scala
@@ -28,20 +28,20 @@ trait CappedRegionsPartitionerArgs {
  * @param regions regions to partition loci based on.
  * @param halfWindowSize consider regions to overlap loci that their ends are within this many base-pairs of.
  * @param maxRegionsPerPartition cap partitions at this many regions.
- * @param printStats print some statistics about the computed partitioning; adds several Spark stages so should be
+ * @param printPartitioningStats print some statistics about the computed partitioning; adds several Spark stages so should be
  *                   skipped for performance-critical runs.
  */
 class CappedRegionsPartitioner[R <: ReferenceRegion: ClassTag](regions: RDD[R],
                                                                halfWindowSize: Int,
                                                                maxRegionsPerPartition: Int,
-                                                               printStats: Boolean)
+                                                               printPartitioningStats: Boolean)
   extends LociPartitioner {
 
   def partition(loci: LociSet): LociPartitioning = {
 
     val coverageRDD = new CoverageRDD(regions)
 
-    if (printStats) {
+    if (printPartitioningStats) {
       val (depthRunsRDD, validLoci, invalidLoci) =
         coverageRDD.validLociCounts(halfWindowSize, loci, maxRegionsPerPartition)
 

--- a/src/main/scala/org/hammerlab/guacamole/loci/partitioning/LociPartitioner.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/partitioning/LociPartitioner.scala
@@ -44,7 +44,7 @@ trait LociPartitionerArgs
           regions,
           halfWindowSize,
           maxReadsPerPartition,
-          printStats = !quiet
+          printPartitioningStats
         )
       case "approximate" =>
         new MicroRegionPartitioner(regions, halfWindowSize, numPartitions, partitioningAccuracy)
@@ -56,12 +56,12 @@ trait LociPartitionerArgs
   }
 
   @Args4JOption(
-    name = "--quiet",
-    aliases = Array("-q"),
-    usage = "Whether to compute additional statistics about the partitioned reads (default: false).",
+    name = "--partitioning-stats",
+    usage = "Compute additional statistics about the partitioned loci and reads; causes additional Spark jobs to be run, " +
+      "so should be disabled in performance-critical environments. Default: false.",
     handler = classOf[BooleanOptionHandler]
   )
-  var quiet: Boolean = false
+  var printPartitioningStats: Boolean = false
 }
 
 trait LociPartitioner {

--- a/src/main/scala/org/hammerlab/guacamole/readsets/rdd/PartitionedRegions.scala
+++ b/src/main/scala/org/hammerlab/guacamole/readsets/rdd/PartitionedRegions.scala
@@ -124,7 +124,7 @@ object PartitionedRegions {
       regionRDDs,
       lociPartitioning,
       halfWindowSize,
-      !args.quiet
+      args.printPartitioningStats
     )
   }
 


### PR DESCRIPTION
fixes #544 

also removes a harmless joint-caller println's gating behind this param

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/550)
<!-- Reviewable:end -->
