### PR TITLE
restore removed docstrings

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
@@ -28,6 +28,7 @@ trait Read {
 
   def asMappedRead: Option[MappedRead]
 
+  /** The sample (e.g. "tumor" or "patient3636") name. */
   def sampleName: SampleName
 
   /** Whether the read failed predefined vendor checks for quality */

--- a/src/main/scala/org/hammerlab/guacamole/reference/ReferenceRegion.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reference/ReferenceRegion.scala
@@ -18,6 +18,12 @@ trait ReferenceRegion
     start - halfWindowSize <= locus && end + halfWindowSize > locus
   }
 
+  /**
+   * Does the region overlap another reference region
+   *
+   * @param other another region on the genome
+   * @return True if the the regions overlap
+   */
   def overlaps(other: ReferenceRegion): Boolean = {
     other.contigName == contigName && (overlapsLocus(other.start) || other.overlapsLocus(start))
   }

--- a/src/main/scala/org/hammerlab/guacamole/util/Bases.scala
+++ b/src/main/scala/org/hammerlab/guacamole/util/Bases.scala
@@ -50,6 +50,7 @@ object Bases {
     base == Bases.A || base == Bases.C || base == Bases.T || base == Bases.G
   }
 
+  /** Throw an error if the given base is not one of the canonical DNA bases. */
   def assertStandardBase(base: Byte) = {
     assert(isStandardBase(base), "Invalid base: %s".format(base.toChar.toString))
   }
@@ -59,6 +60,7 @@ object Bases {
     bases.forall(b => isStandardBase(b))
   }
 
+  /** Throw an error if any of the given bases are not standard. */
   def assertAllStandardBases(bases: Seq[Byte]) = {
     assert(allStandardBases(bases), "Invalid base array: %s".format(bases.map(_.toChar).mkString))
   }


### PR DESCRIPTION
mistakenly removed in #552

needed a `^` at the start of the perl regex 😞 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/558)
<!-- Reviewable:end -->
