### PR TITLE
Fix ordering of tumor and normal read data

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
@@ -66,7 +66,7 @@ object SomaticStandard {
 
       val reference = ReferenceBroadcast(args.referenceFastaPath, sc)
 
-      val (tumorReads, normalReads, contigLengths) =
+      val (normalReads, tumorReads, contigLengths) =
         ReadSets.loadTumorNormalReads(
           args,
           sc,
@@ -91,7 +91,7 @@ object SomaticStandard {
         pileupFlatMapTwoSamples[CalledSomaticAllele](
           partitionedReads,
           skipEmpty = true, // skip empty pileups
-          function = (pileupTumor, pileupNormal) =>
+          function = (pileupNormal, pileupTumor) =>
             findPotentialVariantAtLocus(
               pileupTumor,
               pileupNormal,


### PR DESCRIPTION
In https://github.com/hammerlab/guacamole/commit/995af3dbc9c7dcb595c4389a87b4a6fce940cfebthe order of the tumor read and normal reads was swapped, mislabeling tumor as normal and vice-versa.

At some point it seems the pileups returned from `pileupFlatMapTwoSamples` were also flipped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/575)
<!-- Reviewable:end -->
