### PR TITLE
Move commons-io back to standard dep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,6 +320,11 @@
       <artifactId>grizzled-slf4j_${scala.version.prefix}</artifactId>
       <version>1.0.3</version>
     </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.5</version>
+    </dependency>
 
     <!-- Test deps -->
     <dependency>
@@ -341,12 +346,7 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.5</version>
-      <scope>test</scope>
-    </dependency>
+
   </dependencies>
 
   <profiles>


### PR DESCRIPTION
At some point, `commons-io` was moved to a test-only dependency, but this is necessary as a dependency when running without `spark-submit` for Hadoop output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/577)
<!-- Reviewable:end -->
