### PR TITLE
rm broken .array call

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/likelihood/Likelihood.scala
+++ b/src/main/scala/org/hammerlab/guacamole/likelihood/Likelihood.scala
@@ -134,7 +134,6 @@ object Likelihood {
         .flatMap(_.alleles)
         .distinct
         .sorted
-        .array
 
     // map from allele -> allele index in our alleles sequence.
     val alleleToIndex =

--- a/src/main/scala/org/hammerlab/guacamole/loci/partitioning/LociPartitioning.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/partitioning/LociPartitioning.scala
@@ -114,21 +114,21 @@ object LociPartitioning {
 
     progress(s"Partitioning loci")
 
-    val lociPartitioner =
+    val lociPartitioning =
       args
         .getPartitioner(regions, halfWindowSize)
         .partition(loci)
 
     for (lociPartitioningPath <- args.lociPartitioningPathOpt) {
       progress(s"Saving loci partitioning to $lociPartitioningPath")
-      lociPartitioner.save(
+      lociPartitioning.save(
         FileSystem
           .get(regions.sparkContext.hadoopConfiguration)
           .create(new Path(lociPartitioningPath))
       )
     }
 
-    lociPartitioner
+    lociPartitioning
   }
 
   implicit def lociMapToLociPartitioning(map: LociMap[PartitionIndex]): LociPartitioning = LociPartitioning(map)


### PR DESCRIPTION
I was seeing task (then stage) failures in `Likelihood` due to the `.array` call I removed here:

```
java.lang.ClassCastException: [Ljava.lang.Object; cannot be cast to [Lorg.hammerlab.guacamole.variants.Allele;
        at org.hammerlab.guacamole.likelihood.Likelihood$.likelihoodsOfGenotypes(Likelihood.scala:137)
        at org.hammerlab.guacamole.likelihood.Likelihood$.likelihoodsOfAllPossibleGenotypesFromPileup(Likelihood.scala:78)
        at org.hammerlab.guacamole.commands.SomaticStandard$Caller$.findPotentialVariantAtLocus(SomaticStandardCaller.scala:166)
        at org.hammerlab.guacamole.commands.SomaticStandard$Caller$$anonfun$1.apply(SomaticStandardCaller.scala:80)
        at org.hammerlab.guacamole.commands.SomaticStandard$Caller$$anonfun$1.apply(SomaticStandardCaller.scala:79)
        at org.hammerlab.guacamole.distributed.PileupFlatMapUtils$$anonfun$pileupFlatMapTwoSamples$1.apply(PileupFlatMapUtils.scala:95)
        at org.hammerlab.guacamole.distributed.PileupFlatMapUtils$$anonfun$pileupFlatMapTwoSamples$1.apply(PileupFlatMapUtils.scala:90)
        at org.hammerlab.guacamole.distributed.WindowFlatMapUtils$$anonfun$windowFlatMapWithState$1$$anonfun$apply$1.apply(WindowFlatMapUtils.scala:65)
        at org.hammerlab.guacamole.distributed.WindowFlatMapUtils$$anonfun$windowFlatMapWithState$1$$anonfun$apply$1.apply(WindowFlatMapUtils.scala:55)
        at org.hammerlab.guacamole.distributed.WindowFlatMapUtils$$anonfun$splitPartitionByContigAndMap$2.apply(WindowFlatMapUtils.scala:141)
        at org.hammerlab.guacamole.distributed.WindowFlatMapUtils$$anonfun$splitPartitionByContigAndMap$2.apply(WindowFlatMapUtils.scala:131)
        at scala.collection.Iterator$$anon$13.hasNext(Iterator.scala:371)
        at org.apache.spark.storage.MemoryStore.unrollSafely(MemoryStore.scala:284)
        at org.apache.spark.CacheManager.putInBlockManager(CacheManager.scala:171)
        at org.apache.spark.CacheManager.getOrCompute(CacheManager.scala:78)
        at org.apache.spark.rdd.RDD.iterator(RDD.scala:268)
        at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:66)
        at org.apache.spark.scheduler.Task.run(Task.scala:89)
        at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:214)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
```

Is there a reason it was needed? Any ideas why it would lead to this crashing?