### PR TITLE
rm redundant/obsolete licensing info

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/Main.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Main.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole
 
 import java.util.logging.Level

--- a/src/main/scala/org/hammerlab/guacamole/commands/Command.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/Command.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.commands
 
 import org.apache.spark.Logging

--- a/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.commands
 
 import org.apache.spark.SparkContext

--- a/src/main/scala/org/hammerlab/guacamole/commands/VariantSupport.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/VariantSupport.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.commands
 
 import org.apache.spark.SparkContext

--- a/src/main/scala/org/hammerlab/guacamole/filters/FishersExactTest.scala
+++ b/src/main/scala/org/hammerlab/guacamole/filters/FishersExactTest.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.filters
 
 import org.apache.commons.math3.util.ArithmeticUtils

--- a/src/main/scala/org/hammerlab/guacamole/filters/GenotypeFilter.scala
+++ b/src/main/scala/org/hammerlab/guacamole/filters/GenotypeFilter.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.filters
 
 import org.apache.spark.rdd.RDD

--- a/src/main/scala/org/hammerlab/guacamole/filters/PileupElementsFilter.scala
+++ b/src/main/scala/org/hammerlab/guacamole/filters/PileupElementsFilter.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.filters
 
 import org.hammerlab.guacamole.pileup.PileupElement

--- a/src/main/scala/org/hammerlab/guacamole/filters/PileupFilter.scala
+++ b/src/main/scala/org/hammerlab/guacamole/filters/PileupFilter.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.filters
 
 import org.hammerlab.guacamole.logging.DebugLogArgs

--- a/src/main/scala/org/hammerlab/guacamole/filters/SomaticGenotypeFilter.scala
+++ b/src/main/scala/org/hammerlab/guacamole/filters/SomaticGenotypeFilter.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.filters
 
 import org.apache.spark.rdd.RDD

--- a/src/main/scala/org/hammerlab/guacamole/kryo/Registrar.scala
+++ b/src/main/scala/org/hammerlab/guacamole/kryo/Registrar.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.kryo
 
 import com.esotericsoftware.kryo.Kryo

--- a/src/main/scala/org/hammerlab/guacamole/likelihood/Likelihood.scala
+++ b/src/main/scala/org/hammerlab/guacamole/likelihood/Likelihood.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.likelihood
 
 import cern.colt.matrix.impl.DenseDoubleMatrix2D

--- a/src/main/scala/org/hammerlab/guacamole/loci/map/LociMap.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/map/LociMap.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.loci.map
 
 import java.io.{OutputStream, PrintStream}

--- a/src/main/scala/org/hammerlab/guacamole/loci/set/LociSet.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/set/LociSet.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.loci.set
 
 import java.lang.{Long => JLong}

--- a/src/main/scala/org/hammerlab/guacamole/logging/DelayedMessages.scala
+++ b/src/main/scala/org/hammerlab/guacamole/logging/DelayedMessages.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.logging
 
 import scala.collection.mutable

--- a/src/main/scala/org/hammerlab/guacamole/pileup/Alignment.scala
+++ b/src/main/scala/org/hammerlab/guacamole/pileup/Alignment.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.pileup
 
 import org.hammerlab.guacamole.util.Bases

--- a/src/main/scala/org/hammerlab/guacamole/pileup/Pileup.scala
+++ b/src/main/scala/org/hammerlab/guacamole/pileup/Pileup.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.pileup
 
 import org.hammerlab.guacamole.reads.MappedRead

--- a/src/main/scala/org/hammerlab/guacamole/pileup/PileupElement.scala
+++ b/src/main/scala/org/hammerlab/guacamole/pileup/PileupElement.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.pileup
 
 import htsjdk.samtools.{CigarElement, CigarOperator}

--- a/src/main/scala/org/hammerlab/guacamole/reads/MappedRead.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/MappedRead.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.reads
 
 import htsjdk.samtools.{Cigar, CigarElement}

--- a/src/main/scala/org/hammerlab/guacamole/reads/MappedReadSerializer.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/MappedReadSerializer.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.reads
 
 import com.esotericsoftware.kryo.io.{Input, Output}

--- a/src/main/scala/org/hammerlab/guacamole/reads/MateAlignmentProperties.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/MateAlignmentProperties.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.reads
 
 import htsjdk.samtools.SAMRecord

--- a/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.reads
 
 import htsjdk.samtools._
