### PR TITLE
"upgrade" adam to forked "0.20.0"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ cache:
   # Local builds of zinc (Scala incremental compiler).
   - $HOME/.zinc
 
+  # Experimental: cache built classes and incremental-compile analysis
+  - target/scala-2.10.5
+  - target/analysis
+
 # Run the tests and generate coverage reports in one go.
 script: mvn scoverage:report
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: java
 jdk:
   - oraclejdk8
 sudo: false
+jdk:
+  - oraclejdk8
 
 cache:
   directories:

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
           <reportsDirectory>${project.build.directory}/scalatest-reports</reportsDirectory>
           <junitxml>.</junitxml>
           <filereports>GuacamoleTestSuite.txt</filereports>
-          <argLine>-Xmx4g -XX:MaxPermSize=256m</argLine>
+          <argLine>-Xmx2g -XX:MaxPermSize=256m</argLine>
 
           <!-- Print full stack traces when tests fail. -->
           <stdout>F</stdout>

--- a/pom.xml
+++ b/pom.xml
@@ -16,16 +16,11 @@
   <name>guacamole: variant caller</name>
 
   <properties>
-    <adam.version>0.19.0</adam.version>
-    <bdg-formats.version>0.7.0</bdg-formats.version>
     <java.version>1.8</java.version>
     <scala.version>2.10.5</scala.version>
     <scala.version.prefix>2.10</scala.version.prefix>
     <hadoop.version>2.7.0</hadoop.version>
     <spark.version>1.6.1</spark.version>
-    <maven.release.plugin.version>2.4.1</maven.release.plugin.version>
-    <shade.plugin.version>2.1</shade.plugin.version>
-    <scoverage.plugin.version>1.1.1</scoverage.plugin.version>
   </properties>
 
   <licenses>
@@ -50,7 +45,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>${shade.plugin.version}</version>
+        <version>2.1</version>
         <configuration>
           <transformers>
             <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
@@ -177,7 +172,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>${maven.release.plugin.version}</version>
+        <version>2.4.1</version>
         <configuration>
           <branchName>branch-@{project.version}</branchName>
           <goals>deploy</goals>
@@ -246,19 +241,25 @@
       <version>[2.0.29,)</version>
     </dependency>
     <dependency>
-      <groupId>org.bdgenomics.adam</groupId>
+      <groupId>org.hammerlab.adam</groupId>
       <artifactId>adam-core_${scala.version.prefix}</artifactId>
-      <version>${adam.version}</version>
+      <version>0.20.0</version>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.bdg-formats</groupId>
       <artifactId>bdg-formats</artifactId>
-      <version>${bdg-formats.version}</version>
+      <version>0.9.0</version>
     </dependency>
     <dependency>
-      <groupId>org.bdgenomics.qc-metrics</groupId>
-      <artifactId>qc-metrics-core_${scala.version.prefix}</artifactId>
-      <version>0.0.1</version>
+      <groupId>org.bdgenomics.quinine</groupId>
+      <artifactId>quinine-core_${scala.version.prefix}</artifactId>
+      <version>0.0.2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.bdgenomics.adam</groupId>
+          <artifactId>adam-core_2.10</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.spire-math</groupId>
@@ -409,7 +410,7 @@
           <plugin>
             <groupId>org.scoverage</groupId>
             <artifactId>scoverage-maven-plugin</artifactId>
-            <version>${scoverage.plugin.version}</version>
+            <version>1.1.1</version>
             <configuration>
               <scalaVersion>${scala.version}</scalaVersion>
             </configuration>

