### PR TITLE
truncate progress-printing of LociPartitioning

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/loci/partitioning/LociPartitioning.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/partitioning/LociPartitioning.scala
@@ -9,6 +9,7 @@ import org.hammerlab.guacamole.loci.partitioning.LociPartitioner.PartitionIndex
 import org.hammerlab.guacamole.loci.set.LociSet
 import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.reference.{NumLoci, ReferenceRegion}
+import org.hammerlab.guacamole.strings.TruncatedToString
 import org.hammerlab.magic.iterator.LinesIterator
 import org.hammerlab.magic.stats.Stats
 import org.hammerlab.magic.util.Saveable
@@ -20,7 +21,9 @@ import scala.reflect.ClassTag
  *
  * Includes some functionality for saving to / loading from disk.
  */
-case class LociPartitioning(map: LociMap[PartitionIndex]) extends Saveable {
+case class LociPartitioning(map: LociMap[PartitionIndex])
+  extends Saveable
+    with TruncatedToString {
 
   @transient lazy val numPartitions = partitionsMap.size
 
@@ -51,6 +54,8 @@ case class LociPartitioning(map: LociMap[PartitionIndex]) extends Saveable {
   }
 
   override def toString: String = map.toString
+
+  override def stringPieces: Iterator[String] = map.stringPieces
 }
 
 object LociPartitioning {

--- a/src/main/scala/org/hammerlab/guacamole/readsets/rdd/PartitionedRegions.scala
+++ b/src/main/scala/org/hammerlab/guacamole/readsets/rdd/PartitionedRegions.scala
@@ -200,7 +200,10 @@ object PartitionedRegions {
 
     val numPartitions = lociPartitioning.numPartitions
 
-    progress(s"Partitioning reads according to loci partitioning:\n$lociPartitioning")
+    progress(
+      s"Partitioning reads into $numPartitions partitions according to loci partitioning:",
+      lociPartitioning.truncatedString()
+    )
 
     implicit val accumulableParam = new HistogramParam[Int, Long]
 

--- a/src/main/scala/org/hammerlab/guacamole/strings/TruncatedToString.scala
+++ b/src/main/scala/org/hammerlab/guacamole/strings/TruncatedToString.scala
@@ -4,12 +4,11 @@ trait TruncatedToString {
   override def toString: String = truncatedString(Int.MaxValue)
 
   /** String representation, truncated to maxLength characters. */
-  def truncatedString(maxLength: Int = 500): String = {
+  def truncatedString(maxLength: Int = 500): String =
     TruncatedToString(stringPieces, maxLength)
-  }
 
   /**
-   * Iterator over string representations of
+   * Iterator over string representations of data comprising this object.
    */
   def stringPieces: Iterator[String]
 }


### PR DESCRIPTION
fixes #476 

there is already a code path for optionally saving the `LociPartitioning` to a file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/561)
<!-- Reviewable:end -->
