### PR TITLE
improvements / bugfix in capped-regions partitioner

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
     <dependency>
       <groupId>org.hammerlab</groupId>
       <artifactId>magic-rdds_${scala.version.prefix}</artifactId>
-      <version>1.2.2</version>
+      <version>1.2.4</version>
     </dependency>
     <dependency>
       <groupId>org.clapper</groupId>

--- a/src/main/scala/org/hammerlab/guacamole/loci/partitioning/LociPartitioner.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/partitioning/LociPartitioner.scala
@@ -51,7 +51,8 @@ trait LociPartitionerArgs
           regions,
           halfWindowSize,
           maxReadsPerPartition,
-          printPartitioningStats
+          printPartitioningStats,
+          explodeCoverage
         )
       case "approximate" =>
         new MicroRegionPartitioner(regions, halfWindowSize, numPartitions, partitioningAccuracy)

--- a/src/main/scala/org/hammerlab/guacamole/loci/partitioning/LociPartitioner.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/partitioning/LociPartitioner.scala
@@ -32,9 +32,9 @@ trait LociPartitionerArgs
 
   @Args4JOption(
     name = "--loci-partitioner",
-    usage = "Loci partitioner to use: 'exact', 'approximate', or 'uniform' (default: 'exact')."
+    usage = "Loci partitioner to use: 'capped', 'micro-regions', or 'uniform' (default: 'capped')."
   )
