### PR TITLE
allow spark confs as cmdline flags

### DIFF
--- a/scripts/.spark-rc
+++ b/scripts/.spark-rc
@@ -25,6 +25,18 @@ conf_dir="$repo_root/conf"
 kryo_confs="$conf_dir/kryo"
 cat "$kryo_confs" > "$conf_file"
 
+concat_file() {
+  file="$1"
+  if [ -e "$file" ]; then
+    cat "$file" >> "$conf_file"
+  elif [ -e "$conf_dir/$file" ]; then
+    cat "$conf_dir/$file" >> "$conf_file"
+  else
+    echo "Config file not found: $file" >&2
+    exit 2
+  fi
+}
+
 # If the $GUAC_SPARK_CONFS variable is set, append the configs in that path to $conf_file.
 if [ -n "$GUAC_SPARK_CONFS" ]; then
   if [[ "$GUAC_SPARK_CONFS" =~ , ]]; then
@@ -36,16 +48,15 @@ if [ -n "$GUAC_SPARK_CONFS" ]; then
     for file in $(echo "$GUAC_SPARK_CONFS" | tr ',' '\n'); do
       if [ -z "$file" ]; then
         continue
-      elif [ -e "$file" ]; then
-        cat "$file" >> "$conf_file"
       else
-        cat "$conf_dir/$file" >> "$conf_file"
+        concat_file "$file"
       fi
     done
     IFS="$OLD_IFS"
   else
-    echo "Using Spark config file: $GUAC_SPARK_CONFS"
-    cat "$GUAC_SPARK_CONFS" >> "$conf_file"
+    file="$GUAC_SPARK_CONFS"
+    echo "Using Spark config file: $file"
+    concat_file "$file"
   fi
 else
   # If it's not set, add configs from conf/local.

--- a/scripts/guacamole
+++ b/scripts/guacamole
@@ -2,14 +2,20 @@
 
 set -e
 
-# Wrapper script for spark-submit that finds Guacamole JARs and a Spark properties file.
+# Wrapper script for spark-submit that loads Guacamole JARs onto Spark's classpath and handles Spark configuration from
+# user-supplied properties files and command-line arguments.
 #
 # Example:
 #
-#   $ scripts/guacamole somatic-joint normal.bam tumor.bam --reference hg19.fasta --out out.vcf
+#   $ scripts/guacamole \
+#       --conf spark.driver.memory=12g \
+#       somatic-joint \
+#       normal.bam tumor.bam \
+#       --reference hg19.fasta \
+#       --out out.vcf
 #
-# Default Spark-properties file is at conf/spark-defaults.conf, and configures a 4gb, 1-worker, local Spark master. To
-# specify other Spark properties, set the $GUAC_CONF_PATH environment variable.
+# Default Spark-properties file is at conf/local, and configures a 4gb, 1-worker, local Spark master. To specify other
+# Spark properties, set the $GUAC_CONF_PATH environment variable or pass them in "--conf spark.…" format.
 
 scripts_dir="$(dirname "${BASH_SOURCE[0]}")"
 
@@ -19,5 +25,35 @@ find_jars
 # Build a spark properties file and set the variable $conf_file to its path.
 source "$scripts_dir/.spark-rc"
 
+# Look for pairs of arguments starting with "--conf spark.…", and pass them to `spark-submit`; other arguments are sent
+# to guacamole.
+#
+# All Spark configs can be set with "--conf spark.…" syntax, though some also have shorthands (e.g. "--driver-memory",
+# "--num-executors", etc.); rather than hard-code the latter here, we just force all Spark configs to conform to the
+# former.
+spark_args=()
+guac_args=()
+while [ $# -gt 0 ]; do
+  arg="$1"
+  shift
+  if [ "$arg" == "--conf" ]; then
+    spark_args+=("$arg")
+    value="$1"
+    shift
+    if ! [[ "$value" =~ ^spark\. ]]; then
+      echo "Suspicious arguments: '--conf $value'; expect '--conf' values to begin with 'spark.'" >&2
+    fi
+    spark_args+=("$value")
+  else
+    guac_args+=("$arg")
+  fi
+done
+
 # Run Spark!
-time "$SPARK_HOME"/bin/spark-submit --properties-file "$conf_file" --jars "$deps" "$main_jar" "$@"
+time \
+  "$SPARK_HOME"/bin/spark-submit \
+    --properties-file "$conf_file" \
+    "${spark_args[@]}" \
+    --jars "$deps" \
+    "$main_jar" \
+    "${guac_args[@]}"


### PR DESCRIPTION
forcing everything to go through `GUAC_SPARK_CONFS` props files was too restrictive; now we'll pick out arg-pairs of the form `--conf spark.…` and send them to spark, sending everything else to guacamole.

also fixed a GUAC_SPARK_CONFS bug where defaulting to `conf/` dir didn't work when one file was specified.