### PR TITLE
add `partition-loci` cmd

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/Main.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Main.scala
@@ -20,7 +20,9 @@ object Main extends Logging {
     SomaticStandard.Caller,
     VariantSupport.Caller,
     VAFHistogram.Caller,
-    SomaticJoint.Caller)
+    SomaticJoint.Caller,
+    PartitionLoci
+  )
 
   private def printUsage() = {
     println("Usage: java ... <command> [other args]\n")

--- a/src/main/scala/org/hammerlab/guacamole/commands/PartitionLoci.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/PartitionLoci.scala
@@ -1,0 +1,24 @@
+package org.hammerlab.guacamole.commands
+
+import org.apache.spark.SparkContext
+import org.hammerlab.guacamole.loci.partitioning.{HalfWindowArgs, LociPartitionerArgs, LociPartitioning}
+import org.hammerlab.guacamole.readsets.ReadSets
+import org.hammerlab.guacamole.readsets.args.{Arguments => ReadSetsArgs}
+
+class PartitionLociArgs
+  extends Args
+    with LociPartitionerArgs
+    with HalfWindowArgs
+    with ReadSetsArgs
+
+object PartitionLoci extends SparkCommand[PartitionLociArgs] {
+
+  override def name: String = "partition-loci"
+  override def description: String = "Partition loci according to various paramters."
+
+  override def run(args: PartitionLociArgs, sc: SparkContext): Unit = {
+    val (readsets, loci) = ReadSets(sc, args)
+
+    LociPartitioning(readsets.allMappedReads, loci, args)
+  }
+}

--- a/src/main/scala/org/hammerlab/guacamole/loci/partitioning/HalfWindowArgs.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/partitioning/HalfWindowArgs.scala
@@ -1,0 +1,15 @@
+package org.hammerlab.guacamole.loci.partitioning
+
+import org.kohsuke.args4j.{Option => Args4JOption}
+
+trait HalfWindowArgs extends HalfWindowConfig {
+  @Args4JOption(
+    name = "--half-window",
+    usage =
+      "When partitioning loci and reads, consider reads to overlap loci this far on either side of their ends, in " +
+      "order to provide context to offer context to downstream logic."
+  )
+  private var _halfWindowSize: Int = 0
+
+  override def halfWindowSize: Int = _halfWindowSize
+}


### PR DESCRIPTION
reuses all the same arguments, partitions loci (optionally writing it to `--loci-partitioning` path), and exits