-  var lociPartitionerName: String = "exact"
+  var lociPartitionerName: String = "capped"
 
   def getPartitioner[R <: ReferenceRegion: ClassTag](regions: RDD[R], halfWindowSize: Int = 0): LociPartitioner = {
     val sc = regions.sparkContext
@@ -46,7 +46,7 @@ trait LociPartitionerArgs
         parallelism
 
     lociPartitionerName match {
-      case "exact" =>
+      case "capped" =>
         new CappedRegionsPartitioner(
           regions,
           halfWindowSize,
@@ -54,7 +54,8 @@ trait LociPartitionerArgs
           printPartitioningStats,
           explodeCoverage
         )
-      case "approximate" =>
+
+      case "micro-regions" =>
         new MicroRegionPartitioner(regions, halfWindowSize, numPartitions, partitioningAccuracy)
       case "uniform" =>
         UniformPartitioner(numPartitions)

--- a/src/main/scala/org/hammerlab/guacamole/loci/partitioning/LociPartitioning.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/partitioning/LociPartitioning.scala
@@ -114,21 +114,21 @@ object LociPartitioning {
 
     progress(s"Partitioning loci")
 
-    val lp =
+    val lociPartitioner =
       args
         .getPartitioner(regions, halfWindowSize)
         .partition(loci)
 
     for (lociPartitioningPath <- args.lociPartitioningPathOpt) {
       progress(s"Saving loci partitioning to $lociPartitioningPath")
-      lp.save(
+      lociPartitioner.save(
         FileSystem
           .get(regions.sparkContext.hadoopConfiguration)
           .create(new Path(lociPartitioningPath))
       )
     }
 
-    lp
+    lociPartitioner
   }
 
   implicit def lociMapToLociPartitioning(map: LociMap[PartitionIndex]): LociPartitioning = LociPartitioning(map)

--- a/src/main/scala/org/hammerlab/guacamole/readsets/rdd/CoverageRDD.scala
+++ b/src/main/scala/org/hammerlab/guacamole/readsets/rdd/CoverageRDD.scala
@@ -3,10 +3,9 @@ package org.hammerlab.guacamole.readsets.rdd
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.hammerlab.guacamole.loci.Coverage
-import org.hammerlab.guacamole.loci.set.{LociSet, TakeLociIterator}
-import org.hammerlab.guacamole.readsets.ContigLengths
+import org.hammerlab.guacamole.loci.set.{LociIterator, LociSet, TakeLociIterator}
 import org.hammerlab.guacamole.readsets.iterator.{ContigCoverageIterator, ContigsIterator}
-import org.hammerlab.guacamole.reference.{ContigName, NumLoci, Position, ReferenceRegion}
+import org.hammerlab.guacamole.reference.{ContigName, Interval, NumLoci, Position, ReferenceRegion}
 import org.hammerlab.magic.rdd.RunLengthRDD._
 
 import scala.collection.mutable
@@ -20,19 +19,106 @@ class CoverageRDD[R <: ReferenceRegion: ClassTag](@transient rdd: RDD[R])
 
   @transient val sc = rdd.sparkContext
 
+  // Cache of [[coverage]]s computed below.
+  private val _coveragesCache = mutable.HashMap[(Int, LociSet), RDD[(Position, Coverage)]]()
+
   /**
    * Compute a PositionCoverage for every position in @loci, allowing a half-window of @halfWindowSize.
+   *
+   * @param halfWindowSize count bases as contributing coverage to a window that extends this many loci in either
+   *                       direction.
+   * @param lociBroadcast Spark Broadcast of a set of loci to compute depths for.
+   * @param explode If true, emit (locus, 1) tuples for every read-base before letting Spark do map-side, then
+   *                reduce-side, reductions. Otherwise, traverse reads, emitting (locus, depth) tuples for all reads
+   *                in a partition that overlap a current locus, effectively folding the map-side-reduction into
+   *                application code, as an optimization.
+   * @return RDD of (Position, Coverage) tuples giving the total read coverage, and number of read-starts, at each
+   *         genomic position in `lociBroadcast`.
    */
-  def coverage(halfWindowSize: Int, loci: LociSet): RDD[(Position, Coverage)] =
-    coverage(halfWindowSize, sc.broadcast(loci))
-
-  private val _coveragesCache = mutable.HashMap[(Int, LociSet), RDD[(Position, Coverage)]]()
   def coverage(halfWindowSize: Int,
-               lociBroadcast: Broadcast[LociSet]): RDD[(Position, Coverage)] =
-    _coveragesCache.getOrElseUpdate(
-      (halfWindowSize, lociBroadcast.value),
-      rdd
-        .mapPartitions(it =>
+               lociBroadcast: Broadcast[LociSet],
+               explode: Boolean = false): RDD[(Position, Coverage)] =
+    _coveragesCache
+      .getOrElseUpdate(
+        (halfWindowSize, lociBroadcast.value),
+        if (explode)
+          explodedCoverage(halfWindowSize, lociBroadcast)
+        else
+          traversalCoverage(halfWindowSize, lociBroadcast)
+      )
+
+  /**
+   * Break the input @loci into smaller LociSets such that the number of reads (with a @halfWindowSize grace-window)
+   * overlapping each set is ≤ @maxRegionsPerPartition.
+   *
+   * First obtains the "coverage" RDD, then takes reads greedily, meaning the end of each partition of the coverage-RDD
+   * will tend to have a "remainder" LociSet that has ≈half the maximum regions per partition.
+   */
+  def makeCappedLociSets(halfWindowSize: Int,
+                         loci: LociSet,
+                         maxRegionsPerPartition: Int,
+                         explode: Boolean): RDD[LociSet] =
+    coverage(
+      halfWindowSize,
+      sc.broadcast(loci),
+      explode
+    )
+    .mapPartitionsWithIndex(
+      (idx, it) =>
+        new TakeLociIterator(it.buffered, maxRegionsPerPartition)
+    )
+
+  /**
+   * Compute the depth at each locus in @rdd, then group loci into runs that are uniformly below (true) or above (false)
+   * `depthCutoff`.
+   *
+   * Useful for getting a sense of which parts of the genome have exceedingly high coverage.
+   *
+   * @param halfWindowSize see [[coverage]].
+   * @param lociBroadcast see [[coverage]].
+   * @param depthCutoff separate runs of loci that are uniformly below (or equal to) vs. above (>) this cutoff.
+   * @return [[RDD]] whose elements have:
+   *        - a key consisting of a contig name and a boolean indicating whether loci represented by this element have
+   *          coverage depth ≤ `depthCutoff`, and
+   *        - a value indicating the length of a run of loci with depth above or below `depthCutoff`, as described
+   *          above.
+   */
+  def partitionDepths(halfWindowSize: Int,
+                      lociBroadcast: Broadcast[LociSet],
+                      depthCutoff: Int): RDD[((ContigName, Boolean), Long)] =
+    (for {
+      (Position(contig, _), Coverage(depth, _)) <- coverage(halfWindowSize, lociBroadcast)
+    } yield
+      contig -> (depth <= depthCutoff)
+    ).runLengthEncode
+
+  /**
+   * Compute the coverage-depth at each locus, then aggregate loci into runs that are all above or below `depthCutoff`.
+   *
+   * @return tuple containing an [[RDD]] returned by [[partitionDepths]] as well as the total numbers of loci with depth
+   *         below (or equal to) `depthCutoff` (resp. above `depthCutoff`).
+   */
+  def validLociCounts(halfWindowSize: Int,
+                      lociBroadcast: Broadcast[LociSet],
+                      depthCutoff: Int): (RDD[((ContigName, Boolean), NumLoci)], NumLoci, NumLoci) = {
+    val depthRuns = partitionDepths(halfWindowSize, lociBroadcast, depthCutoff)
+    val map =
+      (for {
+        ((_, validDepth), numLoci) <- depthRuns
+      } yield
+        validDepth -> numLoci.toLong
+        )
+      .reduceByKey(_ + _)
+      .collectAsMap
+
+    (depthRuns, map.getOrElse(true, 0), map.getOrElse(false, 0))
+  }
+
+  private[rdd] def traversalCoverage(halfWindowSize: Int,
+                                     lociBroadcast: Broadcast[LociSet]): RDD[(Position, Coverage)] =
+    rdd
+      .mapPartitions(
+        it =>
           for {
 
             // For each contig, and only the regions that lie on it…
@@ -49,95 +135,34 @@ class CoverageRDD[R <: ReferenceRegion: ClassTag](@transient rdd: RDD[R])
 
           } yield
             Position(contigName, locus) -> coverage
-        )
-        .reduceByKey(_ + _)
-        .sortByKey()
-    )
-
-  /**
-   * Break the input @loci into smaller LociSets such that the number of reads (with a @halfWindowSize grace-window)
-   * overlapping each set is ≤ @maxRegionsPerPartition.
-   *
-   * First obtains the "coverage" RDD, then takes reads greedily, meaning the end of each partition of the coverage-RDD
-   * will tend to have a "remainder" LociSet that has ≈half the maximum regions per partition.
-   */
-  def makeCappedLociSets(halfWindowSize: Int,
-                         loci: LociSet,
-                         maxRegionsPerPartition: Int): RDD[LociSet] =
-    coverage(
-      halfWindowSize,
-      sc.broadcast(loci)
-    )
-    .mapPartitionsWithIndex(
-      (idx, it) =>
-        new TakeLociIterator(it.buffered, maxRegionsPerPartition)
-    )
-
-  /**
-   * Compute the depth at each locus in @rdd, then group loci into runs that are uniformly below (true) or above (false)
-   * `depthCutoff`.
-   *
-   * Useful for getting a sense of which parts of the genome have exceedingly high coverage.
-   *
-   * @param halfWindowSize see [[coverage]].
-   * @param loci see [[coverage]].
-   * @param depthCutoff separate runs of loci that are uniformly below (or equal to) vs. above (>) this cutoff.
-   * @return [[RDD]] whose elements have:
-   *        - a key consisting of a contig name and a boolean indicating whether loci represented by this element have
-   *          coverage depth ≤ `depthCutoff`, and
-   *        - a value indicating the length of a run of loci with depth above or below `depthCutoff`, as described
-   *          above.
-   */
-  def partitionDepths(halfWindowSize: Int,
-                      loci: LociSet,
-                      depthCutoff: Int): RDD[((ContigName, Boolean), Long)] = {
-    (for {
-      (Position(contig, _), Coverage(depth, _)) <- coverage(halfWindowSize, loci)
-    } yield
-      contig -> (depth <= depthCutoff)
-    ).runLengthEncode
-  }
-
-  /**
-   * Compute the coverage-depth at each locus, then aggregate loci into runs that are all above or below `depthCutoff`.
-   *
-   * @return tuple containing an [[RDD]] returned by [[partitionDepths]] as well as the total numbers of loci with depth
-   *         below (or equal to) `depthCutoff` (resp. above `depthCutoff`).
-   */
-  def validLociCounts(halfWindowSize: Int,
-                      loci: LociSet,
-                      depthCutoff: Int): (RDD[((ContigName, Boolean), NumLoci)], NumLoci, NumLoci) = {
-    val depthRuns = partitionDepths(halfWindowSize, loci, depthCutoff)
-    val map =
-      (for {
-        ((_, validDepth), numLoci) <- depthRuns
-      } yield
-        validDepth -> numLoci.toLong
-        )
+      )
       .reduceByKey(_ + _)
-      .collectAsMap
+      .sortByKey()
 
-    (depthRuns, map.getOrElse(true, 0), map.getOrElse(false, 0))
-  }
+  private def coveragesForRegion(region: ReferenceRegion,
+                                 halfWindowSize: Int,
+                                 loci: LociSet): Iterator[(Position, Coverage)] = {
 
-  /**
-   * Alternative implementation of this.coverage; will generally perform significantly worse on sorted inputs. Useful as
-   * a sanity check.
-   */
-  def shuffleCoverage(halfWindowSize: Int,
-                      contigLengthsBroadcast: Broadcast[ContigLengths]): RDD[(Position, Coverage)] =
-    (for {
+    val ReferenceRegion(contigName, start, end) = region
 
-      // For each region…
-      ReferenceRegion(contigName, start, end) <- rdd
+    // Compute the bounds of loci that this region should contribute 1 unit of coverage-depth to.
+    val lowerBound = math.max(0, start - halfWindowSize)
+    val upperBound = end + halfWindowSize
 
-      // Compute the bounds of loci that this region should contribute 1 unit of coverage-depth to.
-      contigLength = contigLengthsBroadcast.value(contigName)
-      lowerBound = math.max(0, start - halfWindowSize)
-      upperBound = math.min(contigLength, end + halfWindowSize)
+    // Iterator over loci spanned by the current region, including the half-window buffer on each end.
+    val readLocusIterator = new LociIterator(Iterator(Interval(lowerBound, upperBound)).buffered)
 
-      // For each such locus…
-      locus <- lowerBound until upperBound
+    // Eligible loci on this region's contig.
+    val lociContig = loci.onContig(contigName).iterator
+
+    // Intersect the eligible loci with the read's loci.
+    val lociIterator = lociContig.intersect(readLocusIterator)
+
+    var readStart = true
+
+    for {
+      // Each resulting locus is covered by the read (±halfWindowSize), and is part of the valid LociSet.
+      locus <- lociIterator
 
       position = Position(contigName, locus)
 
@@ -147,9 +172,10 @@ class CoverageRDD[R <: ReferenceRegion: ClassTag](@transient rdd: RDD[R])
       // The first locus should also record one unit of "region-start depth", which is also recorded by `Coverage`
       // objects, and read downstream by code computing the number of regions straddling partition boundaries.
       coverages =
-        if (locus == lowerBound)
+        if (readStart) {
+          readStart = false
           List(Coverage(starts = 1), depthCoverage)
-        else
+        } else
           List(depthCoverage)
 
       // For each of the (1 or 2) Coverages above…
@@ -158,7 +184,16 @@ class CoverageRDD[R <: ReferenceRegion: ClassTag](@transient rdd: RDD[R])
     } yield
       // Emit the Coverage, keyed by the current genomic position.
       position -> coverage
-    )
-    .reduceByKey(_ + _)  // sum all Coverages for each Position
-    .sortByKey()  // sort by Position
+  }
+
+  /**
+   * Alternative implementation of this.coverage; will generally perform significantly worse on sorted inputs. Useful as
+   * a sanity check.
+   */
+  private[rdd] def explodedCoverage(halfWindowSize: Int,
+                                    lociBroadcast: Broadcast[LociSet]): RDD[(Position, Coverage)] =
+    rdd
+      .flatMap(coveragesForRegion(_, halfWindowSize, lociBroadcast.value))
+      .reduceByKey(_ + _)  // sum all Coverages for each Position
+      .sortByKey()  // sort by Position
 }

--- a/src/test/scala/org/hammerlab/guacamole/commands/VAFHistogramSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/commands/VAFHistogramSuite.scala
@@ -12,7 +12,7 @@ class VAFHistogramSuiteRegistrar extends KryoTestRegistrar {
 
 class VAFHistogramSuite extends GuacFunSuite {
 
-  override def registrar = "org.hammerlab.guacamole.commands.VAFHistogramSuiteRegistrar"
+  override def registrar = classOf[VAFHistogramSuiteRegistrar].getCanonicalName
 
   test("generating the histogram") {
 

--- a/src/test/scala/org/hammerlab/guacamole/distributed/PileupFlatMapUtilsSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/distributed/PileupFlatMapUtilsSuite.scala
@@ -46,7 +46,7 @@ class PileupFlatMapUtilsSuite
     with PartitionedRegionsUtil
     with ReferenceUtil {
 
-  override def registrar: String = "org.hammerlab.guacamole.distributed.PileupFlatMapUtilsSuiteRegistrar"
+  override def registrar = classOf[PileupFlatMapUtilsSuiteRegistrar].getCanonicalName
 
   lazy val reference = makeReference(sc, Seq(("chr1", 0, "ATCGATCGA")))
 

--- a/src/test/scala/org/hammerlab/guacamole/loci/set/SerializerSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/loci/set/SerializerSuite.scala
@@ -17,7 +17,7 @@ class SerializerSuiteRegistrar extends KryoTestRegistrar {
 
 class SerializerSuite extends GuacFunSuite {
 
-  override def registrar = "org.hammerlab.guacamole.loci.set.SerializerSuiteRegistrar"
+  override def registrar = classOf[SerializerSuiteRegistrar].getCanonicalName
 
   test("make an RDD[LociSet]") {
 

--- a/src/test/scala/org/hammerlab/guacamole/readsets/ContigLengthsUtil.scala
+++ b/src/test/scala/org/hammerlab/guacamole/readsets/ContigLengthsUtil.scala
@@ -2,8 +2,9 @@ package org.hammerlab.guacamole.readsets
 
 trait ContigLengthsUtil {
   def makeContigLengths(contigs: (String, Int)*): ContigLengths =
-      (
-        for ((contig, length) <- contigs)
-          yield contig -> length.toLong
-      ).toMap
+    (for {
+      (contig, length) <- contigs
+    } yield
+      contig -> length.toLong
+    ).toMap
 }

--- a/src/test/scala/org/hammerlab/guacamole/readsets/iterator/ContigCoverageIteratorSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/readsets/iterator/ContigCoverageIteratorSuite.scala
@@ -1,9 +1,10 @@
 package org.hammerlab.guacamole.readsets.iterator
 
 import org.hammerlab.guacamole.loci.Coverage
+import org.hammerlab.guacamole.loci.set.LociIterator
 import org.hammerlab.guacamole.reads.TestRegion
 import org.hammerlab.guacamole.readsets.{ContigLengths, ContigLengthsUtil}
-import org.hammerlab.guacamole.reference.ContigIterator
+import org.hammerlab.guacamole.reference.{ContigIterator, Interval}
 import org.scalatest.{FunSuite, Matchers}
 
 class ContigCoverageIteratorSuite
@@ -71,17 +72,17 @@ class ContigCoverageIteratorSuite
     )
   }
 
-  test("skips") {
-    val reads =
-      ContigIterator(
-        Iterator(
-          TestRegion("chr1", 10, 20),
-          TestRegion("chr1", 11, 21),
-          TestRegion("chr1", 11, 21),
-          TestRegion("chr1", 30, 40)
-        ).buffered
-      )
+  def reads =
+    ContigIterator(
+      Iterator(
+        TestRegion("chr1", 10, 20),
+        TestRegion("chr1", 11, 21),
+        TestRegion("chr1", 11, 21),
+        TestRegion("chr1", 30, 40)
+      ).buffered
+    )
 
+  test("skips") {
     val it = ContigCoverageIterator(halfWindowSize = 1, reads)
 
     it.next() should be( 9 -> Coverage(1, 1))
@@ -98,6 +99,42 @@ class ContigCoverageIteratorSuite
     it.next() should be(39 -> Coverage(1, 0))
     it.skipTo(45)
     it.hasNext should be(false)
+  }
+
+  test("skips+starts") {
+    val it = ContigCoverageIterator(halfWindowSize = 1, reads)
+
+    it.skipTo(15)
+    it.next() should be(15 -> Coverage(3, 3))
+    it.skipTo(35)
+    it.next() should be(35 -> Coverage(1, 1))
+  }
+
+  test("skip completely over read") {
+    val it = ContigCoverageIterator(halfWindowSize = 1, reads)
+
+    it.skipTo(21)
+    it.next() should be(21 -> Coverage(2, 2))
+  }
+
+  test("skip completely over reads") {
+    val it = ContigCoverageIterator(halfWindowSize = 1, reads)
+
+    it.skipTo(25)
+    it.next() should be(29 -> Coverage(1, 1))
+  }
+
+  test("intersection") {
+    val lociIterator = new LociIterator(Iterator(Interval(12, 15)).buffered)
+    val it = ContigCoverageIterator(halfWindowSize = 1, reads).intersect(lociIterator)
+
+    it.toList should be(
+      List(
+        12 -> Coverage(3, 3),
+        13 -> Coverage(3, 0),
+        14 -> Coverage(3, 0)
+      )
+    )
   }
 
   test("throw on unsorted regions") {

--- a/src/test/scala/org/hammerlab/guacamole/readsets/iterator/ContigCoverageIteratorSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/readsets/iterator/ContigCoverageIteratorSuite.scala
@@ -117,6 +117,14 @@ class ContigCoverageIteratorSuite
     it.next() should be(21 -> Coverage(2, 2))
   }
 
+  test("load read then skip over it") {
+    val it = ContigCoverageIterator(halfWindowSize = 1, reads)
+
+    it.hasNext
+    it.skipTo(21)
+    it.next() should be(21 -> Coverage(2, 2))
+  }
+
   test("skip completely over reads") {
     val it = ContigCoverageIterator(halfWindowSize = 1, reads)
 

--- a/src/test/scala/org/hammerlab/guacamole/readsets/rdd/CoverageRDDSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/readsets/rdd/CoverageRDDSuite.scala
@@ -1,18 +1,16 @@
 package org.hammerlab.guacamole.readsets.rdd
 
 import com.esotericsoftware.kryo.Kryo
-import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.hammerlab.guacamole.loci.Coverage
 import org.hammerlab.guacamole.loci.set.LociSet
 import org.hammerlab.guacamole.reads.TestRegion
 import org.hammerlab.guacamole.readsets.{ContigLengths, ContigLengthsUtil}
-import org.hammerlab.guacamole.reference.{ContigName, Position, ReferenceRegion}
+import org.hammerlab.guacamole.reference.Position
 import org.hammerlab.guacamole.util.{GuacFunSuite, KryoTestRegistrar}
 import org.hammerlab.magic.rdd.cmp.CmpStats
 import org.hammerlab.magic.rdd.cmp.EqualsRDD._
-
-import scala.collection.SortedMap
+import org.hammerlab.magic.test.SeqMatcher.seqMatch
 
 class CoverageRDDSuiteRegistrar extends KryoTestRegistrar {
   override def registerTestClasses(kryo: Kryo): Unit = {
@@ -26,38 +24,92 @@ class CoverageRDDSuiteRegistrar extends KryoTestRegistrar {
   }
 }
 
-class RegionRDDSuite
+class CoverageRDDSuite
   extends GuacFunSuite
     with RegionsRDDUtil
     with ContigLengthsUtil {
 
   override def registrar = "org.hammerlab.guacamole.readsets.rdd.CoverageRDDSuiteRegistrar"
 
-  def testLoci[T, U](actual: Array[(Position, T)],
-                     actualStrs: Array[(String, U)],
-                     expected: List[(String, U)]): Unit = {
+  lazy val readsRDD =
+    makeRegionsRDD(
+      numPartitions = 1,
+      ("chr1", 100, 105,  1),
+      ("chr1", 101, 106,  1),
+      ("chr2",   8,   9,  1),
+      ("chr2",   9,  11,  1),
+      ("chr2", 102, 105,  1),
+      ("chr2", 103, 106, 10),
+      ("chr5",  90,  91, 10)
+    )
 
-    val actualMap = SortedMap(actualStrs: _*)
-    val expectedMap = SortedMap(expected: _*)
+  lazy val coverageRDD = new CoverageRDD(readsRDD)
 
-    val extraElems = actualMap.filterKeys(!expectedMap.contains(_))
-    val missingElems = expectedMap.filterKeys(!actualMap.contains(_))
+  val contigLengths: ContigLengths =
+    makeContigLengths(
+      "chr1" -> 1000,
+      "chr2" -> 1000,
+      "chr5" -> 1000
+    )
 
-    val diffElems =
-      for {
-        (k, ev) <- expectedMap
-        av <- actualMap.get(k)
-        if ev != av
-      } yield
-        k -> (av, ev)
+  test("all loci") {
+    val loci = LociSet.all(contigLengths)
 
-    withClue("differing loci:") { diffElems should be(Map()) }
-    withClue("found extra loci:") { extraElems should be(Map()) }
-    withClue("missing loci:") { missingElems should be(Map()) }
+    val lociBroadcast = sc.broadcast(loci)
 
-    withClue("loci out of order:") {
-      actual.map(_._1).sortBy(x => x) should be(actual.map(_._1))
-    }
+    val traversalCoverage = coverageRDD.traversalCoverage(halfWindowSize = 0, lociBroadcast)
+    val explodedCoverage = coverageRDD.explodedCoverage(0, sc.broadcast(loci))
+
+    val expected =
+      List(
+        "chr1:100" -> ( 1,  1),
+        "chr1:101" -> ( 2,  1),
+        "chr1:102" -> ( 2,  0),
+        "chr1:103" -> ( 2,  0),
+        "chr1:104" -> ( 2,  0),
+        "chr1:105" -> ( 1,  0),
+        "chr2:8"   -> ( 1,  1),
+        "chr2:9"   -> ( 1,  1),
+        "chr2:10"  -> ( 1,  0),
+        "chr2:102" -> ( 1,  1),
+        "chr2:103" -> (11, 10),
+        "chr2:104" -> (11,  0),
+        "chr2:105" -> (10,  0),
+        "chr5:90"  -> (10, 10)
+      )
+
+    checkCoverage(traversalCoverage, expected)
+    checkCoverage(explodedCoverage, expected)
+
+    traversalCoverage.compare(explodedCoverage).stats should be(CmpStats(14))
+  }
+
+  test("some loci, half-window") {
+    val loci = LociSet("chr1:102-107,chr2:7-20")
+
+    val lociBroadcast = sc.broadcast(loci)
+
+    val traversalCoverage = coverageRDD.traversalCoverage(halfWindowSize = 1, lociBroadcast)
+    val explodedCoverage = coverageRDD.explodedCoverage(halfWindowSize = 1, lociBroadcast)
+
+    val expected =
+      List(
+        "chr1:102" -> ( 2,  2),
+        "chr1:103" -> ( 2,  0),
+        "chr1:104" -> ( 2,  0),
+        "chr1:105" -> ( 2,  0),
+        "chr1:106" -> ( 1,  0),
+        "chr2:7"   -> ( 1,  1),
+        "chr2:8"   -> ( 2,  1),
+        "chr2:9"   -> ( 2,  0),
+        "chr2:10"  -> ( 1,  0),
+        "chr2:11"  -> ( 1,  0)
+      )
+
+    checkCoverage(traversalCoverage, expected)
+    checkCoverage(explodedCoverage, expected)
+
+    traversalCoverage.compare(explodedCoverage).stats should be(CmpStats(10))
   }
 
   def checkCoverage(rdd: RDD[(Position, Coverage)], expected: List[(String, (Int, Int))]): Unit = {
@@ -69,69 +121,6 @@ class RegionRDDSuite
         pos.toString -> (depth, starts)
       }
 
-    testLoci(actual, actualStrs, expected)
-  }
-
-  def testRDDReads[R <: ReferenceRegion](rdd: RDD[(Position, Iterable[R])],
-                                         expected: List[(String, Iterable[(ContigName, Int, Int)])]) = {
-    val actual = rdd.map(t => t._1 -> t._2.toList).collect()
-    val actualStrs: Array[(String, Iterable[(ContigName, Int, Int)])] =
-      for {
-        (pos, reads) <- actual
-      } yield
-        pos.toString ->
-          reads.map(r => (r.contigName, r.start.toInt, r.end.toInt))
-
-    testLoci(actual, actualStrs, expected)
-  }
-
-  test("coverage") {
-    val readsRDD =
-      makeRegionsRDD(
-        numPartitions = 1,
-        ("chr1", 100, 105,  1),
-        ("chr1", 101, 106,  1),
-        ("chr2",   8,   9,  1),
-        ("chr2",   9,  11,  1),
-        ("chr2", 102, 105,  1),
-        ("chr2", 103, 106, 10),
-        ("chr5",  90,  91, 10)
-      )
-
-    val coverageRDD = new CoverageRDD(readsRDD)
-
-    val contigLengths: ContigLengths = makeContigLengths("chr1" -> 1000, "chr2" -> 1000, "chr5" -> 1000)
-    implicit val contigLengthsBroadcast: Broadcast[ContigLengths] = sc.broadcast(contigLengths)
-
-    val rdd =
-      coverageRDD.coverage(
-        halfWindowSize = 0,
-        LociSet.all(contigLengths)
-      )
-
-    val expected =
-      List(
-        "chr1:100" -> ( 1,  1),
-        "chr1:101" -> ( 2,  1),
-        "chr1:102" -> ( 2,  0),
-        "chr1:103" -> ( 2,  0),
-        "chr1:104" -> ( 2,  0),
-        "chr1:105" -> ( 1,  0),
-          "chr2:8" -> ( 1,  1),
-          "chr2:9" -> ( 1,  1),
-         "chr2:10" -> ( 1,  0),
-        "chr2:102" -> ( 1,  1),
-        "chr2:103" -> (11, 10),
-        "chr2:104" -> (11,  0),
-        "chr2:105" -> (10,  0),
-         "chr5:90" -> (10, 10)
-      )
-
-    val shuffled = coverageRDD.shuffleCoverage(0, contigLengthsBroadcast)
-
-    checkCoverage(rdd, expected)
-    checkCoverage(shuffled, expected)
-
-    rdd.compare(shuffled).stats should be(CmpStats(14))
+    actualStrs.toList should seqMatch[String, (Int, Int)](expected)
   }
 }

--- a/src/test/scala/org/hammerlab/guacamole/readsets/rdd/CoverageRDDSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/readsets/rdd/CoverageRDDSuite.scala
@@ -29,7 +29,7 @@ class CoverageRDDSuite
     with RegionsRDDUtil
     with ContigLengthsUtil {
 
-  override def registrar = "org.hammerlab.guacamole.readsets.rdd.CoverageRDDSuiteRegistrar"
+  override def registrar = classOf[CoverageRDDSuiteRegistrar].getCanonicalName
 
   lazy val readsRDD =
     makeRegionsRDD(

--- a/src/test/scala/org/hammerlab/guacamole/variants/AlleleSuite.scala
+++ b/src/test/scala/org/hammerlab/guacamole/variants/AlleleSuite.scala
@@ -12,7 +12,7 @@ class AlleleSuiteRegistrar extends KryoTestRegistrar {
 
 class AlleleSuite extends GuacFunSuite with Matchers {
 
-  override def registrar = "org.hammerlab.guacamole.variants.AlleleSuiteRegistrar"
+  override def registrar = classOf[AlleleSuiteRegistrar].getCanonicalName
 
   test("isVariant") {
     val mismatch = Allele(Seq(Bases.T), Seq(Bases.A))


### PR DESCRIPTION
- surface alternate coverage-computation strategy, "exploding" reads into per-base, depth-1 tuples, controllable by a flag
  - opens a part of the performance-space where memory-use is not proportional to maximum depth of reads, partly inspired by discussions on #572 
- fix a bug with how read-starts are tallied given `loci` strings that start and stop in the interior of contigs
- rename the loci-partitioners