### PR TITLE
likelihood nits

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/pileup/PileupElement.scala
+++ b/src/main/scala/org/hammerlab/guacamole/pileup/PileupElement.scala
@@ -1,6 +1,7 @@
 package org.hammerlab.guacamole.pileup
 
 import htsjdk.samtools.{CigarElement, CigarOperator}
+import org.bdgenomics.adam.util.PhredUtils
 import org.hammerlab.guacamole.reads.MappedRead
 import org.hammerlab.guacamole.reference.{ContigSequence, Locus}
 import org.hammerlab.guacamole.util.CigarUtils
@@ -151,6 +152,12 @@ case class PileupElement(
     case MatchOrMisMatch(_, qs)   => qs
     case Insertion(_, qss)        => qss.min
   }
+
+  def probabilityCorrectIgnoringAlignment: Double =
+    PhredUtils.phredToSuccessProbability(qualityScore)
+
+  def probabilityCorrectIncludingAlignment: Double =
+    PhredUtils.phredToSuccessProbability(qualityScore) * read.alignmentLikelihood
 
   /**
    * Returns a new [[PileupElement]] of the same read, advanced by one cigar element.


### PR DESCRIPTION
goes on top of #571 

- private-ize a few methods
- simplify alignment-inclusion API in likelihood calculation: simple
  boolean instead of arbitrary function
- remove "Likelihood." from call-sites
- misc line-spacing

I can make this a separate PR if you don't want to combine it with #571 / things here are controversial, @arahuja, lmk!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/574)
<!-- Reviewable:end -->
