### PR TITLE
add PartitionReads cmd

### DIFF
--- a/src/main/scala/org/hammerlab/guacamole/Main.scala
+++ b/src/main/scala/org/hammerlab/guacamole/Main.scala
@@ -20,7 +20,9 @@ object Main extends Logging {
     SomaticStandard.Caller,
     VariantSupport.Caller,
     VAFHistogram.Caller,
-    SomaticJoint.Caller)
+    SomaticJoint.Caller,
+    PartitionReads
+  )
 
   private def printUsage() = {
     println("Usage: java ... <command> [other args]\n")

--- a/src/main/scala/org/hammerlab/guacamole/commands/PartitionReads.scala
+++ b/src/main/scala/org/hammerlab/guacamole/commands/PartitionReads.scala
@@ -1,0 +1,23 @@
+package org.hammerlab.guacamole.commands
+
+import org.apache.spark.SparkContext
+import org.hammerlab.guacamole.loci.partitioning.HalfWindowArgs
+import org.hammerlab.guacamole.readsets.ReadSets
+import org.hammerlab.guacamole.readsets.args.{Arguments => ReadSetsArgs}
+import org.hammerlab.guacamole.readsets.rdd.{PartitionedRegions, PartitionedRegionsArgs}
+
+class PartitionReadsArgs
+  extends Args
+    with ReadSetsArgs
+    with PartitionedRegionsArgs
+    with HalfWindowArgs
+
+object PartitionReads extends SparkCommand[PartitionReadsArgs] {
+  override val name: String = "partition-reads"
+  override val description: String = "Partition some reads and output statistics about them."
+
+  override def run(args: PartitionReadsArgs, sc: SparkContext): Unit = {
+    val (readsets, loci) = ReadSets(sc, args)
+    PartitionedRegions(readsets.allMappedReads, loci, args)
+  }
+}

--- a/src/main/scala/org/hammerlab/guacamole/loci/partitioning/HalfWindowArgs.scala
+++ b/src/main/scala/org/hammerlab/guacamole/loci/partitioning/HalfWindowArgs.scala
@@ -1,0 +1,15 @@
+package org.hammerlab.guacamole.loci.partitioning
+
+import org.kohsuke.args4j.{Option => Args4JOption}
+
+trait HalfWindowArgs extends HalfWindowConfig {
+  @Args4JOption(
+    name = "--half-window",
+    usage =
+      "When partitioning loci and reads, consider reads to overlap loci this far on either side of their ends, in " +
+      "order to provide context to offer context to downstream logic."
+  )
+  private var _halfWindowSize: Int = 0
+
+  override def halfWindowSize: Int = _halfWindowSize
+}


### PR DESCRIPTION
similar to #603, this command is useful for getting through most of the steps leading up to pileup-creation + variant-calling, then persisting its state and exiting, allowing for quicker iteration at the later levels.