--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
@@ -49,13 +49,13 @@ object GermlineAssemblyCaller {
     override val name = "germline-assembly"
     override val description = "call germline variants by assembling the surrounding region of reads"
 
-    override def computeGenotypes(args: Arguments, sc: SparkContext) = {
+    override def computeVariants(args: Arguments, sc: SparkContext) = {
       val reference = args.reference(sc)
       val loci = args.parseLoci(sc.hadoopConfiguration)
-      val (mappedReads, contigLengths) =
-        ReadSets.loadMappedReads(
-          args,
+      val readsets =
+        ReadSets(
           sc,
+          args.inputs,
           InputFilters(
             overlapsLoci = loci,
             mapped = true,
@@ -64,27 +64,34 @@ object GermlineAssemblyCaller {
         )
 
       val minAlignmentQuality = args.minAlignmentQuality
-      val qualityReads = mappedReads.filter(_.alignmentQuality > minAlignmentQuality)
+      val qualityReads = readsets.allMappedReads.filter(_.alignmentQuality > minAlignmentQuality)
 
       val partitionedReads =
         PartitionedRegions(
           qualityReads,
-          loci.result(contigLengths),
+          loci.result(readsets.contigLengths),
           args,
           args.assemblyWindowRange
         )
 
-      discoverGermlineVariants(
-        partitionedReads,
-        args.sampleName,
-        kmerSize = args.kmerSize,
-        assemblyWindowRange = args.assemblyWindowRange,
-        minOccurrence = args.minOccurrence,
-        minAreaVaf = args.minAreaVaf / 100.0f,
-        reference = reference,
-        minMeanKmerQuality = args.minMeanKmerQuality,
-        minPhredScaledLikelihood = args.minLikelihood,
-        shortcutAssembly = args.shortcutAssembly
+      val calledAlleles =
+        discoverGermlineVariants(
+          partitionedReads,
+          args.sampleName,
+          kmerSize = args.kmerSize,
+          assemblyWindowRange = args.assemblyWindowRange,
+          minOccurrence = args.minOccurrence,
+          minAreaVaf = args.minAreaVaf / 100.0f,
+          reference = reference,
+          minMeanKmerQuality = args.minMeanKmerQuality,
+          minPhredScaledLikelihood = args.minLikelihood,
+          shortcutAssembly = args.shortcutAssembly
+        )
+
+      (
+        calledAlleles,
+        readsets.sequenceDictionary,
+        Vector(args.sampleName)
       )
     }
 

--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
@@ -133,6 +133,7 @@ object GermlineAssemblyCaller {
             val pileup =
               Pileup(
                 currentLocusReads,
+                sampleName,
                 contigName,
                 window.currentLocus,
                 referenceContig

--- a/src/main/scala/org/hammerlab/guacamole/commands/SomaticJointCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/SomaticJointCaller.scala
@@ -193,7 +193,7 @@ object SomaticJoint {
     }
 
     pileupFlatMapMultipleSamples(
-      readsets.numSamples,
+      readsets.sampleNames,
       partitionedReads,
       skipEmpty = true,  // TODO: shouldn't skip empty positions if we might force call them. Need an efficient way to handle this.
       callPileups,

--- a/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
@@ -48,7 +48,7 @@ object SomaticStandard {
     override val name = "somatic-standard"
     override val description = "call somatic variants using independent callers on tumor and normal"
 
-    override def computeGenotypes(args: Arguments, sc: SparkContext): RDD[CalledSomaticAllele] = {
+    override def computeVariants(args: Arguments, sc: SparkContext) = {
       val reference = args.reference(sc)
 
       val (readsets, loci) = ReadSets(sc, args)
@@ -113,7 +113,7 @@ object SomaticStandard {
         potentialGenotypes =
           potentialGenotypes
             .keyBy(_.bdgVariant)
-            .leftOuterJoin(dbSnpVariants.keyBy(_.getVariant))
+            .leftOuterJoin(dbSnpVariants.rdd.keyBy(_.getVariant))
             .values
             .map {
               case (calledAllele: CalledSomaticAllele, dbSnpVariantOpt: Option[DatabaseVariantAnnotation]) =>
@@ -121,7 +121,11 @@ object SomaticStandard {
             }
       }
 
-      SomaticGenotypeFilter(potentialGenotypes, args)
+      (
+        SomaticGenotypeFilter(potentialGenotypes, args),
+        readsets.sequenceDictionary,
+        Vector(args.tumorSampleName)
+      )
     }
 
     def findPotentialVariantAtLocus(tumorPileup: Pileup,

--- a/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
@@ -67,9 +67,14 @@ object SomaticStandard {
       val filterMultiAllelic = args.filterMultiAllelic
       val maxTumorReadDepth = args.maxTumorReadDepth
 
+      val normalSampleName = args.normalSampleName
+      val tumorSampleName = args.tumorSampleName
+
       var potentialGenotypes: RDD[CalledSomaticAllele] =
         pileupFlatMapTwoSamples[CalledSomaticAllele](
           partitionedReads,
+          sample1Name = normalSampleName,
+          sample2Name = tumorSampleName,
           skipEmpty = true,  // skip empty pileups
           function = (pileupNormal, pileupTumor) =>
             findPotentialVariantAtLocus(
@@ -182,8 +187,7 @@ object SomaticStandard {
       lazy val normalVariantsTotalLikelihood = normalVariantGenotypes.values.sum
       lazy val somaticOdds = mostLikelyTumorGenotypeLikelihood / normalVariantsTotalLikelihood
 
-      if (mostLikelyTumorGenotype.hasVariantAllele
-        && somaticOdds * 100 >= oddsThreshold)
+      if (mostLikelyTumorGenotype.hasVariantAllele && somaticOdds * 100 >= oddsThreshold)
         for {
           // NOTE(ryan): currently only look at the first non-ref allele in the most likely tumor genotype.
           // removeCorrelatedGenotypes depends on there only being one variant per locus.

--- a/src/main/scala/org/hammerlab/guacamole/commands/VariantSupport.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/VariantSupport.scala
@@ -79,7 +79,7 @@ object VariantSupport {
 
       val alleleCounts =
         pileupFlatMapMultipleSamples[AlleleCount](
-          readsets.numSamples,
+          readsets.sampleNames,
           partitionedReads,
           skipEmpty = true,
           pileupsToAlleleCounts,

--- a/src/main/scala/org/hammerlab/guacamole/commands/VariantSupport.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/VariantSupport.scala
@@ -52,7 +52,7 @@ object VariantSupport {
 
       val adamContext = new ADAMContext(sc)
 
-      val variants: RDD[Variant] = adamContext.loadVariants(args.variants)
+      val variants: RDD[Variant] = adamContext.loadVariants(args.variants).rdd
 
       val readsets =
         ReadSets(
@@ -65,7 +65,7 @@ object VariantSupport {
       val loci =
         LociSet(
           variants
-            .map(variant => (variant.getContig.getContigName, variant.getStart: Long, variant.getEnd: Long))
+            .map(variant => (variant.getContigName, variant.getStart: Long, variant.getEnd: Long))
             .collect()
         )
 

--- a/src/main/scala/org/hammerlab/guacamole/filters/pileup/PileupFilter.scala
+++ b/src/main/scala/org/hammerlab/guacamole/filters/pileup/PileupFilter.scala
@@ -44,6 +44,6 @@ object PileupFilter {
       elements = EdgeBaseFilter(elements, minEdgeDistance)
     }
 
-    Pileup(pileup.contigName, pileup.locus, pileup.contigSequence, elements)
+    pileup.copy(elements = elements)
   }
 }

--- a/src/main/scala/org/hammerlab/guacamole/kryo/Registrar.scala
+++ b/src/main/scala/org/hammerlab/guacamole/kryo/Registrar.scala
@@ -15,7 +15,7 @@ import org.hammerlab.guacamole.loci.set.{LociSet, Contig => LociSetContig, Conti
 import org.hammerlab.guacamole.reads.{MappedRead, MappedReadSerializer, MateAlignmentProperties, PairedRead, Read, UnmappedRead, UnmappedReadSerializer}
 import org.hammerlab.guacamole.readsets.ContigLengths
 import org.hammerlab.guacamole.reference.Position
-import org.hammerlab.guacamole.variants.{Allele, AlleleEvidence, AlleleSerializer, CalledAllele, Genotype}
+import org.hammerlab.guacamole.variants.{Allele, AlleleEvidence, AlleleSerializer, CalledAllele, CalledSomaticAllele, Genotype}
 import org.hammerlab.magic.accumulables.{HashMap => MagicHashMap}
 import org.hammerlab.magic.kryo.{Registrar => MagicRDDRegistrar}
 
@@ -83,5 +83,8 @@ class Registrar extends KryoRegistrator {
     kryo.register(classOf[RichVariant])
     kryo.register(classOf[VariantContext])
     kryo.register(classOf[Array[String]])
+
+    kryo.register(classOf[Array[CalledSomaticAllele]])
+    kryo.register(classOf[CalledSomaticAllele])
   }
 }

--- a/src/main/scala/org/hammerlab/guacamole/reads/MappedRead.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/MappedRead.scala
@@ -3,7 +3,7 @@ package org.hammerlab.guacamole.reads
 import htsjdk.samtools.{Cigar, CigarElement}
 import org.bdgenomics.adam.util.PhredUtils
 import org.hammerlab.guacamole.pileup.PileupElement
-import org.hammerlab.guacamole.readsets.{SampleId, SampleName}
+import org.hammerlab.guacamole.readsets.SampleId
 import org.hammerlab.guacamole.reference.{ContigName, ContigSequence, Locus, ReferenceRegion}
 import org.hammerlab.guacamole.util.{Bases, CigarUtils}
 
@@ -23,7 +23,6 @@ case class MappedRead(
     baseQualities: IndexedSeq[Byte],
     isDuplicate: Boolean,
     sampleId: SampleId,
-    sampleName: SampleName,
     contigName: ContigName,
     alignmentQuality: Int,
     start: Locus,

--- a/src/main/scala/org/hammerlab/guacamole/reads/MappedReadSerializer.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/MappedReadSerializer.scala
@@ -15,7 +15,6 @@ class MappedReadSerializer extends Serializer[MappedRead] {
     output.writeBytes(obj.baseQualities.toArray)
     output.writeBoolean(obj.isDuplicate)
     output.writeInt(obj.sampleId)
-    output.writeString(obj.sampleName)
     output.writeString(obj.contigName)
     output.writeInt(obj.alignmentQuality, true)
     output.writeLong(obj.start, true)
@@ -32,7 +31,6 @@ class MappedReadSerializer extends Serializer[MappedRead] {
     val qualityScoresArray: IndexedSeq[Byte] = input.readBytes(count).toVector
     val isDuplicate = input.readBoolean()
     val sampleId = input.readInt()
-    val sampleName = input.readString().intern()
     val referenceContig = input.readString().intern()
     val alignmentQuality = input.readInt(true)
     val start = input.readLong(true)
@@ -49,7 +47,6 @@ class MappedReadSerializer extends Serializer[MappedRead] {
       qualityScoresArray,
       isDuplicate,
       sampleId,
-      sampleName.intern,
       referenceContig,
       alignmentQuality,
       start,

--- a/src/main/scala/org/hammerlab/guacamole/reads/PairedRead.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/PairedRead.scala
@@ -18,7 +18,6 @@ case class PairedRead[+T <: Read](read: T,
   override val name: String = read.name
   override val failedVendorQualityChecks: Boolean = read.failedVendorQualityChecks
   override val sampleId: SampleId = read.sampleId
-  override val sampleName: SampleName = read.sampleName
   override val baseQualities: IndexedSeq[Byte] = read.baseQualities
   override val isDuplicate: Boolean = read.isDuplicate
   override val sequence: IndexedSeq[Byte] = read.sequence

--- a/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
@@ -3,7 +3,6 @@ package org.hammerlab.guacamole.reads
 import grizzled.slf4j.Logging
 import htsjdk.samtools._
 import org.bdgenomics.formats.avro.AlignmentRecord
-import org.hammerlab.guacamole.readsets.SampleName
 import org.hammerlab.guacamole.util.Bases
 
 /**
@@ -27,9 +26,6 @@ trait Read extends HasSampleId {
   def isMapped: Boolean
 
   def asMappedRead: Option[MappedRead]
-
-  /** The sample (e.g. "tumor" or "patient3636") name. */
-  def sampleName: SampleName
 
   /** Whether the read failed predefined vendor checks for quality */
   def failedVendorQualityChecks: Boolean
@@ -73,13 +69,6 @@ object Read extends Logging {
       record.getAlignmentStart >= 0 &&
       record.getUnclippedStart >= 0)
 
-    val sampleName =
-      (if (record.getReadGroup != null && record.getReadGroup.getSample != null)
-        record.getReadGroup.getSample
-      else
-        "default"
-      ).intern
-
     val read =
       if (isMapped) {
         val result =
@@ -89,7 +78,6 @@ object Read extends Logging {
             record.getBaseQualities,
             record.getDuplicateReadFlag,
             sampleId,
-            sampleName.intern,
             record.getReferenceName.intern,
             record.getMappingQuality,
             record.getAlignmentStart - 1,
@@ -115,7 +103,6 @@ object Read extends Logging {
           record.getBaseQualities,
           record.getDuplicateReadFlag,
           sampleId,
-          sampleName,
           record.getReadFailsVendorQualityCheckFlag,
           record.getReadPairedFlag
         )
@@ -151,7 +138,6 @@ object Read extends Logging {
           baseQualities = baseQualities,
           isDuplicate = alignmentRecord.getDuplicateRead,
           sampleId = sampleId,
-          sampleName = alignmentRecord.getRecordGroupSample.intern(),
           contigName = referenceContig,
           alignmentQuality = alignmentRecord.getMapq,
           start = alignmentRecord.getStart,
@@ -167,7 +153,6 @@ object Read extends Logging {
           baseQualities = baseQualities,
           isDuplicate = alignmentRecord.getDuplicateRead,
           sampleId = sampleId,
-          sampleName = alignmentRecord.getRecordGroupSample.intern(),
           failedVendorQualityChecks = alignmentRecord.getFailedVendorQualityChecks,
           alignmentRecord.getReadPaired
         )

--- a/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/Read.scala
@@ -140,7 +140,7 @@ object Read extends Logging {
     val sequence = Bases.stringToBases(alignmentRecord.getSequence)
     val baseQualities = baseQualityStringToArray(alignmentRecord.getQual, sequence.length)
 
-    val referenceContig = alignmentRecord.getContig.getContigName.intern
+    val referenceContig = alignmentRecord.getContigName.intern
     val cigar = TextCigarCodec.decode(alignmentRecord.getCigar)
 
     val read =
@@ -175,7 +175,7 @@ object Read extends Logging {
     if (alignmentRecord.getReadPaired) {
       val mateAlignment = if (alignmentRecord.getMateMapped) Some(
         MateAlignmentProperties(
-          contigName = alignmentRecord.getMateContig.getContigName.intern(),
+          contigName = alignmentRecord.getMateContigName.intern(),
           start = alignmentRecord.getMateAlignmentStart,
           inferredInsertSize = if (alignmentRecord.getInferredInsertSize != 0 && alignmentRecord.getInferredInsertSize != null) Some(alignmentRecord.getInferredInsertSize.toInt) else None,
           isPositiveStrand = !alignmentRecord.getMateNegativeStrand

--- a/src/main/scala/org/hammerlab/guacamole/reads/UnmappedRead.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/UnmappedRead.scala
@@ -12,7 +12,6 @@ case class UnmappedRead(
     baseQualities: IndexedSeq[Byte],
     isDuplicate: Boolean,
     sampleId: SampleId,
-    sampleName: SampleName,
     failedVendorQualityChecks: Boolean,
     isPaired: Boolean) extends Read {
 

--- a/src/main/scala/org/hammerlab/guacamole/reads/UnmappedReadSerializer.scala
+++ b/src/main/scala/org/hammerlab/guacamole/reads/UnmappedReadSerializer.scala
@@ -13,7 +13,6 @@ class UnmappedReadSerializer extends Serializer[UnmappedRead] {
     output.writeBytes(obj.baseQualities.toArray)
     output.writeBoolean(obj.isDuplicate)
     output.writeInt(obj.sampleId)
-    output.writeString(obj.sampleName)
     output.writeBoolean(obj.failedVendorQualityChecks)
     output.writeBoolean(obj.isPaired)
 
@@ -26,7 +25,6 @@ class UnmappedReadSerializer extends Serializer[UnmappedRead] {
     val qualityScoresArray = input.readBytes(count).toVector
     val isDuplicate = input.readBoolean()
     val sampleId = input.readInt()
-    val sampleName = input.readString().intern()
     val failedVendorQualityChecks = input.readBoolean()
     val isPaired = input.readBoolean()
 
@@ -36,7 +34,6 @@ class UnmappedReadSerializer extends Serializer[UnmappedRead] {
       qualityScoresArray,
       isDuplicate,
       sampleId,
-      sampleName.intern,
       failedVendorQualityChecks,
       isPaired
     )

--- a/src/main/scala/org/hammerlab/guacamole/readsets/ReadSets.scala
+++ b/src/main/scala/org/hammerlab/guacamole/readsets/ReadSets.scala
@@ -9,12 +9,11 @@ import org.apache.hadoop.io.LongWritable
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models.SequenceDictionary
-import org.bdgenomics.adam.rdd.{ADAMContext, ADAMSpecificRecordSequenceDictionaryRDDAggregator}
-import org.bdgenomics.formats.avro.AlignmentRecord
+import org.bdgenomics.adam.rdd.ADAMContext
 import org.hammerlab.guacamole.loci.set.{LociParser, LociSet}
 import org.hammerlab.guacamole.logging.LoggingUtils.progress
-import org.hammerlab.guacamole.reads.{MappedRead, Read}
-import org.hammerlab.guacamole.readsets.args.{SingleSampleArgs, Base => BaseArgs}
+import org.hammerlab.guacamole.reads.Read
+import org.hammerlab.guacamole.readsets.args.{Base => BaseArgs}
 import org.hammerlab.guacamole.readsets.io.{Input, InputFilters}
 import org.hammerlab.guacamole.readsets.rdd.ReadsRDD
 import org.hammerlab.guacamole.reference.{ContigName, Locus}
@@ -33,8 +32,10 @@ case class ReadSets(readsRDDs: PerSample[ReadsRDD],
                     contigLengths: ContigLengths)
   extends PerSample[ReadsRDD] {
 
+  def inputs: PerSample[Input] = readsRDDs.map(_.input)
+
   def numSamples: NumSamples = readsRDDs.length
-  def sampleNames: PerSample[String] = readsRDDs.map(_.input.sampleName)
+  def sampleNames: PerSample[String] = inputs.map(_.sampleName)
 
   override def length: NumSamples = readsRDDs.length
   override def apply(sampleId: SampleId): ReadsRDD = readsRDDs(sampleId)
@@ -47,34 +48,6 @@ case class ReadSets(readsRDDs: PerSample[ReadsRDD],
 }
 
 object ReadSets extends Logging {
-
-  /**
-   * Load one read-set from an input file.
-   */
-  private[readsets] def loadReads(args: SingleSampleArgs,
-                                  sc: SparkContext,
-                                  filters: InputFilters): (ReadsRDD, ContigLengths) = {
-
-    val ReadSets(reads, _, contigLengths) =
-      ReadSets(
-        sc,
-        args.inputs,
-        filters,
-        contigLengthsFromDictionary = !args.noSequenceDictionary
-      )
-
-    (reads(0), contigLengths)
-  }
-
-  /**
-   * Load just the mapped reads from an input ReadSet.
-   */
-  def loadMappedReads(args: SingleSampleArgs,
-                      sc: SparkContext,
-                      filters: InputFilters): (RDD[MappedRead], ContigLengths) = {
-    val (reads, contigLengths) = loadReads(args, sc, filters)
-    (reads.mappedReads, contigLengths)
-  }
 
   /**
    * Load ReadSet instances from user-specified BAMs (specified as an InputCollection).
@@ -120,7 +93,7 @@ object ReadSets extends Logging {
 
     val (readsRDDs, sequenceDictionaries) =
       (for {
-        (Input(sampleId, sampleName, filename), filters) <- inputsAndFilters
+        (Input(sampleId, _, filename), filters) <- inputsAndFilters
       } yield
         load(filename, sc, sampleId, filters)
       ).unzip
@@ -238,13 +211,12 @@ object ReadSets extends Logging {
 
     val adamContext = new ADAMContext(sc)
 
-    val adamRecords: RDD[AlignmentRecord] = adamContext.loadAlignments(
-      filename, projection = None, stringency = ValidationStringency.LENIENT).rdd
+    val alignmentRDD =
+      adamContext.loadAlignments(filename, projection = None, stringency = ValidationStringency.LENIENT)
 
-    val sequenceDictionary =
-      new ADAMSpecificRecordSequenceDictionaryRDDAggregator(adamRecords).adamGetSequenceDictionary()
+    val sequenceDictionary = alignmentRDD.sequences
 
-    (adamRecords.map(Read(_, sampleId)), sequenceDictionary)
+    (alignmentRDD.rdd.map(Read(_, sampleId)), sequenceDictionary)
   }
 
 

--- a/src/main/scala/org/hammerlab/guacamole/readsets/args/TumorNormalReadsArgs.scala
+++ b/src/main/scala/org/hammerlab/guacamole/readsets/args/TumorNormalReadsArgs.scala
@@ -13,5 +13,8 @@ trait TumorNormalReadsArgs extends Base {
 
   override def paths = Array(normalReads, tumorReads)
 
-  override def sampleNames = Array("normal", "tumor")
+  val normalSampleName = "normal"
+  val tumorSampleName = "tumor"
+
+  override def sampleNames = Array(normalSampleName, tumorSampleName)
 }

--- a/src/main/scala/org/hammerlab/guacamole/variants/AlleleEvidence.scala
+++ b/src/main/scala/org/hammerlab/guacamole/variants/AlleleEvidence.scala
@@ -72,12 +72,13 @@ object AlleleEvidence {
         meanBaseQuality = mean(baseQualityScores),
         medianBaseQuality = median(baseQualityScores),
         medianMismatchesPerRead = median(
-          DenseVector(alleleElements.map(_.read.countOfMismatches(pileup.contigSequence)).toArray)))
+          DenseVector(alleleElements.map(_.read.countOfMismatches(pileup.contigSequence)).toArray)
+        )
+      )
   }
 
   def apply(likelihood: Double, allele: Allele, pileup: Pileup): AlleleEvidence = {
     val (alleleReadDepth, allelePositiveReadDepth) = pileup.alleleReadDepthAndPositiveDepth(allele)
     AlleleEvidence(likelihood, allele, alleleReadDepth, allelePositiveReadDepth, pileup)
-
   }
 }

--- a/src/main/scala/org/hammerlab/guacamole/variants/CalledSomaticAllele.scala
+++ b/src/main/scala/org/hammerlab/guacamole/variants/CalledSomaticAllele.scala
@@ -41,6 +41,9 @@ case class CalledSomaticAllele(sampleName: SampleName,
       .newBuilder
       .setAlleles(seqAsJavaList(Seq(GenotypeAllele.Ref, GenotypeAllele.Alt)))
       .setSampleId(sampleName)
+      .setContigName(contigName)
+      .setStart(start)
+      .setEnd(end)
       .setGenotypeQuality(phredScaledSomaticLikelihood)
       .setReadDepth(tumorVariantEvidence.readDepth)
       .setExpectedAlleleDosage(

--- a/src/main/scala/org/hammerlab/guacamole/variants/Concordance.scala
+++ b/src/main/scala/org/hammerlab/guacamole/variants/Concordance.scala
@@ -7,7 +7,7 @@ import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rich.RichVariant
 import org.bdgenomics.formats.avro.{GenotypeType, Genotype => BDGGenotype}
-import org.bdgenomics.qc.rdd.variation.{ConcordanceTable, GenotypeConcordanceRDDFunctions}
+import org.bdgenomics.quinine.rdd.variation.{ConcordanceTable, GenotypeConcordanceRDDFunctions}
 import org.hammerlab.guacamole.logging.DebugLogArgs
 import org.kohsuke.args4j.{Option => Args4jOption}
 
@@ -61,7 +61,7 @@ object Concordance {
 
     def chromosomeFilter(genotype: BDGGenotype): Boolean =
       chromosome == "" ||
-        genotype.getVariant.getContig.getContigName == chromosome
+        genotype.getVariant.getContigName == chromosome
 
     def variantTypeFilter(genotype: BDGGenotype): Boolean = {
       val variant = new RichVariant(genotype.getVariant)
@@ -146,7 +146,7 @@ object Concordance {
    */
   def loadGenotypes(path: String, sc: SparkContext): RDD[BDGGenotype] = {
     if (path.endsWith(".vcf")) {
-      sc.loadGenotypes(path)
+      sc.loadGenotypes(path).rdd
     } else {
       sc.loadParquet(path)
     }

--- a/src/main/scala/org/hammerlab/guacamole/variants/ReferenceVariant.scala
+++ b/src/main/scala/org/hammerlab/guacamole/variants/ReferenceVariant.scala
@@ -1,9 +1,9 @@
 package org.hammerlab.guacamole.variants
 
-import org.bdgenomics.formats.avro.{Contig, DatabaseVariantAnnotation, Variant, Genotype => BDGGenotype}
+import org.bdgenomics.formats.avro.{DatabaseVariantAnnotation, Variant, Genotype => BDGGenotype}
 import org.hammerlab.guacamole.readsets.SampleName
 import org.hammerlab.guacamole.reference.ReferenceRegion
-import org.hammerlab.guacamole.util.Bases
+import org.hammerlab.guacamole.util.Bases.basesToString
 
 /**
  * Base properties of a genomic change in a sequence sample from a reference genome
@@ -21,9 +21,9 @@ trait ReferenceVariant extends ReferenceRegion {
       .newBuilder
       .setStart(start)
       .setEnd(end)
-      .setReferenceAllele(Bases.basesToString(allele.refBases))
-      .setAlternateAllele(Bases.basesToString(allele.altBases))
-      .setContig(Contig.newBuilder.setContigName(contigName).build)
+      .setReferenceAllele(basesToString(allele.refBases))
+      .setAlternateAllele(basesToString(allele.altBases))
+      .setContigName(contigName)
       .build
 
   def rsID: Option[Int]

--- a/src/test/resources/tough.golden.vcf
+++ b/src/test/resources/tough.golden.vcf
@@ -1,5 +1,5 @@
 ##fileformat=VCFv4.2
-##FORMAT=<ID=AD,Number=.,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
+##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
 ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth (reads with MQ=255 or with bad mates are filtered)">
 ##FORMAT=<ID=FT,Number=1,Type=String,Description="Genotype-level filter">
 ##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
@@ -16,7 +16,92 @@
 ##INFO=<ID=ReadPosRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt vs. Ref read position bias">
 ##INFO=<ID=VQSLOD,Number=1,Type=Float,Description="Log odds ratio of being a true variant versus being false under the trained gaussian mixture model">
 ##INFO=<ID=culprit,Number=1,Type=String,Description="The annotation which was the worst performing in the Gaussian mixture model, likely the reason why the variant was filtered out">
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	tumor.chr20
+##contig=<ID=1,length=249250621,assembly=GRCh37>
+##contig=<ID=2,length=243199373,assembly=GRCh37>
+##contig=<ID=3,length=198022430,assembly=GRCh37>
+##contig=<ID=4,length=191154276,assembly=GRCh37>
+##contig=<ID=5,length=180915260,assembly=GRCh37>
+##contig=<ID=6,length=171115067,assembly=GRCh37>
+##contig=<ID=7,length=159138663,assembly=GRCh37>
+##contig=<ID=8,length=146364022,assembly=GRCh37>
+##contig=<ID=9,length=141213431,assembly=GRCh37>
+##contig=<ID=10,length=135534747,assembly=GRCh37>
+##contig=<ID=11,length=135006516,assembly=GRCh37>
+##contig=<ID=12,length=133851895,assembly=GRCh37>
+##contig=<ID=13,length=115169878,assembly=GRCh37>
+##contig=<ID=14,length=107349540,assembly=GRCh37>
+##contig=<ID=15,length=102531392,assembly=GRCh37>
+##contig=<ID=16,length=90354753,assembly=GRCh37>
+##contig=<ID=17,length=81195210,assembly=GRCh37>
+##contig=<ID=18,length=78077248,assembly=GRCh37>
+##contig=<ID=19,length=59128983,assembly=GRCh37>
+##contig=<ID=20,length=63025520,assembly=GRCh37>
+##contig=<ID=21,length=48129895,assembly=GRCh37>
+##contig=<ID=22,length=51304566,assembly=GRCh37>
+##contig=<ID=X,length=155270560,assembly=GRCh37>
+##contig=<ID=Y,length=59373566,assembly=GRCh37>
+##contig=<ID=MT,length=16569,assembly=GRCh37>
+##contig=<ID=GL000207.1,length=4262,assembly=GRCh37>
+##contig=<ID=GL000226.1,length=15008,assembly=GRCh37>
+##contig=<ID=GL000229.1,length=19913,assembly=GRCh37>
+##contig=<ID=GL000231.1,length=27386,assembly=GRCh37>
+##contig=<ID=GL000210.1,length=27682,assembly=GRCh37>
+##contig=<ID=GL000239.1,length=33824,assembly=GRCh37>
+##contig=<ID=GL000235.1,length=34474,assembly=GRCh37>
+##contig=<ID=GL000201.1,length=36148,assembly=GRCh37>
+##contig=<ID=GL000247.1,length=36422,assembly=GRCh37>
+##contig=<ID=GL000245.1,length=36651,assembly=GRCh37>
+##contig=<ID=GL000197.1,length=37175,assembly=GRCh37>
+##contig=<ID=GL000203.1,length=37498,assembly=GRCh37>
+##contig=<ID=GL000246.1,length=38154,assembly=GRCh37>
+##contig=<ID=GL000249.1,length=38502,assembly=GRCh37>
+##contig=<ID=GL000196.1,length=38914,assembly=GRCh37>
+##contig=<ID=GL000248.1,length=39786,assembly=GRCh37>
+##contig=<ID=GL000244.1,length=39929,assembly=GRCh37>
+##contig=<ID=GL000238.1,length=39939,assembly=GRCh37>
+##contig=<ID=GL000202.1,length=40103,assembly=GRCh37>
+##contig=<ID=GL000234.1,length=40531,assembly=GRCh37>
+##contig=<ID=GL000232.1,length=40652,assembly=GRCh37>
+##contig=<ID=GL000206.1,length=41001,assembly=GRCh37>
+##contig=<ID=GL000240.1,length=41933,assembly=GRCh37>
+##contig=<ID=GL000236.1,length=41934,assembly=GRCh37>
+##contig=<ID=GL000241.1,length=42152,assembly=GRCh37>
+##contig=<ID=GL000243.1,length=43341,assembly=GRCh37>
+##contig=<ID=GL000242.1,length=43523,assembly=GRCh37>
+##contig=<ID=GL000230.1,length=43691,assembly=GRCh37>
+##contig=<ID=GL000237.1,length=45867,assembly=GRCh37>
+##contig=<ID=GL000233.1,length=45941,assembly=GRCh37>
+##contig=<ID=GL000204.1,length=81310,assembly=GRCh37>
+##contig=<ID=GL000198.1,length=90085,assembly=GRCh37>
+##contig=<ID=GL000208.1,length=92689,assembly=GRCh37>
+##contig=<ID=GL000191.1,length=106433,assembly=GRCh37>
+##contig=<ID=GL000227.1,length=128374,assembly=GRCh37>
+##contig=<ID=GL000228.1,length=129120,assembly=GRCh37>
+##contig=<ID=GL000214.1,length=137718,assembly=GRCh37>
+##contig=<ID=GL000221.1,length=155397,assembly=GRCh37>
+##contig=<ID=GL000209.1,length=159169,assembly=GRCh37>
+##contig=<ID=GL000218.1,length=161147,assembly=GRCh37>
+##contig=<ID=GL000220.1,length=161802,assembly=GRCh37>
+##contig=<ID=GL000213.1,length=164239,assembly=GRCh37>
+##contig=<ID=GL000211.1,length=166566,assembly=GRCh37>
+##contig=<ID=GL000199.1,length=169874,assembly=GRCh37>
+##contig=<ID=GL000217.1,length=172149,assembly=GRCh37>
+##contig=<ID=GL000216.1,length=172294,assembly=GRCh37>
+##contig=<ID=GL000215.1,length=172545,assembly=GRCh37>
+##contig=<ID=GL000205.1,length=174588,assembly=GRCh37>
+##contig=<ID=GL000219.1,length=179198,assembly=GRCh37>
+##contig=<ID=GL000224.1,length=179693,assembly=GRCh37>
+##contig=<ID=GL000223.1,length=180455,assembly=GRCh37>
+##contig=<ID=GL000195.1,length=182896,assembly=GRCh37>
+##contig=<ID=GL000212.1,length=186858,assembly=GRCh37>
+##contig=<ID=GL000222.1,length=186861,assembly=GRCh37>
+##contig=<ID=GL000200.1,length=187035,assembly=GRCh37>
+##contig=<ID=GL000193.1,length=189789,assembly=GRCh37>
+##contig=<ID=GL000194.1,length=191469,assembly=GRCh37>
+##contig=<ID=GL000225.1,length=211173,assembly=GRCh37>
+##contig=<ID=GL000192.1,length=547496,assembly=GRCh37>
+##contig=<ID=NC_007605,length=171823,assembly=NC_007605.1>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	tumor
 20	755755	.	G	A	.	.	.	GT:AD:DP:GQ	0/1:28,11:39:99
 20	1843814	.	G	T	.	.	.	GT:AD:DP:GQ	0/1:18,8:26:99
 20	3555767	.	T	G	.	.	.	GT:AD:DP:GQ	0/1:21,10:31:99

--- a/src/test/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCallerSuite.scala
@@ -46,10 +46,10 @@ class GermlineAssemblyCallerSuite
 
     val lociParser = LociParser(s"$contig:$windowStart-$windowEnd")
 
-    val (mappedReads, contigLengths) =
-      ReadSets.loadMappedReads(
-        args,
+    val readsets =
+      ReadSets(
         sc,
+        args.inputs,
         InputFilters(
           mapped = true,
           nonDuplicate = true,
@@ -57,9 +57,9 @@ class GermlineAssemblyCallerSuite
         )
       )
 
-    val lociPartitioning = new UniformPartitioner(args.parallelism).partition(lociParser.result(contigLengths))
+    val lociPartitioning = new UniformPartitioner(args.parallelism).partition(lociParser.result(readsets.contigLengths))
 
-    val partitionedReads = partitionReads(mappedReads, lociPartitioning)
+    val partitionedReads = partitionReads(readsets.allMappedReads, lociPartitioning)
 
     val variants =
       GermlineAssemblyCaller.Caller.discoverGermlineVariants(
@@ -86,31 +86,26 @@ class GermlineAssemblyCallerSuite
     actualVariants should be(expectedVariants)
   }
 
-  test (
-    "test assembly caller: illumina platinum tests; homozygous snp") {
+  test("test assembly caller: illumina platinum tests; homozygous snp") {
     verifyVariantsAtLocus(772754) (
       ("chr1", 772754, "A", "C")
     )
   }
 
-
-  test (
-    "test assembly caller: illumina platinum tests; homozygous snp; shortcut assembly") {
+  test("test assembly caller: illumina platinum tests; homozygous snp; shortcut assembly") {
     verifyVariantsAtLocus(772754, shortcutAssembly = true) (
       ("chr1", 772754, "A", "C")
     )
   }
 
-  test (
-    "test assembly caller: illumina platinum tests; nearby homozygous snps") {
+  test("test assembly caller: illumina platinum tests; nearby homozygous snps") {
     verifyVariantsAtLocus(1297212) (
       ("chr1", 1297212, "G", "C"),
       ("chr1", 1297215, "A", "G")
     )
   }
 
-  test (
-    "test assembly caller: illumina platinum tests; 2 nearby homozygous snps") {
+  test("test assembly caller: illumina platinum tests; 2 nearby homozygous snps") {
     verifyVariantsAtLocus(1316669) (
       ("chr1", 1316647, "C", "T"),
       ("chr1", 1316669, "C", "G"),
@@ -118,8 +113,7 @@ class GermlineAssemblyCallerSuite
     )
   }
 
-  test (
-    "test assembly caller: illumina platinum tests; 2 nearby homozygous snps; shortcut assembly") {
+  test("test assembly caller: illumina platinum tests; 2 nearby homozygous snps; shortcut assembly") {
     verifyVariantsAtLocus(1316669, shortcutAssembly = true) (
       ("chr1", 1316647, "C", "T"),
       ("chr1", 1316669, "C", "G"),
@@ -127,72 +121,62 @@ class GermlineAssemblyCallerSuite
     )
   }
 
-  test (
-    "test assembly caller: illumina platinum tests; het snp") {
+  test("test assembly caller: illumina platinum tests; het snp") {
     verifyVariantsAtLocus(1342611) (
       ("chr1", 1342611, "G", "C")
     )
   }
 
-  test (
-    "test assembly caller: illumina platinum tests; homozygous deletion") {
+  test("test assembly caller: illumina platinum tests; homozygous deletion") {
     verifyVariantsAtLocus(1296368) (
       ("chr1", 1296368, "GAC", "G")
     )
   }
 
-  test (
-    "test assembly caller: illumina platinum tests; homozygous deletion; shortcut assembly") {
+  test("test assembly caller: illumina platinum tests; homozygous deletion; shortcut assembly") {
     verifyVariantsAtLocus(1296368, shortcutAssembly = true) (
       ("chr1", 1296368, "GAC", "G")
     )
   }
 
-  test (
-    "test assembly caller: illumina platinum tests; homozygous deletion 2") {
+  test("test assembly caller: illumina platinum tests; homozygous deletion 2") {
     verifyVariantsAtLocus(1303426) (
       ("chr1", 1303426, "ACT", "A")
     )
   }
 
-  test (
-    "test assembly caller: illumina platinum tests; homozygous insertion") {
+  test("test assembly caller: illumina platinum tests; homozygous insertion") {
     verifyVariantsAtLocus(1321298) (
       ("chr1", 1321298, "A", "AG")
     )
   }
 
-  test (
-    "test assembly caller: illumina platinum tests; homozygous insertion 2") {
+  test("test assembly caller: illumina platinum tests; homozygous insertion 2") {
     verifyVariantsAtLocus(1302671) (
       ("chr1", 1302554, "C", "T"),
       ("chr1", 1302671, "A", "AGT")
     )
   }
 
-  test (
-    "test assembly caller: empty region") {
+  test("test assembly caller: empty region") {
     verifyVariantsAtLocus(1303917)()
   }
 
-  test (
-    "test assembly caller: homozygous snp in a repeat region") {
+  test("test assembly caller: homozygous snp in a repeat region") {
     verifyVariantsAtLocus(789255) (
       ("chr1", 789192, "C", "G"),
       ("chr1", 789255, "T", "C")
     )
   }
 
-  test (
-      "test assembly caller: het variant near homozygous variant") {
+  test("test assembly caller: het variant near homozygous variant") {
       verifyVariantsAtLocus(743020) (
         ("chr1", 743020, "T", "C"),
         ("chr1", 743071, "C", "A")
       )
   }
 
-  test (
-    "test assembly caller: het variant in between two homozygous variants") {
+  test("test assembly caller: het variant in between two homozygous variants") {
     verifyVariantsAtLocus(821925) (
       ("chr1", 821886, "A", "G"),
       ("chr1", 821925, "C", "G"),

--- a/src/test/scala/org/hammerlab/guacamole/commands/SomaticStandardCallerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/SomaticStandardCallerSuite.scala
@@ -30,7 +30,7 @@ class SomaticStandardCallerSuite
         ("TCGATCGA", "8M", 0)
       )
 
-    val normalPileup = makePileup(normalReads, "chr1", 2)
+    val normalPileup = makeNormalPileup(normalReads, "chr1", 2)
 
     val tumorReads =
       makeReads(
@@ -39,7 +39,7 @@ class SomaticStandardCallerSuite
         ("TCGGTCGA", "8M", 0)
       )
 
-    val tumorPileup = makePileup(tumorReads, "chr1", 2)
+    val tumorPileup = makeTumorPileup(tumorReads, "chr1", 2)
 
     SomaticStandard.Caller.findPotentialVariantAtLocus(tumorPileup, normalPileup, oddsThreshold = 2).size should be(0)
   }
@@ -52,7 +52,7 @@ class SomaticStandardCallerSuite
         ("TCGATCGA", "8M", 0)
       )
 
-    val normalPileup = makePileup(normalReads, "chr1", 2)
+    val normalPileup = makeNormalPileup(normalReads, "chr1", 2)
 
     val tumorReads =
       makeReads(
@@ -61,7 +61,7 @@ class SomaticStandardCallerSuite
         ("TCGTCGA", "3M1D4M", 0)
       )
 
-    val tumorPileup = makePileup(tumorReads, "chr1", 2)
+    val tumorPileup = makeTumorPileup(tumorReads, "chr1", 2)
 
     val alleles = SomaticStandard.Caller.findPotentialVariantAtLocus(tumorPileup, normalPileup, oddsThreshold = 2)
     alleles.size should be(1)
@@ -80,7 +80,7 @@ class SomaticStandardCallerSuite
         ("TCGAAGCTTCGAAGCT", "16M", 0)
       )
 
-    val normalPileup = makePileup(normalReads, "chr4", 4)
+    val normalPileup = makeNormalPileup(normalReads, "chr4", 4)
 
     val tumorReads =
       makeReads(
@@ -90,7 +90,7 @@ class SomaticStandardCallerSuite
         ("TCGAAAAGCT", "5M6D5M", 0)
       )
 
-    val tumorPileup = makePileup(tumorReads, "chr4", 4)
+    val tumorPileup = makeTumorPileup(tumorReads, "chr4", 4)
 
     val alleles = SomaticStandard.Caller.findPotentialVariantAtLocus(tumorPileup, normalPileup, oddsThreshold = 2)
     alleles.size should be(1)
@@ -108,7 +108,7 @@ class SomaticStandardCallerSuite
         ("TCGATCGA", "8M", 0)
       )
 
-    val normalPileup = makePileup(normalReads, "chr1", 2)
+    val normalPileup = makeNormalPileup(normalReads, "chr1", 2)
 
     val tumorReads =
       makeReads(
@@ -117,7 +117,7 @@ class SomaticStandardCallerSuite
         ("TCGAGTCGA", "4M1I4M", 0)
       )
 
-    val tumorPileup = makePileup(tumorReads, "chr1", 3)
+    val tumorPileup = makeTumorPileup(tumorReads, "chr1", 3)
 
     val alleles = SomaticStandard.Caller.findPotentialVariantAtLocus(tumorPileup, normalPileup, oddsThreshold = 2)
     alleles.size should be(1)
@@ -143,8 +143,8 @@ class SomaticStandardCallerSuite
       )
 
     val alleles = SomaticStandard.Caller.findPotentialVariantAtLocus(
-      makePileup(tumorReads, "chr1", 3),
-      makePileup(normalReads, "chr1", 3),
+      makeTumorPileup(tumorReads, "chr1", 3),
+      makeNormalPileup(normalReads, "chr1", 3),
       oddsThreshold = 2
     )
     alleles.size should be(1)
@@ -179,8 +179,8 @@ class SomaticStandardCallerSuite
 
     def testLocus(contigName: ContigName, locus: Locus, refBases: String, altBases: String) = {
       val alleles = SomaticStandard.Caller.findPotentialVariantAtLocus(
-        makePileup(tumorReads, contigName, locus),
-        makePileup(normalReads, contigName, locus),
+        makeTumorPileup(tumorReads, contigName, locus),
+        makeNormalPileup(normalReads, contigName, locus),
         oddsThreshold = 2
       )
       alleles.size should be(1)

--- a/src/test/scala/org/hammerlab/guacamole/distributed/PileupFlatMapUtilsSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/distributed/PileupFlatMapUtilsSuite.scala
@@ -82,6 +82,7 @@ class PileupFlatMapUtilsSuite
     val pileups =
       pileupFlatMapOneSample(
         partitionedReads,
+        sampleName = "sampleName",
         skipEmpty = false,
         pileup => Iterator(pileup),
         reference = reference
@@ -105,6 +106,7 @@ class PileupFlatMapUtilsSuite
     val pileups =
       pileupFlatMapOneSample(
         partitionedReads,
+        sampleName = "sampleName",
         skipEmpty = false,
         pileup => Iterator(pileup),
         reference = reference
@@ -124,6 +126,7 @@ class PileupFlatMapUtilsSuite
     val loci =
       pileupFlatMapOneSample(
         partitionedReads,
+        sampleName = "sampleName",
         skipEmpty = true,
         pileup => Iterator(pileup.locus),
         reference = reference
@@ -162,6 +165,8 @@ class PileupFlatMapUtilsSuite
     val loci =
       pileupFlatMapTwoSamples(
         partitionedReads,
+        sample1Name = "sample1",
+        sample2Name = "sample2",
         skipEmpty = true,
         (pileup1, _) => Iterator(pileup1.locus),
         reference = reference
@@ -206,7 +211,7 @@ class PileupFlatMapUtilsSuite
 
     val resultPlain =
       pileupFlatMapMultipleSamples[PerSample[Iterable[String]]](
-        numSamples = 3,
+        sampleNames = Vector("a", "b", "c"),
         partitionReads(reads, UniformPartitioner(1).partition(loci)),
         skipEmpty = true,
         pileupsToElementStrings,
@@ -215,7 +220,7 @@ class PileupFlatMapUtilsSuite
 
     val resultParallelized =
       pileupFlatMapMultipleSamples[PerSample[Iterable[String]]](
-        numSamples = 3,
+        sampleNames = Vector("a", "b", "c"),
         partitionReads(reads, UniformPartitioner(800).partition(loci)),
         skipEmpty = true,
         pileupsToElementStrings,
@@ -224,7 +229,7 @@ class PileupFlatMapUtilsSuite
 
     val resultWithEmpty =
       pileupFlatMapMultipleSamples[PerSample[Iterable[String]]](
-        numSamples = 3,
+        sampleNames = Vector("a", "b", "c"),
         partitionReads(reads, UniformPartitioner(5).partition(loci)),
         skipEmpty = false,
         pileupsToElementStrings,
@@ -256,6 +261,7 @@ class PileupFlatMapUtilsSuite
     val pileups =
       pileupFlatMapOneSample[PileupElement](
         partitionedReads,
+        sampleName = "sampleName",
         skipEmpty = false,
         _.elements.toIterator,
         reference = makeReference(sc, Seq(("chr1", 1, "TCGATCGA")))
@@ -295,6 +301,8 @@ class PileupFlatMapUtilsSuite
     val elements =
       pileupFlatMapTwoSamples[PileupElement](
         partitionedReads,
+        sample1Name = "sample1",
+        sample2Name = "sample2",
         skipEmpty = false,
         (pileup1, pileup2) => (pileup1.elements ++ pileup2.elements).toIterator,
         reference = makeReference(sc, Seq(("chr1", 0, "ATCGATCGA" + "N" * 90 + "AGGGGGGGGGG")))
@@ -322,6 +330,7 @@ class PileupFlatMapUtilsSuite
           reads,
           UniformPartitioner(5).partition(LociSet("chr1:1-12"))
         ),
+        sampleName = "sampleName",
         skipEmpty = false,
         _.elements.toIterator,
         reference = makeReference(sc, Seq(("chr1", 0, "ATCGATCGA")))

--- a/src/test/scala/org/hammerlab/guacamole/loci/map/SerializerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/loci/map/SerializerSuite.scala
@@ -30,27 +30,27 @@ class SerializerSuite extends GuacFunSuite {
     }
   }
 
-  testSerde("empty")()(10, 0, 0)
+  testSerde("empty")()(11, 0, 0)
 
   testSerde("1")(
     ("chr1", 100L, 200L, "A")
-  )(43, 1, 100)
+  )(44, 1, 100)
 
   testSerde("2")(
     ("chr1", 100L, 200L, "A"),
     ("chr1", 400L, 500L, "B")
-  )(63, 2, 200)
+  )(64, 2, 200)
 
   testSerde("3")(
     ("chr1", 100L, 200L, "A"),
     ("chr1", 400L, 500L, "B"),
     ("chr1", 600L, 700L, "C")
-  )(83, 3, 300)
+  )(84, 3, 300)
 
   testSerde("4")(
     ("chr1", 100L, 200L, "A"),
     ("chr1", 400L, 500L, "B"),
     ("chr1", 600L, 700L, "C"),
     ("chr1", 700L, 800L, "A")
-  )(101, 4, 400)
+  )(102, 4, 400)
 }

--- a/src/test/scala/org/hammerlab/guacamole/pileup/PileupSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/pileup/PileupSuite.scala
@@ -234,15 +234,15 @@ class PileupSuite
     val read = makeRead("AATTGAATTG", "5M1D5M", 1, "chr4")
 
     intercept[AssertionError] {
-      Pileup(Seq(read), "chr4", 0, reference.getContig("chr4"))
+      Pileup(Seq(read), "sample", "chr4", 0, reference.getContig("chr4"))
     }
 
     intercept[AssertionError] {
-      Pileup(Seq(read), "chr4", 12, reference.getContig("chr4"))
+      Pileup(Seq(read), "sample", "chr4", 12, reference.getContig("chr4"))
     }
 
     intercept[AssertionError] {
-      Pileup(Seq(read), "chr5", 1, reference.getContig("chr4"))
+      Pileup(Seq(read), "sample", "chr5", 1, reference.getContig("chr4"))
     }
   }
 

--- a/src/test/scala/org/hammerlab/guacamole/pileup/Util.scala
+++ b/src/test/scala/org/hammerlab/guacamole/pileup/Util.scala
@@ -15,7 +15,17 @@ trait Util
   def makePileup(reads: Seq[MappedRead],
                  contigName: ContigName,
                  locus: Locus) =
-    Pileup(reads, contigName, locus, reference.getContig(contigName))
+    Pileup(reads, "sample", contigName, locus, reference.getContig(contigName))
+
+  def makeNormalPileup(reads: Seq[MappedRead],
+                       contigName: ContigName,
+                       locus: Locus) =
+    Pileup(reads, "normal", contigName, locus, reference.getContig(contigName))
+
+  def makeTumorPileup(reads: Seq[MappedRead],
+                      contigName: ContigName,
+                      locus: Locus) =
+    Pileup(reads, "tumor", contigName, locus, reference.getContig(contigName))
 
   def loadTumorNormalPileup(tumorReads: Seq[MappedRead],
                             normalReads: Seq[MappedRead],
@@ -23,8 +33,8 @@ trait Util
     val contig = tumorReads(0).contigName
     assume(normalReads(0).contigName == contig)
     (
-      Pileup(tumorReads.filter(_.overlapsLocus(locus)), contig, locus, reference.getContig(contig)),
-      Pileup(normalReads.filter(_.overlapsLocus(locus)), contig, locus, reference.getContig(contig))
+      Pileup(tumorReads.filter(_.overlapsLocus(locus)), "tumor", contig, locus, reference.getContig(contig)),
+      Pileup(normalReads.filter(_.overlapsLocus(locus)), "normal", contig, locus, reference.getContig(contig))
     )
   }
 
@@ -50,6 +60,7 @@ trait Util
 
     Pileup(
       localReads,
+      filename,
       actualContig,
       locus,
       reference.getContig(actualContig)

--- a/src/test/scala/org/hammerlab/guacamole/reads/MappedReadSerializerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/MappedReadSerializerSuite.scala
@@ -13,7 +13,6 @@ class MappedReadSerializerSuite extends GuacFunSuite {
       Array[Byte]((10 to 20).map(_.toByte): _*),
       true,
       123,
-      "some sample name",
       "chr5",
       50,
       325352323,
@@ -36,7 +35,6 @@ class MappedReadSerializerSuite extends GuacFunSuite {
     deserialized.sequence should equal(read.sequence)
     deserialized.baseQualities should equal(read.baseQualities)
     deserialized.isDuplicate should equal(read.isDuplicate)
-    deserialized.sampleName should equal(read.sampleName)
     deserialized.contigName should equal(read.contigName)
     deserialized.alignmentQuality should equal(read.alignmentQuality)
     deserialized.start should equal(read.start)
@@ -53,7 +51,6 @@ class MappedReadSerializerSuite extends GuacFunSuite {
       Array[Byte]((10 to 20).map(_.toByte): _*),
       true,
       123,
-      "some sample name",
       "chr5",
       50,
       325352323,
@@ -76,7 +73,6 @@ class MappedReadSerializerSuite extends GuacFunSuite {
     deserialized.sequence should equal(read.sequence)
     deserialized.baseQualities should equal(read.baseQualities)
     deserialized.isDuplicate should equal(read.isDuplicate)
-    deserialized.sampleName should equal(read.sampleName)
     deserialized.contigName should equal(read.contigName)
     deserialized.alignmentQuality should equal(read.alignmentQuality)
     deserialized.start should equal(read.start)
@@ -93,7 +89,6 @@ class MappedReadSerializerSuite extends GuacFunSuite {
       Array[Byte]((10 to 20).map(_.toByte): _*),
       true,
       123,
-      "some sample name",
       "chr5",
       50,
       325352323,
@@ -116,7 +111,6 @@ class MappedReadSerializerSuite extends GuacFunSuite {
     deserialized.sequence should equal(read.sequence)
     deserialized.baseQualities should equal(read.baseQualities)
     deserialized.isDuplicate should equal(read.isDuplicate)
-    deserialized.sampleName should equal(read.sampleName)
     deserialized.contigName should equal(read.contigName)
     deserialized.alignmentQuality should equal(read.alignmentQuality)
     deserialized.start should equal(read.start)

--- a/src/test/scala/org/hammerlab/guacamole/reads/MappedReadSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/MappedReadSuite.scala
@@ -17,7 +17,6 @@ class MappedReadSuite
       Array[Byte]((10 to 20).map(_.toByte): _*),
       isDuplicate = true,
       sampleId = 123,
-      "some sample name",
       "chr5",
       50,
       325352323,
@@ -38,7 +37,6 @@ class MappedReadSuite
       Array[Byte]((10 to 20).map(_.toByte): _*),
       isDuplicate = true,
       123,
-      "some sample name",
       failedVendorQualityChecks = false,
       isPaired = true
     )
@@ -49,7 +47,6 @@ class MappedReadSuite
       Array[Byte]((10 to 20).map(_.toByte): _*),
       isDuplicate = true,
       123,
-      "some sample name",
       "chr5",
       50,
       325352323,

--- a/src/test/scala/org/hammerlab/guacamole/reads/PairedReadSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/PairedReadSuite.scala
@@ -13,7 +13,6 @@ class PairedReadSuite extends FunSuite with Matchers {
       Array[Byte]((10 to 20).map(_.toByte): _*),
       isDuplicate = true,
       123,
-      "some sample name",
       failedVendorQualityChecks = false,
       isPaired = true)
 
@@ -46,7 +45,6 @@ class PairedReadSuite extends FunSuite with Matchers {
         Array[Byte]((10 to 20).map(_.toByte): _*),
         isDuplicate = true,
         123,
-        "some sample name",
         failedVendorQualityChecks = false,
         isPaired = true),
       isFirstInPair = true,
@@ -68,7 +66,6 @@ class PairedReadSuite extends FunSuite with Matchers {
           Array[Byte]((10 to 20).map(_.toByte): _*),
           isDuplicate = true,
           sampleId = 123,
-          sampleName = "some sample name",
           contigName = "chr5",
           alignmentQuality = 50,
           start = 325352323,

--- a/src/test/scala/org/hammerlab/guacamole/reads/ReadsUtil.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/ReadsUtil.scala
@@ -1,7 +1,7 @@
 package org.hammerlab.guacamole.reads
 
 import htsjdk.samtools.TextCigarCodec
-import org.hammerlab.guacamole.readsets.{SampleId, SampleName}
+import org.hammerlab.guacamole.readsets.SampleId
 import org.hammerlab.guacamole.reference.{ContigName, Locus}
 
 trait ReadsUtil {
@@ -13,7 +13,6 @@ trait ReadsUtil {
                    baseQualities: String = "",
                    isDuplicate: Boolean = false,
                    sampleId: SampleId = 0,
-                   sampleName: SampleName = "",
                    contigName: ContigName = "",
                    alignmentQuality: Int = -1,
                    start: Locus = -1L,
@@ -32,7 +31,6 @@ trait ReadsUtil {
       qualityScoresArray,
       isDuplicate,
       sampleId,
-      sampleName.intern,
       contigName,
       alignmentQuality,
       start,
@@ -73,7 +71,7 @@ trait ReadsUtil {
       if (qualityScores.isDefined)
         qualityScores.get.map(q => q + 33).map(_.toChar).mkString
       else
-        sequence.map(x => '@').mkString
+        "@" * sequence.length
 
     read(
       sequence,
@@ -99,7 +97,7 @@ trait ReadsUtil {
                      cigar: String = "12M",
                      inferredInsertSize: Option[Int]): PairedRead[MappedRead] = {
 
-    val qualityScoreString = sequence.map(x => '@').mkString
+    val qualityScoreString = "@" * sequence.length
 
     PairedRead(
       read(

--- a/src/test/scala/org/hammerlab/guacamole/reads/UnmappedReadSerializerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/UnmappedReadSerializerSuite.scala
@@ -12,7 +12,6 @@ class UnmappedReadSerializerSuite extends GuacFunSuite {
       Array[Byte]((10 to 20).map(_.toByte): _*),
       isDuplicate = true,
       123,
-      "some sample name",
       failedVendorQualityChecks = false,
       isPaired = true
     )
@@ -30,9 +29,7 @@ class UnmappedReadSerializerSuite extends GuacFunSuite {
     deserialized.sequence should equal(read.sequence)
     deserialized.baseQualities should equal(read.baseQualities)
     deserialized.isDuplicate should equal(read.isDuplicate)
-    deserialized.sampleName should equal(read.sampleName)
     deserialized.failedVendorQualityChecks should equal(read.failedVendorQualityChecks)
     deserialized.isPaired should equal(read.isPaired)
   }
-
 }

--- a/src/test/scala/org/hammerlab/guacamole/reads/UnmappedReadSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/reads/UnmappedReadSuite.scala
@@ -12,7 +12,6 @@ class UnmappedReadSuite extends GuacFunSuite {
       Array[Byte]((10 to 20).map(_.toByte): _*),
       isDuplicate = true,
       123,
-      "some sample name",
       failedVendorQualityChecks = false,
       isPaired = false
     )
@@ -23,5 +22,4 @@ class UnmappedReadSuite extends GuacFunSuite {
     val collectionMappedReads: Seq[Read] = Seq(read)
     collectionMappedReads(0).isMapped should be(false)
   }
-
 }

--- a/src/test/scala/org/hammerlab/guacamole/readsets/ReadSetsSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/readsets/ReadSetsSuite.scala
@@ -2,7 +2,6 @@ package org.hammerlab.guacamole.readsets
 
 import org.apache.parquet.hadoop.metadata.CompressionCodecName
 import org.bdgenomics.adam.models.{SequenceDictionary, SequenceRecord}
-import org.bdgenomics.adam.rdd.read.AlignmentRecordRDDFunctions
 import org.bdgenomics.adam.rdd.{ADAMContext, ADAMSaveAnyArgs}
 import org.hammerlab.guacamole.loci.set.LociParser
 import org.hammerlab.guacamole.reads.{MappedRead, Read}
@@ -138,8 +137,7 @@ class ReadSetsSuite
       override var compressionCodec: CompressionCodecName = CompressionCodecName.UNCOMPRESSED
     }
 
-    new AlignmentRecordRDDFunctions(adamRecords.rdd)
-      .saveAsParquet(args, adamRecords.sequences, adamRecords.recordGroups)
+    adamRecords.saveAsParquet(args)
 
     ReadSets.load(adamOut, sc, 0, InputFilters.empty)._1.count() should be(8)
 

--- a/src/test/scala/org/hammerlab/guacamole/readsets/rdd/ReadsRDDUtil.scala
+++ b/src/test/scala/org/hammerlab/guacamole/readsets/rdd/ReadsRDDUtil.scala
@@ -4,7 +4,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.hammerlab.guacamole.reads.{MappedRead, ReadsUtil}
 import org.hammerlab.guacamole.readsets.args.SingleSampleArgs
-import org.hammerlab.guacamole.readsets.io.{InputFilters}
+import org.hammerlab.guacamole.readsets.io.InputFilters
 import org.hammerlab.guacamole.readsets.{ReadSets, SampleId}
 import org.hammerlab.guacamole.util.TestUtil.resourcePath
 
@@ -42,6 +42,15 @@ trait ReadsRDDUtil
     assert(sc.hadoopConfiguration != null)
     val args = new SingleSampleArgs {}
     args.reads = path
-    ReadSets.loadReads(args, sc, filters)._1
+
+    val ReadSets(reads, _, _) =
+      ReadSets(
+        sc,
+        args.inputs,
+        filters,
+        contigLengthsFromDictionary = !args.noSequenceDictionary
+      )
+
+    reads(0)
   }
 }


### PR DESCRIPTION
this ports us on to most of the non-trivial changes that have happened in ADAM since 0.19.0, using my forked "0.20.0".

ADAM's VCF-writing now requires [`Sample.sampleId`](https://github.com/bigdatagenomics/bdg-formats/blob/bdg-formats-0.9.0/src/main/resources/avro/bdg.avdl#L1195) to match [`Genotype.sampleId`](https://github.com/bigdatagenomics/bdg-formats/blob/bdg-formats-0.9.0/src/main/resources/avro/bdg.avdl#L627), and I am using the "sampleName" pulled from [readsets.args.Base](https://github.com/hammerlab/guacamole/blob/a6771eeafed073e6858979e01b214b214d965a1f/src/main/scala/org/hammerlab/guacamole/readsets/args/Base.scala#L13) / [ReadSets](https://github.com/hammerlab/guacamole/blob/a6771eeafed073e6858979e01b214b214d965a1f/src/main/scala/org/hammerlab/guacamole/readsets/ReadSets.scala#L35) rather than [the loaded-from-data `sampleName` on `Read`](https://github.com/hammerlab/guacamole/blob/a6771eeafed073e6858979e01b214b214d965a1f/src/main/scala/org/hammerlab/guacamole/reads/Read.scala#L32).

The latter is now unused so I removed it. It might make sense to keep it around explicitly in some way… seems like what ADAM now does with RecordGroups is the right thing, maybe we'll want to use that if we care about that data again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/guacamole/581)
<!-- Reviewable:end -->