@@ -46,7 +28,6 @@ trait Read {
 
   def asMappedRead: Option[MappedRead]
 
-  /** The sample (e.g. "tumor" or "patient3636") name. */
   def sampleName: SampleName
 
   /** Whether the read failed predefined vendor checks for quality */

--- a/src/main/scala/org/hammerlab/guacamole/reads/UnmappedRead.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/UnmappedRead.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.reads
 
 import org.hammerlab.guacamole.readsets.SampleName

--- a/src/main/scala/org/hammerlab/guacamole/reads/UnmappedReadSerializer.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/UnmappedReadSerializer.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.reads
 
 import com.esotericsoftware.kryo.io.{ Input, Output }

--- a/src/main/scala/org/hammerlab/guacamole/reference/ReferenceRegion.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reference/ReferenceRegion.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.reference
 
 /**
@@ -36,12 +18,6 @@ trait ReferenceRegion
     start - halfWindowSize <= locus && end + halfWindowSize > locus
   }
 
-  /**
-   * Does the region overlap another reference region
-   *
-   * @param other another region on the genome
-   * @return True if the the regions overlap
-   */
   def overlaps(other: ReferenceRegion): Boolean = {
     other.contigName == contigName && (overlapsLocus(other.start) || other.overlapsLocus(start))
   }

--- a/src/main/scala/org/hammerlab/guacamole/util/Bases.scala
+++ b/src/main/scala/org/hammerlab/guacamole/util/Bases.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.util
 
 /**
@@ -68,7 +50,6 @@ object Bases {
     base == Bases.A || base == Bases.C || base == Bases.T || base == Bases.G
   }
 
-  /** Throw an error if the given base is not one of the canonical DNA bases. */
   def assertStandardBase(base: Byte) = {
     assert(isStandardBase(base), "Invalid base: %s".format(base.toChar.toString))
   }
@@ -78,7 +59,6 @@ object Bases {
     bases.forall(b => isStandardBase(b))
   }
 
-  /** Throw an error if any of the given bases are not standard. */
   def assertAllStandardBases(bases: Seq[Byte]) = {
     assert(allStandardBases(bases), "Invalid base array: %s".format(bases.map(_.toChar).mkString))
   }

--- a/src/main/scala/org/hammerlab/guacamole/util/CigarUtils.scala
+++ b/src/main/scala/org/hammerlab/guacamole/util/CigarUtils.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.util
 
 import htsjdk.samtools.{CigarElement, CigarOperator}

--- a/src/main/scala/org/hammerlab/guacamole/variants/Allele.scala
+++ b/src/main/scala/org/hammerlab/guacamole/variants/Allele.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.variants
 
 import com.esotericsoftware.kryo.io.{Input, Output}

--- a/src/main/scala/org/hammerlab/guacamole/variants/AlleleConversions.scala
+++ b/src/main/scala/org/hammerlab/guacamole/variants/AlleleConversions.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.variants
 
 import org.bdgenomics.formats.avro.{ GenotypeAllele, Genotype => ADAMGenotype }

--- a/src/main/scala/org/hammerlab/guacamole/variants/AlleleEvidence.scala
+++ b/src/main/scala/org/hammerlab/guacamole/variants/AlleleEvidence.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.variants
 
 import breeze.linalg.DenseVector

--- a/src/main/scala/org/hammerlab/guacamole/variants/CalledAllele.scala
+++ b/src/main/scala/org/hammerlab/guacamole/variants/CalledAllele.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.variants
 
 import org.hammerlab.guacamole.readsets.SampleName

--- a/src/main/scala/org/hammerlab/guacamole/variants/CalledSomaticAllele.scala
+++ b/src/main/scala/org/hammerlab/guacamole/variants/CalledSomaticAllele.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.variants
 
 import org.bdgenomics.adam.util.PhredUtils

--- a/src/main/scala/org/hammerlab/guacamole/variants/Concordance.scala
+++ b/src/main/scala/org/hammerlab/guacamole/variants/Concordance.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.variants
 
 import java.util.EnumSet

--- a/src/main/scala/org/hammerlab/guacamole/variants/Genotype.scala
+++ b/src/main/scala/org/hammerlab/guacamole/variants/Genotype.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.variants
 
 import com.esotericsoftware.kryo.io.{Input, Output}

--- a/src/main/scala/org/hammerlab/guacamole/variants/ReferenceVariant.scala
+++ b/src/main/scala/org/hammerlab/guacamole/variants/ReferenceVariant.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.variants
 
 import org.bdgenomics.formats.avro.{Contig, DatabaseVariantAnnotation, Variant}

--- a/src/main/scala/org/hammerlab/guacamole/windowing/SlidingWindow.scala
+++ b/src/main/scala/org/hammerlab/guacamole/windowing/SlidingWindow.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.windowing
 
 import org.apache.spark.Logging

--- a/src/test/scala/org/hammerlab/guacamole/commands/SomaticStandardCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/SomaticStandardCallerSuite.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.commands
 
 import org.hammerlab.guacamole.filters.SomaticGenotypeFilter

--- a/src/test/scala/org/hammerlab/guacamole/distributed/PileupFlatMapUtilsSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/distributed/PileupFlatMapUtilsSuite.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.distributed
 
 import com.esotericsoftware.kryo.Kryo

--- a/src/test/scala/org/hammerlab/guacamole/likelihood/LikelihoodSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/likelihood/LikelihoodSuite.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.likelihood
 
 import org.bdgenomics.adam.util.PhredUtils

--- a/src/test/scala/org/hammerlab/guacamole/likelihood/LikelihoodUtil.scala
+++ b/src/test/scala/org/hammerlab/guacamole/likelihood/LikelihoodUtil.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.likelihood
 
 import org.apache.spark.SparkContext

--- a/src/test/scala/org/hammerlab/guacamole/loci/map/LociMapSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/loci/map/LociMapSuite.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.loci.map
 
 import org.hammerlab.guacamole.loci.set.LociSet

--- a/src/test/scala/org/hammerlab/guacamole/loci/set/LociSetSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/loci/set/LociSetSuite.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.loci.set
 
 import org.hammerlab.guacamole.loci.LociArgs

--- a/src/test/scala/org/hammerlab/guacamole/pileup/PileupSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/pileup/PileupSuite.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.pileup
 
 import org.hammerlab.guacamole.reads.{MappedRead, ReadsUtil}

--- a/src/test/scala/org/hammerlab/guacamole/reads/MappedReadSerializerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/MappedReadSerializerSuite.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.reads
 
 import htsjdk.samtools.TextCigarCodec

--- a/src/test/scala/org/hammerlab/guacamole/reads/MappedReadSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/MappedReadSuite.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.reads
 
 import htsjdk.samtools.TextCigarCodec

--- a/src/test/scala/org/hammerlab/guacamole/reads/UnmappedReadSerializerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/UnmappedReadSerializerSuite.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.reads
 
 import org.hammerlab.guacamole.util.TestUtil.Implicits._

--- a/src/test/scala/org/hammerlab/guacamole/reads/UnmappedReadSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/UnmappedReadSuite.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.reads
 
 import org.hammerlab.guacamole.util.GuacFunSuite

--- a/src/test/scala/org/hammerlab/guacamole/readsets/ReadSetsSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/readsets/ReadSetsSuite.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.readsets
 
 import org.apache.parquet.hadoop.metadata.CompressionCodecName

--- a/src/test/scala/org/hammerlab/guacamole/util/BasesSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/BasesSuite.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.util
 
 import org.scalatest.{FunSuite, Matchers}

--- a/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
+++ b/src/test/scala/org/hammerlab/guacamole/util/TestUtil.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.util
 
 import java.io.{File, FileNotFoundException}

--- a/src/test/scala/org/hammerlab/guacamole/variants/AlleleSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/variants/AlleleSuite.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.variants
 
 import com.esotericsoftware.kryo.Kryo

--- a/src/test/scala/org/hammerlab/guacamole/windowing/SlidingWindowSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/windowing/SlidingWindowSuite.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.windowing
 
 import org.hammerlab.guacamole.loci.set.LociSet

--- a/src/test/scala/org/hammerlab/guacamole/windowing/SplitIteratorSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/windowing/SplitIteratorSuite.scala
@@ -1,21 +1,3 @@
-/**
- * Licensed to Big Data Genomics (BDG) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The BDG licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.hammerlab.guacamole.windowing
 
 import org.scalatest.{ FunSuite, Matchers }


### PR DESCRIPTION
fixes #332 

```bash
git grep -l 'Licensed to Big Data Genomics' | \
parallel -j+0 'perl -p -077 -i -e "s/\/\*\*.*?\*\/\s+//s" {}'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/552)
<!-- Reviewable:end -->
