### PR TITLE
Move logging to grizzled slf4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,6 +325,11 @@
       <artifactId>magic-rdds</artifactId>
       <version>1.0.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.clapper</groupId>
+      <artifactId>grizzled-slf4j_${scala.version.prefix}</artifactId>
+      <version>1.0.3</version>
+    </dependency>
 
     <!-- Test deps -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
     <dependency>
       <groupId>com.holdenkarau</groupId>
       <artifactId>spark-testing-base_${scala.version.prefix}</artifactId>
-      <version>${spark.version}_0.3.3</version>
+      <version>${spark.version}_0.4.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/scala/org/hammerlab/guacamole/Main.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Main.scala
@@ -2,7 +2,7 @@ package org.hammerlab.guacamole
 
 import java.util.logging.Level
 
-import org.apache.spark.Logging
+import grizzled.slf4j.Logging
 import org.bdgenomics.adam.util.ParquetLogger
 import org.hammerlab.guacamole.commands._
 import org.hammerlab.guacamole.logging.LoggingUtils.progress

--- a/src/main/scala/org/hammerlab/guacamole/assembly/AssemblyUtils.scala
+++ b/src/main/scala/org/hammerlab/guacamole/assembly/AssemblyUtils.scala
@@ -1,7 +1,7 @@
 package org.hammerlab.guacamole.assembly
 
+import grizzled.slf4j.Logging
 import htsjdk.samtools.CigarOperator
-import org.apache.spark.Logging
 import org.hammerlab.guacamole.alignment.{AffineGapPenaltyAlignment, ReadAlignment}
 import org.hammerlab.guacamole.reads.MappedRead
 import org.hammerlab.guacamole.reference.{ContigSequence, ReferenceGenome}
@@ -83,7 +83,7 @@ object AssemblyUtils extends Logging {
 
     // Score up to the maximum number of paths
     if (paths.isEmpty) {
-      log.warn(s"In window $contigName:$referenceStart-$referenceEnd assembly failed")
+      warn(s"In window $contigName:$referenceStart-$referenceEnd assembly failed")
       List.empty
     } else if (paths.size <= expectedPloidy) {
       paths
@@ -101,7 +101,7 @@ object AssemblyUtils extends Logging {
         .map(_._2)
 
     } else {
-      log.warn(s"In window $contigName:$referenceStart-$referenceEnd " +
+      warn(s"In window $contigName:$referenceStart-$referenceEnd " +
         s"there were ${paths.size} paths found, all variants skipped")
       List.empty
     }
@@ -126,7 +126,7 @@ object AssemblyUtils extends Logging {
                                                    allowReferenceVariant: Boolean = false): Seq[T] = {
 
     val alignment = alignPath(path)
-    log.warn(s"Building variants from ${alignment.toCigarString} alignment")
+    warn(s"Building variants from ${alignment.toCigarString} alignment")
 
     var referenceIndex = alignment.refStartIdx
     var pathIndex = 0

--- a/src/main/scala/org/hammerlab/guacamole/commands/Command.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/Command.scala
@@ -1,6 +1,6 @@
 package org.hammerlab.guacamole.commands
 
-import org.apache.spark.Logging
+import grizzled.slf4j.Logging
 import org.bdgenomics.utils.cli.{Args4j, Args4jBase}
 
 /**

--- a/src/main/scala/org/hammerlab/guacamole/commands/SomaticJointCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/SomaticJointCaller.scala
@@ -64,7 +64,7 @@ object SomaticJoint {
 
       val (readsets, loci) = ReadSets(sc, args)
 
-      log.info(
+      info(
         (s"Running on ${inputs.items.length} inputs:" :: inputs.items.toList).mkString("\n")
       )
 

--- a/src/main/scala/org/hammerlab/guacamole/jointcaller/pileup_summarization/ReadSubsequence.scala
+++ b/src/main/scala/org/hammerlab/guacamole/jointcaller/pileup_summarization/ReadSubsequence.scala
@@ -1,6 +1,6 @@
 package org.hammerlab.guacamole.jointcaller.pileup_summarization
 
-import org.apache.spark.Logging
+import grizzled.slf4j.Logging
 import org.hammerlab.guacamole.pileup.PileupElement
 import org.hammerlab.guacamole.reads.MappedRead
 import org.hammerlab.guacamole.reference.{ContigSequence, Locus}

--- a/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
@@ -1,7 +1,7 @@
 package org.hammerlab.guacamole.reads
 
+import grizzled.slf4j.Logging
 import htsjdk.samtools._
-import org.apache.spark.Logging
 import org.bdgenomics.formats.avro.AlignmentRecord
 import org.hammerlab.guacamole.readsets.SampleName
 import org.hammerlab.guacamole.util.Bases
@@ -101,7 +101,7 @@ object Read extends Logging {
 
         // We subtract 1 from start, since samtools is 1-based and we're 0-based.
         if (result.unclippedStart != record.getUnclippedStart - 1)
-          log.warn(
+          warn(
             "Computed read 'unclippedStart' %d != samtools read end %d.".format(
               result.unclippedStart, record.getUnclippedStart - 1
             )

--- a/src/main/scala/org/hammerlab/guacamole/windowing/SlidingWindow.scala
+++ b/src/main/scala/org/hammerlab/guacamole/windowing/SlidingWindow.scala
@@ -1,6 +1,5 @@
 package org.hammerlab.guacamole.windowing
 
-import org.apache.spark.Logging
 import org.hammerlab.guacamole.loci.set.LociIterator
 import org.hammerlab.guacamole.readsets.PerSample
 import org.hammerlab.guacamole.reference.{ContigName, Interval, Locus, ReferenceRegion}
@@ -26,7 +25,7 @@ import scala.collection.mutable
  */
 case class SlidingWindow[R <: ReferenceRegion](contigName: ContigName,
                                                halfWindowSize: Int,
-                                               rawSortedRegions: Iterator[R]) extends Logging {
+                                               rawSortedRegions: Iterator[R]) {
   /** The locus currently under consideration. */
   var currentLocus = -1L
   /** The new regions that were added to currentRegions as a result of the most recent call to setCurrentLocus. */

--- a/src/test/scala/org/hammerlab/guacamole/main/GeneratePartialFasta.scala
+++ b/src/test/scala/org/hammerlab/guacamole/main/GeneratePartialFasta.scala
@@ -97,7 +97,7 @@ object GeneratePartialFasta extends SparkCommand[GeneratePartialFastaArguments] 
         writer.write(sequence)
         writer.write("\n")
       } catch {
-        case e: ContigNotFound => log.warn("No such contig in reference: %s: %s".format(contig, e.toString))
+        case e: ContigNotFound => warn("No such contig in reference: %s: %s".format(contig, e.toString))
       }
     }
     writer.close()


### PR DESCRIPTION
In prep for Spark 2.0 upgrade, this moves the references to `o.a.s.Logging` to to grizzled's scala slf4j wrapper which similarly provides a `Logging` trait 

Another option could be https://github.com/typesafehub/scala-logging with `LazyLogging` trait, but that doesn't have scala 2.10 version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/570)
<!-- Reviewable:end -->
