### PR TITLE
rm ParRegArgs from ReadSets args

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/assembly/AssemblyArgs.scala
+++ b/src/main/scala/org/hammerlab/guacamole/assembly/AssemblyArgs.scala
@@ -1,9 +1,8 @@
 package org.hammerlab.guacamole.assembly
 
-import org.hammerlab.guacamole.commands.Args
 import org.kohsuke.args4j.{Option => Args4jOption}
 
-trait AssemblyArgs extends Args {
+trait AssemblyArgs {
   @Args4jOption(name = "--kmer-size", usage = "Length of kmer used for DeBruijn Graph assembly")
   var kmerSize: Int = 45
 

--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
@@ -12,7 +12,7 @@ import org.hammerlab.guacamole.pileup.Pileup
 import org.hammerlab.guacamole.reads.MappedRead
 import org.hammerlab.guacamole.readsets.args.{GermlineCallerArgs, ReferenceArgs}
 import org.hammerlab.guacamole.readsets.io.InputFilters
-import org.hammerlab.guacamole.readsets.rdd.PartitionedRegions
+import org.hammerlab.guacamole.readsets.rdd.{PartitionedRegions, PartitionedRegionsArgs}
 import org.hammerlab.guacamole.readsets.{PartitionedReads, ReadSets, SampleName}
 import org.hammerlab.guacamole.reference.ReferenceBroadcast
 import org.hammerlab.guacamole.variants.{Allele, AlleleEvidence, CalledAllele, GenotypeOutputCaller}
@@ -33,6 +33,7 @@ object GermlineAssemblyCaller {
   class Arguments
     extends GermlineCallerArgs
       with AssemblyArgs
+      with PartitionedRegionsArgs
       with ReferenceArgs {
 
     @Args4jOption(name = "--min-average-base-quality", usage = "Minimum average of base qualities in the read")

--- a/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/GermlineAssemblyCaller.scala
@@ -31,8 +31,8 @@ import org.kohsuke.args4j.{Option => Args4jOption}
 object GermlineAssemblyCaller {
 
   class Arguments
-    extends AssemblyArgs
-      with GermlineCallerArgs
+    extends GermlineCallerArgs
+      with AssemblyArgs
       with ReferenceArgs {
 
     @Args4jOption(name = "--min-average-base-quality", usage = "Minimum average of base qualities in the read")

--- a/src/main/scala/org/hammerlab/guacamole/commands/SomaticJointCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/SomaticJointCaller.scala
@@ -10,18 +10,18 @@ import org.hammerlab.guacamole.loci.LociArgs
 import org.hammerlab.guacamole.loci.set.LociSet
 import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.pileup.Pileup
-import org.hammerlab.guacamole.readsets.args.ReferenceArgs
-import org.hammerlab.guacamole.readsets.rdd.PartitionedRegions
+import org.hammerlab.guacamole.readsets.args.{ReferenceArgs, Arguments => ReadSetsArguments}
+import org.hammerlab.guacamole.readsets.rdd.{PartitionedRegions, PartitionedRegionsArgs}
 import org.hammerlab.guacamole.readsets.{PerSample, ReadSets}
 import org.hammerlab.guacamole.reference.ReferenceBroadcast
 import org.kohsuke.args4j.spi.StringArrayOptionHandler
 import org.kohsuke.args4j.{Option => Args4jOption}
-import org.hammerlab.guacamole.readsets.args.{Arguments => ReadSetsArguments}
 
 object SomaticJoint {
   class Arguments
     extends Args
       with ReadSetsArguments
+      with PartitionedRegionsArgs
       with Parameters.CommandlineArguments
       with InputCollection.Arguments
       with ReferenceArgs {

--- a/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/SomaticStandardCaller.scala
@@ -14,7 +14,7 @@ import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.pileup.Pileup
 import org.hammerlab.guacamole.readsets.ReadSets
 import org.hammerlab.guacamole.readsets.args.{ReferenceArgs, TumorNormalReadsArgs}
-import org.hammerlab.guacamole.readsets.rdd.PartitionedRegions
+import org.hammerlab.guacamole.readsets.rdd.{PartitionedRegions, PartitionedRegionsArgs}
 import org.hammerlab.guacamole.variants.{Allele, AlleleEvidence, CalledSomaticAllele, GenotypeOutputArgs, GenotypeOutputCaller}
 import org.kohsuke.args4j.{Option => Args4jOption}
 
@@ -33,6 +33,7 @@ object SomaticStandard {
   class Arguments
     extends Args
       with TumorNormalReadsArgs
+      with PartitionedRegionsArgs
       with PileupFilterArguments
       with SomaticGenotypeFilterArguments
       with GenotypeOutputArgs

--- a/src/main/scala/org/hammerlab/guacamole/commands/VAFHistogram.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/VAFHistogram.scala
@@ -13,7 +13,7 @@ import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.pileup.Pileup
 import org.hammerlab.guacamole.readsets.args.{ReferenceArgs, Arguments => ReadSetsArguments}
 import org.hammerlab.guacamole.readsets.io.{Input, InputFilters}
-import org.hammerlab.guacamole.readsets.rdd.PartitionedRegions
+import org.hammerlab.guacamole.readsets.rdd.{PartitionedRegions, PartitionedRegionsArgs}
 import org.hammerlab.guacamole.readsets.{PartitionedReads, PerSample, ReadSets, SampleId, SampleName}
 import org.hammerlab.guacamole.reference.{ContigName, Locus, NumLoci, ReferenceGenome}
 import org.hammerlab.magic.rdd.keyed.SplitByKeyRDD._
@@ -60,6 +60,7 @@ object VAFHistogram {
   protected class Arguments
     extends Args
       with ReadSetsArguments
+      with PartitionedRegionsArgs
       with ReferenceArgs {
 
     @Args4jOption(name = "--out", required = false, forbids = Array("--local-out"),

--- a/src/main/scala/org/hammerlab/guacamole/commands/VariantSupport.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/VariantSupport.scala
@@ -9,7 +9,7 @@ import org.hammerlab.guacamole.loci.set.LociSet
 import org.hammerlab.guacamole.pileup.Pileup
 import org.hammerlab.guacamole.readsets.args.{ReferenceArgs, Arguments => ReadSetsArguments}
 import org.hammerlab.guacamole.readsets.io.InputFilters
-import org.hammerlab.guacamole.readsets.rdd.PartitionedRegions
+import org.hammerlab.guacamole.readsets.rdd.{PartitionedRegions, PartitionedRegionsArgs}
 import org.hammerlab.guacamole.readsets.{PerSample, ReadSets, SampleName}
 import org.hammerlab.guacamole.reference.{ContigName, Locus}
 import org.hammerlab.guacamole.util.Bases
@@ -20,6 +20,7 @@ object VariantSupport {
   protected class Arguments
     extends Args
       with ReadSetsArguments
+      with PartitionedRegionsArgs
       with ReferenceArgs {
 
     @Args4jOption(name = "--input-variant", required = true, aliases = Array("-v"),

--- a/src/main/scala/org/hammerlab/guacamole/readsets/ReadSets.scala
+++ b/src/main/scala/org/hammerlab/guacamole/readsets/ReadSets.scala
@@ -10,6 +10,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models.SequenceDictionary
 import org.bdgenomics.adam.rdd.ADAMContext
+import org.hammerlab.guacamole.loci.partitioning.LociPartitionerArgs
 import org.hammerlab.guacamole.loci.set.{LociParser, LociSet}
 import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.reads.Read
@@ -64,7 +65,7 @@ object ReadSets extends Logging {
     )
   }
 
-  def apply(sc: SparkContext, args: BaseArgs): (ReadSets, LociSet) = {
+  def apply(sc: SparkContext, args: BaseArgs with LociPartitionerArgs): (ReadSets, LociSet) = {
     val loci = args.parseLoci(sc.hadoopConfiguration)
 
     val readsets = apply(sc, args.inputs, loci, !args.noSequenceDictionary)

--- a/src/main/scala/org/hammerlab/guacamole/readsets/args/Base.scala
+++ b/src/main/scala/org/hammerlab/guacamole/readsets/args/Base.scala
@@ -4,9 +4,7 @@ import org.hammerlab.guacamole.readsets.PerSample
 import org.hammerlab.guacamole.readsets.io.Input
 import org.hammerlab.guacamole.readsets.rdd.PartitionedRegionsArgs
 
-trait Base
-  extends PartitionedRegionsArgs
-    with NoSequenceDictionaryArgs {
+trait Base extends NoSequenceDictionaryArgs {
 
   def paths: Array[String]
   def sampleNames: Array[String]

--- a/src/test/scala/org/hammerlab/guacamole/main/GeneratePartialFasta.scala
+++ b/src/test/scala/org/hammerlab/guacamole/main/GeneratePartialFasta.scala
@@ -8,6 +8,7 @@ import org.hammerlab.guacamole.logging.LoggingUtils.progress
 import org.hammerlab.guacamole.readsets.ReadSets
 import org.hammerlab.guacamole.readsets.args.{ReferenceArgs, Arguments => ReadSetsArguments}
 import org.hammerlab.guacamole.readsets.io.InputFilters
+import org.hammerlab.guacamole.readsets.rdd.PartitionedRegionsArgs
 import org.hammerlab.guacamole.reference.{ContigNotFound, Interval}
 import org.hammerlab.guacamole.util.Bases
 import org.kohsuke.args4j.{Option => Args4jOption}
@@ -15,6 +16,7 @@ import org.kohsuke.args4j.{Option => Args4jOption}
 class GeneratePartialFastaArguments
   extends Args
     with ReadSetsArguments
+    with PartitionedRegionsArgs
     with ReferenceArgs {
 
   @Args4jOption(name = "--out", metaVar = "OUT", required = true, aliases = Array("-o"),


### PR DESCRIPTION
I have a use case (standalone partition-loci command) that wants ReadSets args but not PartitionedRegionsArgs; they should be separate and mixed in closer to the leaves of the hierarchy.