### PR TITLE
Update likelihood code to handle non-uniform allelic mixtures

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/kryo/Registrar.scala
+++ b/src/main/scala/org/hammerlab/guacamole/kryo/Registrar.scala
@@ -14,7 +14,7 @@ import org.hammerlab.guacamole.loci.set.{LociSet, Contig => LociSetContig, Conti
 import org.hammerlab.guacamole.reads.{MappedRead, MappedReadSerializer, MateAlignmentProperties, PairedRead, Read, UnmappedRead, UnmappedReadSerializer}
 import org.hammerlab.guacamole.readsets.ContigLengths
 import org.hammerlab.guacamole.reference.Position
-import org.hammerlab.guacamole.variants.{Allele, AlleleEvidence, AlleleSerializer, CalledAllele}
+import org.hammerlab.guacamole.variants.{Allele, AlleleEvidence, AlleleSerializer, CalledAllele, Genotype}
 import org.hammerlab.magic.accumulables.{HashMap => MagicHashMap}
 import org.hammerlab.magic.kryo.{Registrar => MagicRDDRegistrar}
 
@@ -68,6 +68,7 @@ class Registrar extends KryoRegistrator {
     // Germline-assembly caller flatmaps some CalledAlleles.
     kryo.register(classOf[Array[CalledAllele]])
     kryo.register(classOf[CalledAllele])
+    kryo.register(classOf[Genotype])
     kryo.register(classOf[Allele], new AlleleSerializer)
     kryo.register(classOf[AlleleEvidence])
 

--- a/src/main/scala/org/hammerlab/guacamole/likelihood/Likelihood.scala
+++ b/src/main/scala/org/hammerlab/guacamole/likelihood/Likelihood.scala
@@ -86,7 +86,6 @@ object Likelihood {
     normalize: Boolean = false): Seq[(Genotype, Double)] = {
 
     val alleles = pileup.distinctAlleles.filter(allele => allele.altBases.forall((Bases.isStandardBase _)))
-
     val genotypes = (for {
       i <- 0 until alleles.size
       j <- i until alleles.size
@@ -151,10 +150,9 @@ object Likelihood {
       assume(genotype.alleles.size == 2, "Non-diploid genotype not supported")
       val alleleRow1 = alleleElementProbabilities(alleleToIndex(genotype.alleles(0)), ::)
       val alleleRow2 = alleleElementProbabilities(alleleToIndex(genotype.alleles(1)), ::)
-      ( //alleleRow1.aggregate(alleleRow2, Functions.plus, Functions.chain(Functions.log, Functions.plus))
-        sum(log(alleleRow1 + alleleRow2))
+      sum(log(alleleRow1 + alleleRow2))
         + math.log(prior(genotype))
-        - math.log(2) * depth)
+        - math.log(2) * depth
     }))
 
     // Normalize and/or convert log probs to plain probabilities.
@@ -195,5 +193,4 @@ object Likelihood {
 
     alleleElementProbabilities
   }
-
 }

--- a/src/main/scala/org/hammerlab/guacamole/likelihood/Likelihood.scala
+++ b/src/main/scala/org/hammerlab/guacamole/likelihood/Likelihood.scala
@@ -135,11 +135,11 @@ object Likelihood {
                              logSpace: Boolean = false,
                              normalize: Boolean = false): DenseVector[Double] = {
 
-    val alleles = genotypes.flatMap(_.alleles).distinct.toIndexedSeq.sorted // the distinct alleles in our genotypes
+    val alleles = genotypes.flatMap(_.alleles).distinct.sorted.array // the distinct alleles in our genotypes
     val alleleToIndex = alleles.zipWithIndex.toMap // map from allele -> allele index in our alleles sequence.
     val depth = elements.size
 
-    val alleleElementProbabilities = computeAlleleElementProbabilities(elements, alleles.toArray, probabilityCorrect)
+    val alleleElementProbabilities = computeAlleleElementProbabilities(elements, alleles, probabilityCorrect)
 
     // Calculate likelihoods in log-space. For each genotype, we compute:
     //   sum over elements {

--- a/src/main/scala/org/hammerlab/guacamole/likelihood/Likelihood.scala
+++ b/src/main/scala/org/hammerlab/guacamole/likelihood/Likelihood.scala
@@ -87,7 +87,7 @@ object Likelihood {
 
     val alleles = pileup.distinctAlleles.filter(allele => allele.altBases.forall((Bases.isStandardBase _)))
     val genotypes = (for {
-      i <- 0 until alleles.size
+      i <- alleles.indices
       j <- i until alleles.size
     } yield Genotype(alleles(i), alleles(j))).toArray
     val likelihoods = likelihoodsOfGenotypes(pileup.elements, genotypes, probabilityCorrect, prior, logSpace, normalize)

--- a/src/main/scala/org/hammerlab/guacamole/likelihood/Likelihood.scala
+++ b/src/main/scala/org/hammerlab/guacamole/likelihood/Likelihood.scala
@@ -85,7 +85,8 @@ object Likelihood {
     logSpace: Boolean = false,
     normalize: Boolean = false): Seq[(Genotype, Double)] = {
 
-    val alleles = pileup.distinctAlleles.filter(allele => allele.altBases.forall((Bases.isStandardBase _)))
+
+    val alleles = pileup.distinctAlleles.filter(allele => allele.altBases.forall(Bases.isStandardBase))
     val genotypes = (for {
       i <- alleles.indices
       j <- i until alleles.size

--- a/src/main/scala/org/hammerlab/guacamole/likelihood/Likelihood.scala
+++ b/src/main/scala/org/hammerlab/guacamole/likelihood/Likelihood.scala
@@ -24,7 +24,7 @@ object Likelihood {
    *
    * This considers only the base quality scores.
    *
-   * @param element the [org.hammerlab.guacamole.pileup.PileupElement]] to consider
+   * @param element the [[org.hammerlab.guacamole.pileup.PileupElement]] to consider
    * @return the unnormalized likelihood the sequenced bases are correct. Plain probability, NOT a log prob.
    */
   def probabilityCorrectIgnoringAlignment(element: PileupElement): Double = {

--- a/src/main/scala/org/hammerlab/guacamole/likelihood/Likelihood.scala
+++ b/src/main/scala/org/hammerlab/guacamole/likelihood/Likelihood.scala
@@ -181,7 +181,7 @@ object Likelihood {
     //    probability(element, allele).
     //
     // where the probability is defined as in the header comment.
-    val alleleElementProbabilities = new DenseMatrix[Double](alleles.size, depth)
+    val alleleElementProbabilities = new DenseMatrix[Double](alleles.length, depth)
     for {
       (allele, alleleIndex) <- alleles.zipWithIndex
       (element, elementIndex) <- elements.zipWithIndex

--- a/src/main/scala/org/hammerlab/guacamole/pileup/PileupElement.scala
+++ b/src/main/scala/org/hammerlab/guacamole/pileup/PileupElement.scala
@@ -1,6 +1,7 @@
 package org.hammerlab.guacamole.pileup
 
 import htsjdk.samtools.{CigarElement, CigarOperator}
+import org.bdgenomics.adam.util.PhredUtils
 import org.hammerlab.guacamole.reads.MappedRead
 import org.hammerlab.guacamole.reference.{ContigSequence, Locus}
 import org.hammerlab.guacamole.util.CigarUtils
@@ -151,6 +152,12 @@ case class PileupElement(
     case MatchOrMisMatch(_, qs)   => qs
     case Insertion(_, qss)        => qss.min
   }
+
+  def probabilityCorrectIgnoringAlignment: Double =
+    PhredUtils.phredToSuccessProbability(qualityScore)
+
+  def probabilityCorrectIncludingAlignment: Double =
+    PhredUtils.phredToSuccessProbability(qualityScore) * read.alignmentLikelihood
 
   /**
    * Returns a new [[PileupElement]] of the same read, advanced by one cigar element.

--- a/src/main/scala/org/hammerlab/guacamole/variants/Genotype.scala
+++ b/src/main/scala/org/hammerlab/guacamole/variants/Genotype.scala
@@ -9,7 +9,8 @@ package org.hammerlab.guacamole.variants
  */
 case class Genotype(alleleMixture: Map[Allele, Double]) {
 
-  assume(alleleMixture.values.sum <= 1, "Allele fractions are larger than 1")
+  // The allele fractions should sum up to approximately one
+  assume(alleleMixture.values.sum == 1, s"Allele should sum to 1, but sum to ${alleleMixture.values.sum}")
 
   val alleles = alleleMixture.keySet
 

--- a/src/main/scala/org/hammerlab/guacamole/variants/Genotype.scala
+++ b/src/main/scala/org/hammerlab/guacamole/variants/Genotype.scala
@@ -1,28 +1,19 @@
 package org.hammerlab.guacamole.variants
 
-import com.esotericsoftware.kryo.io.{Input, Output}
-import com.esotericsoftware.kryo.{Kryo, Serializer}
-import org.bdgenomics.formats.avro.GenotypeAllele
-
 /**
- * A Genotype is a sequence of alleles of length equal to the ploidy of the organism.
+ * A Genotype is a map of alleles to their allele frequency
  *
  * A Genotype is for a particular reference locus. Each allele gives the base(s) present on a chromosome at that
  * locus.
  *
- * For example, the possible single-base diploid genotypes are Seq('A', 'A'), Seq('A', 'T') ... Seq('T', 'T').
- * Alleles can also be multiple bases as well, e.g. Seq("AAA", "T")
- *
  */
-case class Genotype(alleles: Allele*) {
-  /**
-   * The ploidy of the organism is the number of alleles in the genotype.
-   */
-  val ploidy = alleles.size
+case class Genotype(alleleMixture: Map[Allele, Double]) {
 
-  lazy val uniqueAllelesCount = alleles.toSet.size
+  assume(alleleMixture.values.sum <= 1, "Allele fractions are larger than 1")
 
-  lazy val getNonReferenceAlleles: Seq[Allele] = {
+  val alleles = alleleMixture.keySet
+
+  lazy val getNonReferenceAlleles: Set[Allele] = {
     alleles.filter(_.isVariant)
   }
 
@@ -40,40 +31,5 @@ case class Genotype(alleles: Allele*) {
    */
   lazy val hasVariantAllele: Boolean = (numberOfVariantAlleles > 0)
 
-  /**
-   * Transform the alleles in this genotype to the ADAM allele enumeration.
-   * Classifies alleles as Reference or Alternate.
-   *
-   * @return Sequence of Genotype which are Ref, Alt or OtherAlt.
-   */
-  lazy val getGenotypeAlleles: Seq[GenotypeAllele] = {
-    assume(ploidy == 2)
-    val numVariants = numberOfVariantAlleles
-    if (numVariants == 0) {
-      Seq(GenotypeAllele.Ref, GenotypeAllele.Ref)
-    } else if (numVariants > 0 && uniqueAllelesCount == 1) {
-      Seq(GenotypeAllele.Alt, GenotypeAllele.Alt)
-    } else if (numVariants >= 2 && uniqueAllelesCount > 1) {
-      Seq(GenotypeAllele.Alt, GenotypeAllele.OtherAlt)
-    } else {
-      Seq(GenotypeAllele.Ref, GenotypeAllele.Alt)
-    }
-  }
-
   override def toString: String = "Genotype(%s)".format(alleles.map(_.toString).mkString(","))
-}
-
-class GenotypeSerializer
-    extends Serializer[Genotype]
-    with HasAlleleSerializer {
-  def write(kryo: Kryo, output: Output, obj: Genotype) = {
-    output.writeInt(obj.alleles.length, true)
-    obj.alleles.foreach(alleleSerializer.write(kryo, output, _))
-  }
-
-  def read(kryo: Kryo, input: Input, klass: Class[Genotype]): Genotype = {
-    val numAlleles = input.readInt(true)
-    val alleles = (0 to numAlleles).map(i => alleleSerializer.read(kryo, input, classOf[Allele]))
-    Genotype(alleles: _*)
-  }
 }

--- a/src/test/scala/org/hammerlab/guacamole/likelihood/LikelihoodSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/likelihood/LikelihoodSuite.scala
@@ -21,24 +21,27 @@ class LikelihoodSuite
 
   val referenceBase = 'C'.toByte
 
-  def makeGenotype(alleles: String*): Genotype =
+  def makeGenotype(alleles: String*): Genotype = {
+    val alleleFraction = 1.0 / alleles.length
     Genotype(
-      alleles
-        .map(
-          allele =>
-            Allele(
-              Seq(referenceBase),
-              Bases.stringToBases(allele)
-            )
-        ): _*
+      (for {
+        allele <- alleles
+      }
+        yield Allele(
+          Seq(referenceBase),
+          Bases.stringToBases(allele))
+          -> alleleFraction).toMap
     )
+  }
 
   def makeGenotype(alleles: (Char, Char)): Genotype =
     makeGenotype(
       alleles
         .productIterator
         .map(_.toString)
-        .toList: _*
+        .toList
+        .distinct
+        : _*
     )
 
   val errorPhred30 = PhredUtils.phredToErrorProbability(30)
@@ -72,7 +75,7 @@ class LikelihoodSuite
       )
     ) {
       case (genotype, likelihood) =>
-        actualLikelihoodsMap(genotype) should ===(likelihood +- epsilon)
+        actualLikelihoodsMap(genotype) should === (likelihood +- epsilon)
     }
   }
 


### PR DESCRIPTION
This PR contains the following changes:
- Misc updates from the code review on #568 
- Changes `Genotype` from a collection of alleles to a map of `Allele` -> Allele Fraction
- Updates `Likelihood.scala` and `LikelihoodSuite.scala` to handle this

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/571)
<!-- Reviewable:end -->
