### PR TITLE
rm "-fasta" from reference-param name

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/variants/GenotypeOutputArgs.scala
+++ b/src/main/scala/org/hammerlab/guacamole/variants/GenotypeOutputArgs.scala
@@ -167,4 +167,3 @@ trait GenotypeOutputArgs
     coalescedGenotypes.unpersist()
   }
 }
-


### PR DESCRIPTION
- also rm unused ReferenceArgs

it can be a `.fasta.gz`, making the previous name a bit ambiguous, and both previous ref args were unnecessarily verbose

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/580)
<!-- Reviewable:end -->
